### PR TITLE
132 Avoid deprecated Double(double), Integer(int) constructors

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/BinaryOperation.java
+++ b/src/main/java/org/relique/jdbc/csv/BinaryOperation.java
@@ -100,9 +100,9 @@ class BinaryOperation extends Expression
 			else if (op == '%')
 				bil = bil.remainder(bir);
 			if (isLongExpression)
-				return new Long(bil.toString());
+				return Long.valueOf(bil.toString());
 			else
-				return new Integer(bil.toString());
+				return Integer.valueOf(bil.toString());
 		}
 		catch (ClassCastException e)
 		{
@@ -120,16 +120,16 @@ class BinaryOperation extends Expression
 			Number rightN = (Number)rightEval;
 			BigDecimal bdr = new BigDecimal(rightN.toString());
 			if (op == '+')
-				return new Double(bdl.add(bdr).toString());
+				return Double.valueOf(bdl.add(bdr).toString());
 			if (op == '-')
-				return new Double(bdl.subtract(bdr).toString());
+				return Double.valueOf(bdl.subtract(bdr).toString());
 			if (op == '*')
-				return new Double(bdl.multiply(bdr).toString());
+				return Double.valueOf(bdl.multiply(bdr).toString());
 			MathContext mc = new MathContext("precision=14 roundingMode=HALF_UP");
 			if (op == '/')
-				return new Double(bdl.divide(bdr, mc.getPrecision(), mc.getRoundingMode()).toString());
+				return Double.valueOf(bdl.divide(bdr, mc.getPrecision(), mc.getRoundingMode()).toString());
 			if (op == '%')
-				return new Double(bdl.remainder(bdr, mc).toString());
+				return Double.valueOf(bdl.remainder(bdr, mc).toString());
 		}
 		catch (ClassCastException e)
 		{
@@ -216,7 +216,7 @@ class BinaryOperation extends Expression
 				{
 					long nMillis = ((Date)leftEval).getTime() - ((Date)(rightEval)).getTime();
 					long nDays = (nMillis + MILLISECONDS_PER_DAY / 2) / MILLISECONDS_PER_DAY;
-					return new Integer((int)nDays);
+					return Integer.valueOf((int)nDays);
 				}
 			}
 		}

--- a/src/main/java/org/relique/jdbc/csv/CsvPreparedStatement.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvPreparedStatement.java
@@ -367,7 +367,7 @@ public class CsvPreparedStatement extends CsvStatement implements PreparedStatem
 		checkOpen();
 		checkParameterIndex(parameterIndex);
 
-		this.parameters[parameterIndex] = new Double(x);
+		this.parameters[parameterIndex] = Double.valueOf(x);
 
 	}
 

--- a/src/main/java/org/relique/jdbc/csv/CsvResultSetMetaData.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResultSetMetaData.java
@@ -163,22 +163,22 @@ public class CsvResultSetMetaData implements ResultSetMetaData
 		private static final long serialVersionUID = -8819579540085202365L;
 
 		{
-			put("String", new Integer(Types.VARCHAR));
-			put("Boolean", new Integer(Types.BOOLEAN));
-			put("Byte", new Integer(Types.TINYINT));
-			put("Short", new Integer(Types.SMALLINT));
-			put("Int", new Integer(Types.INTEGER));
-			put("Integer", new Integer(Types.INTEGER));
-			put("Long", new Integer(Types.BIGINT));
-			put("Float", new Integer(Types.FLOAT));
-			put("Double", new Integer(Types.DOUBLE));
-			put("BigDecimal", new Integer(Types.DECIMAL));
-			put("Date", new Integer(Types.DATE));
-			put("Time", new Integer(Types.TIME));
-			put("Timestamp", new Integer(Types.TIMESTAMP));
-			put("Blob", new Integer(Types.BLOB));
-			put("Clob", new Integer(Types.CLOB));
-			put("expression", new Integer(Types.BLOB));
+			put("String", Integer.valueOf(Types.VARCHAR));
+			put("Boolean", Integer.valueOf(Types.BOOLEAN));
+			put("Byte", Integer.valueOf(Types.TINYINT));
+			put("Short", Integer.valueOf(Types.SMALLINT));
+			put("Int", Integer.valueOf(Types.INTEGER));
+			put("Integer", Integer.valueOf(Types.INTEGER));
+			put("Long", Integer.valueOf(Types.BIGINT));
+			put("Float", Integer.valueOf(Types.FLOAT));
+			put("Double", Integer.valueOf(Types.DOUBLE));
+			put("BigDecimal", Integer.valueOf(Types.DECIMAL));
+			put("Date", Integer.valueOf(Types.DATE));
+			put("Time", Integer.valueOf(Types.TIME));
+			put("Timestamp", Integer.valueOf(Types.TIMESTAMP));
+			put("Blob", Integer.valueOf(Types.BLOB));
+			put("Clob", Integer.valueOf(Types.CLOB));
+			put("expression", Integer.valueOf(Types.BLOB));
 		}
 	};
 

--- a/src/main/java/org/relique/jdbc/csv/RelopExpression.java
+++ b/src/main/java/org/relique/jdbc/csv/RelopExpression.java
@@ -85,7 +85,7 @@ class RelopExpression extends LogicalExpression
 		try
 		{
 			if (leftValue != null && rightValue != null)
-				leftComparedToRightObj = new Integer(leftValue.compareTo(rightValue));
+				leftComparedToRightObj = Integer.valueOf(leftValue.compareTo(rightValue));
 		}
 		catch (ClassCastException e)
 		{
@@ -106,7 +106,7 @@ class RelopExpression extends LogicalExpression
 					StringConverter sc = (StringConverter) stringConverter.eval(env);
 					Date date = sc.parseDate(rightValue.toString());
 					if (date != null)
-						leftComparedToRightObj = new Integer(leftValue.compareTo(date));
+						leftComparedToRightObj = Integer.valueOf(leftValue.compareTo(date));
 				}
 				else if (rightValue instanceof Date)
 				{
@@ -114,7 +114,7 @@ class RelopExpression extends LogicalExpression
 					StringConverter sc = (StringConverter) stringConverter.eval(env);
 					Date date = sc.parseDate(leftValue.toString());
 					if (date != null)
-						leftComparedToRightObj = new Integer(date.compareTo((Date)rightValue));
+						leftComparedToRightObj = Integer.valueOf(date.compareTo((Date)rightValue));
 				}
 				else if (leftValue instanceof Time)
 				{
@@ -122,7 +122,7 @@ class RelopExpression extends LogicalExpression
 					StringConverter sc = (StringConverter) stringConverter.eval(env);
 					Time time = sc.parseTime(rightValue.toString());
 					if (time != null)
-						leftComparedToRightObj = new Integer(leftValue.compareTo(time));
+						leftComparedToRightObj = Integer.valueOf(leftValue.compareTo(time));
 				}
 				else if (rightValue instanceof Time)
 				{
@@ -130,7 +130,7 @@ class RelopExpression extends LogicalExpression
 					StringConverter sc = (StringConverter) stringConverter.eval(env);
 					Time time = sc.parseTime(leftValue.toString());
 					if (time != null)
-						leftComparedToRightObj = new Integer(time.compareTo((Time)rightValue));
+						leftComparedToRightObj = Integer.valueOf(time.compareTo((Time)rightValue));
 				}
 				else if (leftValue instanceof Timestamp)
 				{
@@ -138,7 +138,7 @@ class RelopExpression extends LogicalExpression
 					StringConverter sc = (StringConverter) stringConverter.eval(env);
 					Timestamp timestamp = sc.parseTimestamp(rightValue.toString());
 					if (timestamp != null)
-						leftComparedToRightObj = new Integer(leftValue.compareTo(timestamp));
+						leftComparedToRightObj = Integer.valueOf(leftValue.compareTo(timestamp));
 				}
 				else if (rightValue instanceof Timestamp)
 				{
@@ -146,7 +146,7 @@ class RelopExpression extends LogicalExpression
 					StringConverter sc = (StringConverter) stringConverter.eval(env);
 					Timestamp timestamp = sc.parseTimestamp(leftValue.toString());
 					if (timestamp != null)
-						leftComparedToRightObj = new Integer(timestamp.compareTo((Timestamp)rightValue));
+						leftComparedToRightObj = Integer.valueOf(timestamp.compareTo((Timestamp)rightValue));
 				}
 				else if (leftValue instanceof Boolean)
 				{
@@ -163,9 +163,9 @@ class RelopExpression extends LogicalExpression
 				}
 				else
 				{
-					Double leftDouble = new Double(((Number)leftValue).toString());
-					Double rightDouble = new Double(((Number)rightValue).toString());
-					leftComparedToRightObj = new Integer(leftDouble.compareTo(rightDouble));
+					Double leftDouble = Double.valueOf(((Number)leftValue).toString());
+					Double rightDouble = Double.valueOf(((Number)rightValue).toString());
+					leftComparedToRightObj = Integer.valueOf(leftDouble.compareTo(rightDouble));
 				}
 			}
 		}

--- a/src/main/java/org/relique/jdbc/csv/SQLAbsFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLAbsFunction.java
@@ -41,7 +41,7 @@ class SQLAbsFunction extends Expression
 			{
 				try
 				{
-					o = new Double(o.toString());
+					o = Double.valueOf(o.toString());
 				}
 				catch(NumberFormatException e)
 				{
@@ -77,7 +77,7 @@ class SQLAbsFunction extends Expression
 					double d = ((Number)o).doubleValue();
 					if (d < 0)
 						d = -d;
-					retval = new Double(d);
+					retval = Double.valueOf(d);
 				}
 			}
 		}

--- a/src/main/java/org/relique/jdbc/csv/SQLAvgFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLAvgFunction.java
@@ -33,7 +33,7 @@ class SQLAvgFunction extends SQLSumFunction
 		if (o != null)
 		{
 			double average = ((Number)o).doubleValue() / counter;
-			o = new Double(average);
+			o = Double.valueOf(average);
 		}
 		return o;
 	}

--- a/src/main/java/org/relique/jdbc/csv/SQLRoundFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLRoundFunction.java
@@ -40,7 +40,7 @@ class SQLRoundFunction extends Expression
 			{
 				try
 				{
-					retval = new Double(retval.toString());
+					retval = Double.valueOf(retval.toString());
 				}
 				catch(NumberFormatException e)
 				{
@@ -51,15 +51,15 @@ class SQLRoundFunction extends Expression
 			{
 				if (retval instanceof Short)
 				{
-					retval = new Integer(((Short)retval).intValue());
+					retval = Integer.valueOf(((Short)retval).intValue());
 				}
 				else if (!(retval instanceof Integer || retval instanceof Long))
 				{
 					double d = ((Number)retval).doubleValue();
 					if (d < Integer.MIN_VALUE || d > Integer.MAX_VALUE)
-						retval = new Double(Math.round(d));
+						retval = Double.valueOf(Math.round(d));
 					else
-						retval = new Integer((int)Math.round(d));
+						retval = Integer.valueOf((int)Math.round(d));
 				}
 			}
 		}

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -667,9 +667,9 @@ public class TestCsvDriver
 				+ "FROM sample5 WHERE Job = 'Project Manager'");
 
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(1), results
+		assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
 				.getObject("id"));
-		assertEquals("Integer column 1 is wrong", new Integer(1), results
+		assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
 				.getObject(1));
 		java.sql.Date shouldBe = java.sql.Date.valueOf("2001-01-02");
 		assertEquals("Date column Start is wrong", shouldBe, results
@@ -693,9 +693,9 @@ public class TestCsvDriver
 				+ "FROM sample5 WHERE Job = 'Project Manager'");
 
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(1), results
+		assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
 				.getObject("id"));
-		assertEquals("Integer column 1 is wrong", new Integer(1), results
+		assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
 				.getObject(1));
 		java.sql.Date shouldBe = java.sql.Date.valueOf("2001-01-02");
 		assertEquals("Date column Start is wrong", shouldBe, results
@@ -720,9 +720,9 @@ public class TestCsvDriver
 
 		assertTrue(results.next());
 		DateFormat dfp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		assertEquals("Integer column ID is wrong", new Integer(1), results
+		assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
 				.getObject("id"));
-		assertEquals("Integer column 1 is wrong", new Integer(1), results
+		assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
 				.getObject(1));
 		assertEquals("Date column Start is wrong", dfp.parse(results
 				.getString("start")), results.getObject("start"));
@@ -950,7 +950,7 @@ public class TestCsvDriver
 		String target = "2001-01-02 12:30:00";
 		assertEquals("the start time is wrong", target, toUTC.format(results
 				.getObject("start")));
-		assertEquals("The ID is wrong", new Integer(1), results.getObject("id"));
+		assertEquals("The ID is wrong", Integer.valueOf(1), results.getObject("id"));
 		assertEquals("The Name is wrong", "Juan Pablo Morales", results
 				.getObject("name"));
 	}
@@ -970,7 +970,7 @@ public class TestCsvDriver
 		Statement stmt = conn.createStatement();
 		ResultSet results = stmt.executeQuery("SELECT * from sample5");
 		assertTrue(results.next());
-		assertEquals("The sample5 ID is wrong", new Integer(41), results.getObject("id"));
+		assertEquals("The sample5 ID is wrong", Integer.valueOf(41), results.getObject("id"));
 		assertEquals("The sample5 Job is wrong", "Piloto", results.getObject("job"));
 		results.close();
 		results = stmt.executeQuery("SELECT ID,EXTRA_FIELD from sample");
@@ -982,7 +982,7 @@ public class TestCsvDriver
 		// column types are inferred from data.
 		results = stmt.executeQuery("SELECT C2, 'X' as X from numeric");
 		assertTrue(results.next());
-		assertEquals("The numeric C2 is wrong", new Integer(-1010), results.getObject(1));
+		assertEquals("The numeric C2 is wrong", Integer.valueOf(-1010), results.getObject(1));
 		assertEquals("The numeric X is wrong", "X", results.getObject(2));
 	}
 
@@ -2680,11 +2680,11 @@ public class TestCsvDriver
 		assertEquals("comment", metadata.getColumnName(4));
 
 		assertTrue(results.next());
-		assertEquals(new Integer(1), results.getObject(2));
+		assertEquals(Integer.valueOf(1), results.getObject(2));
 		assertTrue(results.next());
-		assertEquals(new Integer(2), results.getObject(2));
+		assertEquals(Integer.valueOf(2), results.getObject(2));
 		assertTrue(results.next());
-		assertEquals(new Integer(3), results.getObject(2));
+		assertEquals(Integer.valueOf(3), results.getObject(2));
 		assertFalse(results.next());
 	}
 
@@ -2768,11 +2768,11 @@ public class TestCsvDriver
 		assertEquals("comment", metadata.getColumnName(4));
 
 		assertTrue(results.next());
-		assertEquals(new Integer(1), results.getObject(2));
+		assertEquals(Integer.valueOf(1), results.getObject(2));
 		assertTrue(results.next());
-		assertEquals(new Integer(2), results.getObject(2));
+		assertEquals(Integer.valueOf(2), results.getObject(2));
 		assertTrue(results.next());
-		assertEquals(new Integer(3), results.getObject(2));
+		assertEquals(Integer.valueOf(3), results.getObject(2));
 		assertFalse(results.next());
 	}
 
@@ -3016,16 +3016,16 @@ public class TestCsvDriver
 		results = stmt.executeQuery("SELECT * FROM varlen1");
 		assertTrue(results.next());
 		assertEquals("007", results.getObject("Station"));
-		assertEquals(new Double("26.54"), results.getObject("P003"));
+		assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
 		assertTrue(results.next());
 		assertEquals("007", results.getObject("Station"));
-		assertEquals(new Double("26.54"), results.getObject("P003"));
+		assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
 		assertTrue(results.next());
 		assertEquals("007", results.getObject("Station"));
-		assertEquals(new Double("26.54"), results.getObject("P003"));
+		assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
 		assertTrue(results.next());
 		assertEquals("001", results.getObject("Station"));
-		assertEquals(new Double("26.55"), results.getObject("P003"));
+		assertEquals(Double.valueOf("26.55"), results.getObject("P003"));
 		assertFalse(results.next());
 
 		results = stmt.executeQuery("SELECT * FROM varlen2");
@@ -3690,9 +3690,9 @@ public class TestCsvDriver
 				.getObject(1)));
 		assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
 				.getObject("COLUMN1")));
-		assertEquals("2 is wrong", new Double(21), results.getObject(2));
-		assertEquals("3 is wrong", new Double(20), results.getObject(3));
-		assertEquals("4 is wrong", new Double(24), results.getObject(4));
+		assertEquals("2 is wrong", Double.valueOf(21), results.getObject(2));
+		assertEquals("3 is wrong", Double.valueOf(20), results.getObject(3));
+		assertEquals("4 is wrong", Double.valueOf(24), results.getObject(4));
 
 	}
 
@@ -3718,10 +3718,10 @@ public class TestCsvDriver
 		results = stmt.executeQuery("SELECT * FROM varlen1");
 		assertTrue(results.next());
 		assertEquals("007", results.getObject("Station"));
-		assertEquals(new Double("26.54"), results.getObject("P003"));
+		assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
 		assertTrue(results.next());
 		assertEquals("001", results.getObject("Station"));
-		assertEquals(new Double("26.55"), results.getObject("P003"));
+		assertEquals(Double.valueOf("26.55"), results.getObject("P003"));
 		assertFalse(results.next());
 	}
 
@@ -4125,9 +4125,9 @@ public class TestCsvDriver
 		assertTrue(results.next());
 		assertTrue(results.next());
 		assertTrue(results.next()); // Mackie Messer
-		assertEquals(new Double(34.1), results.getObject(3));
+		assertEquals(Double.valueOf(34.1), results.getObject(3));
 		assertTrue(results.next()); // Polly Peachum
-		assertEquals(new Double(30.5), results.getObject(3));
+		assertEquals(Double.valueOf(30.5), results.getObject(3));
 	}
 
 	@Test

--- a/src/test/java/org/relique/jdbc/csv/TestPrepareStatement.java
+++ b/src/test/java/org/relique/jdbc/csv/TestPrepareStatement.java
@@ -100,11 +100,11 @@ public class TestPrepareStatement
 		ResultSet results = prepstmt.executeQuery();
 
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(1), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(1), results.getObject("id"));
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(2), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(2), results.getObject("id"));
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(3), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(3), results.getObject("id"));
 		assertFalse(results.next());
 	}
 
@@ -242,7 +242,7 @@ public class TestPrepareStatement
 
 		assertTrue(results1.isClosed());
 		assertTrue(results2.next());
-		assertEquals("Integer column ID is wrong", new Integer(41), results2.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(41), results2.getObject("id"));
 		assertFalse(results2.next());
 	}
 
@@ -260,24 +260,24 @@ public class TestPrepareStatement
 		ResultSet results = prepstmt.executeQuery();
 		
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(1), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(1), results.getObject("id"));
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(3), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(3), results.getObject("id"));
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(4), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(4), results.getObject("id"));
 		assertFalse(results.next());
 		
 		prepstmt.setString(1, "Office Employee");
 		results = prepstmt.executeQuery();
 		
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(6), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(6), results.getObject("id"));
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(7), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(7), results.getObject("id"));
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(8), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(8), results.getObject("id"));
 		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", new Integer(9), results.getObject("id"));
+		assertEquals("Integer column ID is wrong", Integer.valueOf(9), results.getObject("id"));
 		assertFalse(results.next());
 	}
 

--- a/src/test/java/org/relique/jdbc/csv/TestSqlParser.java
+++ b/src/test/java/org/relique/jdbc/csv/TestSqlParser.java
@@ -354,7 +354,7 @@ public class TestSqlParser
 
 		parser.parse("SELECT * FROM test WHERE c=1");
 		env.clear();
-		env.put("C", new Integer("1"));
+		env.put("C", Integer.valueOf("1"));
 		assertEquals(Boolean.TRUE, parser.getWhereClause().isTrue(env));
 
 		parser.parse("SELECT * FROM test WHERE c='1'");
@@ -364,7 +364,7 @@ public class TestSqlParser
 
 		parser.parse("SELECT * FROM test WHERE c=1.0");
 		env.clear();
-		env.put("C", new Double("1.0"));
+		env.put("C", Double.valueOf("1.0"));
 		assertEquals(Boolean.TRUE, parser.getWhereClause().isTrue(env));
 
 		parser.parse("SELECT * FROM test WHERE (A='20' OR B='AA') AND c=1");
@@ -373,15 +373,15 @@ public class TestSqlParser
 		env.clear();
 		env.put("A", new String("20"));
 		env.put("B", new String("AA"));
-		env.put("C", new Integer("1"));
+		env.put("C", Integer.valueOf("1"));
 		assertEquals(Boolean.TRUE, whereClause.isTrue(env));
-		env.put("A", new Double("20"));
+		env.put("A", Double.valueOf("20"));
 		assertEquals(Boolean.TRUE, whereClause.isTrue(env));
 		env.put("B", new String(""));
 		assertEquals(Boolean.FALSE, whereClause.isTrue(env));
 		env.put("A", new String("20"));
 		assertEquals(Boolean.TRUE, whereClause.isTrue(env));
-		env.put("C", new Integer("3"));
+		env.put("C", Integer.valueOf("3"));
 		assertEquals(Boolean.FALSE, whereClause.isTrue(env));
 	}
 
@@ -393,7 +393,7 @@ public class TestSqlParser
 	{
 		SqlParser parser = new SqlParser();
 		Map<String, Object> env = new HashMap<String, Object>();
-		env.put("C", new Integer("12"));
+		env.put("C", Integer.valueOf("12"));
 
 		parser.parse("SELECT * FROM test WHERE c=1");
 		assertEquals(Boolean.FALSE, parser.getWhereClause().isTrue(env));
@@ -462,11 +462,11 @@ public class TestSqlParser
 
 		parser.parse("SELECT * FROM test WHERE c=1.0");
 		env.clear();
-		env.put("C", new Integer("1"));
+		env.put("C", Integer.valueOf("1"));
 		assertEquals(Boolean.TRUE, parser.getWhereClause().isTrue(env));
-		env.put("C", new Double("1"));
+		env.put("C", Double.valueOf("1"));
 		assertEquals(Boolean.TRUE, parser.getWhereClause().isTrue(env));
-		env.put("C", new Float("1"));
+		env.put("C", Float.valueOf("1"));
 		assertEquals(Boolean.TRUE, parser.getWhereClause().isTrue(env));
 	}
 
@@ -478,11 +478,11 @@ public class TestSqlParser
 
 		parser.parse("SELECT * FROM test WHERE c=-1.0");
 		env.clear();
-		env.put("C", new Integer("-1"));
+		env.put("C", Integer.valueOf("-1"));
 		assertEquals(Boolean.TRUE, parser.getWhereClause().isTrue(env));
-		env.put("C", new Double("-1"));
+		env.put("C", Double.valueOf("-1"));
 		assertEquals(Boolean.TRUE, parser.getWhereClause().isTrue(env));
-		env.put("C", new Float("-1"));
+		env.put("C", Float.valueOf("-1"));
 		assertEquals(Boolean.TRUE, parser.getWhereClause().isTrue(env));
 	}
 
@@ -579,12 +579,12 @@ public class TestSqlParser
 		cs = new ExpressionParser(new StringReader("A+b AS result"));
 		cs.parseQueryEnvEntry();
 		Map<String, Object> env = new HashMap<String, Object>();
-		env.put("A", new Integer(1));
+		env.put("A", Integer.valueOf(1));
 
-		env.put("B", new Integer(1));
-		assertEquals((Object)(new Integer("2")), cs.eval(env));
-		env.put("A", new Double(1));
-		assertEquals((Object)(new Double("2")), cs.eval(env));
+		env.put("B", Integer.valueOf(1));
+		assertEquals((Object)(Integer.valueOf("2")), cs.eval(env));
+		env.put("A", Double.valueOf(1));
+		assertEquals((Object)(Double.valueOf("2")), cs.eval(env));
 		env.put("A", new String("1"));
 		// string concatenation because one of the arguments is a string
 		assertEquals("11", ""+cs.eval(env));
@@ -601,7 +601,7 @@ public class TestSqlParser
 		env.put("A", "Hello");
 		env.put("B", "World");
 		assertEquals("HelloWorld", cs.eval(env));
-		env.put("B", new Integer(100));
+		env.put("B", Integer.valueOf(100));
 		assertEquals("Hello100", cs.eval(env));
 	}
 
@@ -615,16 +615,16 @@ public class TestSqlParser
 
 		Map<String, Object> env = new HashMap<String, Object>();
 
-		env.put("A", new Integer(4));
-		env.put("B", new Integer(3));
-		assertEquals((Object)(new Integer("1")), cs.eval(env));
+		env.put("A", Integer.valueOf(4));
+		env.put("B", Integer.valueOf(3));
+		assertEquals((Object)(Integer.valueOf("1")), cs.eval(env));
 
-		env.put("A", new Integer(-3));
-		env.put("B", new Integer(2));
-		assertEquals((Object)(new Integer("-1")), cs.eval(env));
+		env.put("A", Integer.valueOf(-3));
+		env.put("B", Integer.valueOf(2));
+		assertEquals((Object)(Integer.valueOf("-1")), cs.eval(env));
 
-		env.put("A", new Integer(4));
-		env.put("B", new Integer(0));
+		env.put("A", Integer.valueOf(4));
+		env.put("B", Integer.valueOf(0));
 		try
 		{
 			cs.eval(env);
@@ -635,17 +635,17 @@ public class TestSqlParser
 			
 		}
 
-		env.put("A", new Double(5));
-		env.put("B", new Double(3));
-		assertEquals((Object)(new Double("2")), cs.eval(env));
+		env.put("A", Double.valueOf(5));
+		env.put("B", Double.valueOf(3));
+		assertEquals((Object)(Double.valueOf("2")), cs.eval(env));
 
-		env.put("A", new Double(8.8));
-		env.put("B", new Double(3.3));
-		assertEquals((Object)(new Double("2.2")), cs.eval(env));
+		env.put("A", Double.valueOf(8.8));
+		env.put("B", Double.valueOf(3.3));
+		assertEquals((Object)(Double.valueOf("2.2")), cs.eval(env));
 
-		env.put("A", new Double(-5));
-		env.put("B", new Double(3));
-		assertEquals((Object)(new Double("-2")), cs.eval(env));
+		env.put("A", Double.valueOf(-5));
+		env.put("B", Double.valueOf(3));
+		assertEquals((Object)(Double.valueOf("-2")), cs.eval(env));
 	}
 
 	@Test
@@ -655,29 +655,29 @@ public class TestSqlParser
 		cs = new ExpressionParser(new StringReader("a-b AS result"));
 		cs.parseQueryEnvEntry();
 		Map<String, Object> env = new HashMap<String, Object>();
-		env.put("A", new Integer(5));
+		env.put("A", Integer.valueOf(5));
 
-		env.put("B", new Integer(1));
-		assertEquals((Object)(new Integer("4")), cs.eval(env));
-		env.put("B", new Double(1));
-		assertEquals((Object)(new Double("4")), cs.eval(env));
+		env.put("B", Integer.valueOf(1));
+		assertEquals((Object)(Integer.valueOf("4")), cs.eval(env));
+		env.put("B", Double.valueOf(1));
+		assertEquals((Object)(Double.valueOf("4")), cs.eval(env));
 
 		cs = new ExpressionParser(new StringReader("a*b AS result"));
 		cs.parseQueryEnvEntry();
 
-		env.put("B", new Integer(1));
-		assertEquals((Object)(new Integer("5")), cs.eval(env));
-		env.put("B", new Double(1));
-		assertEquals((Object)(new Double("5")), cs.eval(env));
+		env.put("B", Integer.valueOf(1));
+		assertEquals((Object)(Integer.valueOf("5")), cs.eval(env));
+		env.put("B", Double.valueOf(1));
+		assertEquals((Object)(Double.valueOf("5")), cs.eval(env));
 		
 		cs = new ExpressionParser(new StringReader("a/b AS result"));
 		cs.parseQueryEnvEntry();
-		env.put("B", new Integer(2));
-		assertEquals((Object)(new Integer("2")), cs.eval(env));
-		env.put("B", new Double(2));
-		assertEquals((Object)(new Double("2.5")), cs.eval(env));
+		env.put("B", Integer.valueOf(2));
+		assertEquals((Object)(Integer.valueOf("2")), cs.eval(env));
+		env.put("B", Double.valueOf(2));
+		assertEquals((Object)(Double.valueOf("2.5")), cs.eval(env));
 
-		env.put("B", new Double(0));
+		env.put("B", Double.valueOf(0));
 		try
 		{
 			cs.eval(env);
@@ -695,20 +695,20 @@ public class TestSqlParser
 		cs = new ExpressionParser(new StringReader("A+1 AS result"));
 		cs.parseQueryEnvEntry();
 		Map<String, Object> env = new HashMap<String, Object>();
-		env.put("A", new Short("1"));
+		env.put("A", Short.valueOf("1"));
 		Object o = cs.eval(env);
 		assertEquals(o.toString(), "2");
 
 		cs = new ExpressionParser(new StringReader("A+B AS result"));
 		cs.parseQueryEnvEntry();		
-		env.put("A", new Short("3"));
-		env.put("B", new Short("4"));
+		env.put("A", Short.valueOf("3"));
+		env.put("B", Short.valueOf("4"));
 		o = cs.eval(env);
 		assertEquals(o.toString(), "7");
 		
 		cs = new ExpressionParser(new StringReader("A/2 AS result"));
 		cs.parseQueryEnvEntry();		
-		env.put("A", new Short("25"));
+		env.put("A", Short.valueOf("25"));
 		o = cs.eval(env);
 		assertEquals(o.toString(), "12");
 	}
@@ -720,31 +720,31 @@ public class TestSqlParser
 		cs = new ExpressionParser(new StringReader("A+5678678678 AS result"));
 		cs.parseQueryEnvEntry();
 		Map<String, Object> env = new HashMap<String, Object>();
-		env.put("A", new Integer("1"));
+		env.put("A", Integer.valueOf("1"));
 		Object o = cs.eval(env);
 		assertEquals(o.toString(), "5678678679");
 
 		cs = new ExpressionParser(new StringReader("A-50000000000 AS result"));
 		cs.parseQueryEnvEntry();		
-		env.put("A", new Long("120000000000"));
+		env.put("A", Long.valueOf("120000000000"));
 		o = cs.eval(env);
 		assertEquals(o.toString(), "70000000000");
 
 		cs = new ExpressionParser(new StringReader("A*5000000000 AS result"));
 		cs.parseQueryEnvEntry();		
-		env.put("A", new Integer("3"));
+		env.put("A", Integer.valueOf("3"));
 		o = cs.eval(env);
 		assertEquals(o.toString(), "15000000000");
 
 		cs = new ExpressionParser(new StringReader("A*10000L AS result"));
 		cs.parseQueryEnvEntry();		
-		env.put("A", new Integer("1000000"));
+		env.put("A", Integer.valueOf("1000000"));
 		o = cs.eval(env);
 		assertEquals(o.toString(), "10000000000");
 
 		cs = new ExpressionParser(new StringReader("A/10 AS result"));
 		cs.parseQueryEnvEntry();		
-		env.put("A", new Long("-1234567891230"));
+		env.put("A", Long.valueOf("-1234567891230"));
 		o = cs.eval(env);
 		assertEquals(o.toString(), "-123456789123");
 	}
@@ -786,14 +786,14 @@ public class TestSqlParser
 		cs.parseQueryEnvEntry();
 		env.put("EXPIRYDATE", Date.valueOf("2011-11-24"));
 		o = cs.eval(env);
-		assertEquals(o, new Integer(23));
+		assertEquals(o, Integer.valueOf(23));
 
 		cs = new ExpressionParser(new StringReader("ENDDATE - STARTDATE + 1 as result"));
 		cs.parseQueryEnvEntry();
 		env.put("STARTDATE", Date.valueOf("2011-11-22"));
 		env.put("ENDDATE", Date.valueOf("2011-11-24"));
 		o = cs.eval(env);
-		assertEquals(o, new Integer(3));
+		assertEquals(o, Integer.valueOf(3));
 	}
 
 	@Test


### PR DESCRIPTION
Avoid constructors for numeric types (Short, Integer, Long, Float, Double) that are deprecated in Java 9 and use static valueOf() methods instead.