### PR TITLE
Fix more compiler warnings

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/CsvDriver.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvDriver.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URLDecoder;
 import java.sql.Connection;
 import java.sql.Date;
@@ -201,7 +202,7 @@ public class CsvDriver implements Driver
 					throw new SQLException(CsvResources.getString("interfaceNotImplemented") +
 						": " + TableReader.class.getName() + ": " + className);
 				}
-				Object tableReaderInstance = clazz.newInstance();
+				Object tableReaderInstance = clazz.getConstructor().newInstance();
 				connection = new CsvConnection((TableReader)tableReaderInstance, info, urlProperties);
 			}
 			catch (ClassNotFoundException e)
@@ -213,6 +214,14 @@ public class CsvDriver implements Driver
 				throw new SQLException(e);
 			}
 			catch (InstantiationException e)
+			{
+				throw new SQLException(e);
+			}
+			catch (InvocationTargetException e)
+			{
+				throw new SQLException(e);
+			}
+			catch (NoSuchMethodException e)
 			{
 				throw new SQLException(e);
 			}

--- a/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
@@ -41,7 +41,6 @@ import java.sql.Statement;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -843,26 +842,24 @@ public class CsvResultSet implements ResultSet
 
 	private void sortRows(int sqlOffset) throws SQLException
 	{
-		Map<String, Object> []allRows = new Map[bufferedRecordEnvironments.size()];
-		for (int i = 0; i < allRows.length; i++)
-			allRows[i] = bufferedRecordEnvironments.get(i);
+		ArrayList<Map<String, Object>> allRows = new ArrayList<Map<String, Object>>(bufferedRecordEnvironments);
 		bufferedRecordEnvironments.clear();
 		try
 		{
-			Arrays.sort(allRows, new OrderByComparator());
+			allRows.sort(new OrderByComparator());
 		}
 		catch (OrderByException e)
 		{
 			throw new SQLException(e.getMessage());
 		}
-		int rowLimit = allRows.length;
+		int rowLimit = allRows.size();
 		if (maxRows != 0 && maxRows < rowLimit)
 			rowLimit = maxRows;
 		if (limit >= 0 && sqlOffset + limit < rowLimit)
 			rowLimit = sqlOffset + limit;
 
 		for (int i = sqlOffset; i < rowLimit; i++)
-			bufferedRecordEnvironments.add(allRows[i]);
+			bufferedRecordEnvironments.add(allRows.get(i));
 	}
 
 	private void checkOpen() throws SQLException

--- a/src/main/javacc/org/relique/jdbc/csv/where.jj
+++ b/src/main/javacc/org/relique/jdbc/csv/where.jj
@@ -1139,13 +1139,13 @@ Expression numericConstant():
 		}
 		try
 		{
-			value = new Long(digits);
+			value = Long.valueOf(digits);
 			if (isLong == false && value.longValue() >= Integer.MIN_VALUE && value.longValue() <= Integer.MAX_VALUE)
 				value = Integer.valueOf(value.intValue());
 		}
 		catch (NumberFormatException e)
 		{
-			value = new Double(digits);
+			value = Double.valueOf(digits);
 		}
 		return new NumericConstant(value);
 	}

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -57,8 +57,6 @@ import java.util.TimeZone;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.relique.jdbc.csv.CsvDriver;
-import org.relique.jdbc.csv.CsvResultSet;
 
 /**
  * This class is used to test the CsvJdbc driver.

--- a/src/test/java/org/relique/jdbc/csv/TestSqlParser.java
+++ b/src/test/java/org/relique/jdbc/csv/TestSqlParser.java
@@ -32,12 +32,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
-import org.relique.jdbc.csv.Expression;
-import org.relique.jdbc.csv.ExpressionParser;
-import org.relique.jdbc.csv.MultipleSqlParser;
-import org.relique.jdbc.csv.ParseException;
-import org.relique.jdbc.csv.SqlParser;
-import org.relique.jdbc.csv.StringConverter;
 
 /**
  * This class is used to test the SqlParser class.


### PR DESCRIPTION
1. Remove unused imports
2. Use Double.valueOf(), Long.valueOf() instead of new Double() new Long() to avoid deprecated warning
3. Use ArrayList instead of array to avoid unchecked conversion warning
4. Use clazz.getConstructor().newInstance() instead of deprecated method Class.newInstance()