### PR TITLE
Use try-with-resources for unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/java/org/relique/jdbc/csv/TestAggregateFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestAggregateFunctions.java
@@ -70,122 +70,106 @@ public class TestAggregateFunctions
 	@Test
 	public void testCountStar() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT COUNT(*) FROM sample");
-		assertTrue(results.next());
-		assertEquals("Incorrect count", 6, results.getInt(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT COUNT(*) FROM sample"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect count", 6, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testCountColumn() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT count(ID) FROM sample");
-		assertTrue(results.next());
-		assertEquals("Incorrect count", "6", results.getString(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT count(ID) FROM sample"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect count", "6", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testCountInvalidColumn() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		try
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT count(XXXX) FROM sample");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": XXXX", "" + e);
+			try
+			{
+				stmt.executeQuery("SELECT count(XXXX) FROM sample");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": XXXX", "" + e);
+			}
 		}
 	}
 
 	@Test
 	public void testCountPlusColumn() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		try
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT ID, count(ID) FROM sample");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("columnsWithAggregateFunctions"), "" + e);
+			try
+			{
+				stmt.executeQuery("SELECT ID, count(ID) FROM sample");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("columnsWithAggregateFunctions"), "" + e);
+			}
 		}
 	}
 
 	@Test
 	public void testCountWhere() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT count(*) C FROM sample where ID like '%234'");
-		assertTrue(results.next());
-		assertEquals("Incorrect count", 2, results.getInt("C"));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT count(*) C FROM sample where ID like '%234'"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect count", 2, results.getInt("C"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testCountNoResults() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT count(*) FROM sample where ID like 'ZZZ%'");
-		assertTrue(results.next());
-		assertEquals("Incorrect count", 0, results.getInt(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT count(*) FROM sample where ID like 'ZZZ%'"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect count", 0, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testCountInWhereClause() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		try
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM sample where count(*)=1");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noAggregateFunctions"), "" + e);
+			try
+			{
+				stmt.executeQuery("SELECT * FROM sample where count(*)=1");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noAggregateFunctions"), "" + e);
+			}
 		}
 	}
 
@@ -194,18 +178,15 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select MAX(ID) from sample8");
-		assertTrue(results.next());
-		assertEquals("Incorrect max", 6, results.getInt(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select MAX(ID) from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect max", 6, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -213,18 +194,15 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select max(name) from sample8 where id < 3");
-		assertTrue(results.next());
-		assertEquals("Incorrect max", "Mauricio Hernandez", results.getString(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select max(name) from sample8 where id < 3"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect max", "Mauricio Hernandez", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -232,35 +210,28 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select MAX(Name) from sample8 where ID = 999");
-		assertTrue(results.next());
-		assertEquals("Incorrect max", null, results.getObject(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select MAX(Name) from sample8 where ID = 999"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect max", null, results.getObject(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testMaxNoResultsExpression() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT MAX(ID)+1 FROM sample8 WHERE ID > 999");
-		assertTrue(results.next());
-		assertEquals("Incorrect max", null, results.getObject(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT MAX(ID)+1 FROM sample8 WHERE ID > 999"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect max", null, results.getObject(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -268,18 +239,15 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Double,Double,Double,Double,Double,Double,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT ROUND(MAX(C5)) FROM numeric");
-		assertTrue(results.next());
-		assertEquals("Incorrect max", 3, results.getInt(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT ROUND(MAX(C5)) FROM numeric"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect max", 3, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -287,18 +255,15 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select max(d) from sample8");
-		assertTrue(results.next());
-		assertEquals("Incorrect max", "2010-03-28", results.getObject(1).toString());
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select max(d) from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect max", "2010-03-28", results.getObject(1).toString());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -306,18 +271,15 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select MIN(ID) from sample8");
-		assertTrue(results.next());
-		assertEquals("Incorrect min", 1, results.getInt(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select MIN(ID) from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect min", 1, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -325,18 +287,15 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select min(upper(name)) from sample8 where id < 3");
-		assertTrue(results.next());
-		assertEquals("Incorrect min", "JUAN PABLO MORALES", results.getString(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select min(upper(name)) from sample8 where id < 3"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect min", "JUAN PABLO MORALES", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -344,19 +303,15 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select MIN(ID), MAX(ID) from sample8");
-		assertTrue(results.next());
-		assertEquals("Incorrect min", 1, results.getInt(1));
-		assertEquals("Incorrect max", 6, results.getInt(2));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select MIN(ID), MAX(ID) from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect min", 1, results.getInt(1));
+			assertEquals("Incorrect max", 6, results.getInt(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -364,18 +319,14 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select SUM(ID) from sample8");
-		assertTrue(results.next());
-		assertEquals("Incorrect sum", 21, results.getInt(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select SUM(ID) from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect sum", 21, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -383,19 +334,15 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,Int,Int,Long,Double,Double,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select sum(c4), sum(c5) from numeric");
-		assertTrue(results.next());
-		assertEquals("Incorrect sum", 989999995600L, results.getLong(1));
-		assertEquals("Incorrect sum", "3.14", results.getString(2));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select sum(c4), sum(c5) from numeric"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect sum", 989999995600L, results.getLong(1));
+			assertEquals("Incorrect sum", "3.14", results.getString(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -403,18 +350,14 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select SUM(ID) from sample8 where id > 999");
-		assertTrue(results.next());
-		assertEquals("Incorrect sum", null, results.getObject(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select SUM(ID) from sample8 where id > 999"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect sum", null, results.getObject(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -422,38 +365,30 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select AVG(ID) from sample8");
-		assertTrue(results.next());
-		assertEquals("Incorrect avg", "3.5", results.getString(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select AVG(ID) from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect avg", "3.5", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
-	
+
 	@Test
 	public void testAvgTwoColumns() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,Int,Int,Long,Double,Double,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select avg(c2), avg(c5) from numeric");
-		assertTrue(results.next());
-		assertEquals("Incorrect avg", "-497.5", results.getString(1));
-		assertEquals("Incorrect avg", "1.57", results.getString(2));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+				ResultSet results = stmt.executeQuery("select avg(c2), avg(c5) from numeric"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect avg", "-497.5", results.getString(1));
+			assertEquals("Incorrect avg", "1.57", results.getString(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -461,20 +396,16 @@ public class TestAggregateFunctions
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select AVG(ID) from sample8 where id > 999");
-		assertTrue(results.next());
-		assertEquals("Incorrect avg", null, results.getObject(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select AVG(ID) from sample8 where id > 999"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect avg", null, results.getObject(1));
+			assertFalse(results.next());
+		}
 	}
-	
+
 	@Test
 	public void testCountDistinct() throws SQLException
 	{
@@ -484,56 +415,46 @@ public class TestAggregateFunctions
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select count(distinct FROM_ACCT), count(distinct FROM_BLZ) from transactions");
-		assertTrue(results.next());
-		assertEquals("Incorrect count FROM_ACCT", 4, results.getInt(1));
-		assertEquals("Incorrect count FROM_BLZ", 3, results.getInt(2));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select count(distinct FROM_ACCT), count(distinct FROM_BLZ) from transactions"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect count FROM_ACCT", 4, results.getInt(1));
+			assertEquals("Incorrect count FROM_BLZ", 3, results.getInt(2));
+			assertFalse(results.next());
+		}
 	}
-	
+
 	@Test
 	public void testSumAvgDistinct() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,Int,Int,Date,Time");
 		props.put("dateFormat", "M/D/YYYY");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select sum(distinct PurchaseCt), round(avg(distinct PurchaseCt)) from Purchase");
-		assertTrue(results.next());
-		assertEquals("Incorrect sum", 1 + 3 + 4 + 11, results.getInt(1));
-		assertEquals("Incorrect avg", Math.round((1 + 3 + 4 + 11) / 4.0), results.getInt(2));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select sum(distinct PurchaseCt), round(avg(distinct PurchaseCt)) from Purchase"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect sum", 1 + 3 + 4 + 11, results.getInt(1));
+			assertEquals("Incorrect avg", Math.round((1 + 3 + 4 + 11) / 4.0), results.getInt(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testStringAgg() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("select STRING_AGG(ID, ';') from sample");
-		assertTrue(results.next());
-		assertEquals("Incorrect STRING_AGG", "Q123;A123;B234;C456;D789;X234", results.getString(1));
-		assertFalse(results.next());
-
-		results.close();
-		stmt.close();
-		conn.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("select STRING_AGG(ID, ';') from sample"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect STRING_AGG", "Q123;A123;B234;C456;D789;X234", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -3498,9 +3498,8 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("quotechar", "()");
 
-		try
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"	+ filePath, props))
 		{
-			DriverManager.getConnection("jdbc:relique:csv:"	+ filePath, props);
 			fail("expected exception java.sql.SQLException");
 		}
 		catch (SQLException e)
@@ -4703,9 +4702,8 @@ public class TestCsvDriver
 	@Test
 	public void testTableReaderWithBadReader() throws SQLException
 	{
-		try
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" + TestCsvDriver.class.getName()))
 		{
-			DriverManager.getConnection("jdbc:relique:csv:class:" + TestCsvDriver.class.getName());
 			fail("Should raise a java.sqlSQLException");
 		}
 		catch (SQLException e)
@@ -5271,9 +5269,8 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("function.BAD", "java.lang.Math.bad(double)");
 
-		try
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props))
 		{
-			DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 			fail("Should raise a java.sqlSQLException");
 		}
 		catch (SQLException e)

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -62,7 +62,7 @@ import org.relique.jdbc.csv.CsvResultSet;
 
 /**
  * This class is used to test the CsvJdbc driver.
- * 
+ *
  * @author Jonathan Ackerman
  * @author JD Evora
  * @author Chetan Gupta
@@ -91,125 +91,126 @@ public class TestCsvDriver
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");  
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));  
+		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
 		toUTCDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("UTC"));
 	}
 
 	@Test
 	public void testWithDefaultValues() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM sample");
+			ResultSet results = stmt
+				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM sample"))
+		{
+			results.next();
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "\"S,\"", results
+					.getString("NAME"));
+			assertEquals("Incorrect EXTRA_FIELD Value", "F", results
+					.getString("EXTRA_FIELD"));
 
-		results.next();
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "\"S,\"", results
-				.getString("NAME"));
-		assertEquals("Incorrect EXTRA_FIELD Value", "F", results
-				.getString("EXTRA_FIELD"));
+			assertEquals("Incorrect Column 1 Value", "\"S,\"", results.getString(1));
+			assertEquals("Incorrect Column 2 Value", "Q123", results.getString(2));
+			assertEquals("Incorrect Column 3 Value", "F", results.getString(3));
 
-		assertEquals("Incorrect Column 1 Value", "\"S,\"", results.getString(1));
-		assertEquals("Incorrect Column 2 Value", "Q123", results.getString(2));
-		assertEquals("Incorrect Column 3 Value", "F", results.getString(3));
+			results.next();
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
+					.getString("NAME"));
+			assertEquals("Incorrect EXTRA_FIELD Value", "A", results
+					.getString("EXTRA_FIELD"));
 
-		results.next();
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
-				.getString("NAME"));
-		assertEquals("Incorrect EXTRA_FIELD Value", "A", results
-				.getString("EXTRA_FIELD"));
+			results.next();
+			assertEquals("Incorrect ID Value", "B234", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Grady O'Neil", results
+					.getString("NAME"));
+			assertEquals("Incorrect EXTRA_FIELD Value", "B", results
+					.getString("EXTRA_FIELD"));
 
-		results.next();
-		assertEquals("Incorrect ID Value", "B234", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Grady O'Neil", results
-				.getString("NAME"));
-		assertEquals("Incorrect EXTRA_FIELD Value", "B", results
-				.getString("EXTRA_FIELD"));
+			results.next();
+			assertEquals("Incorrect ID Value", "C456", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Susan, Peter and Dave", results
+					.getString("NAME"));
+			assertEquals("Incorrect EXTRA_FIELD Value", "C", results
+					.getString("EXTRA_FIELD"));
 
-		results.next();
-		assertEquals("Incorrect ID Value", "C456", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Susan, Peter and Dave", results
-				.getString("NAME"));
-		assertEquals("Incorrect EXTRA_FIELD Value", "C", results
-				.getString("EXTRA_FIELD"));
+			results.next();
+			assertEquals("Incorrect ID Value", "D789", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Amelia \"meals\" Maurice",
+					results.getString("NAME"));
+			assertEquals("Incorrect EXTRA_FIELD Value", "E", results
+					.getString("EXTRA_FIELD"));
 
-		results.next();
-		assertEquals("Incorrect ID Value", "D789", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Amelia \"meals\" Maurice",
-				results.getString("NAME"));
-		assertEquals("Incorrect EXTRA_FIELD Value", "E", results
-				.getString("EXTRA_FIELD"));
-
-		results.next();
-		assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
-		assertEquals("Incorrect NAME Value",
-				"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
-						.getString("NAME"));
-		assertEquals("Incorrect EXTRA_FIELD Value", "G", results
-				.getString("EXTRA_FIELD"));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			results.next();
+			assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
+			assertEquals("Incorrect NAME Value",
+					"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
+							.getString("NAME"));
+			assertEquals("Incorrect EXTRA_FIELD Value", "G", results
+					.getString("EXTRA_FIELD"));
+		}
 	}
 
 	/**
 	 * This creates several sentences with where and tests they work
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
 	public void testWhereSimple() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ID,Name FROM sample4 WHERE ID='03'");
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "Maria Cristina Lucero", results
-				.getString("Name"));
-		try
+			ResultSet results = stmt
+				.executeQuery("SELECT ID,Name FROM sample4 WHERE ID='03'"))
 		{
-			results.getString("Job");
-			fail("Should not find the column 'Job'");
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "Maria Cristina Lucero", results
+					.getString("Name"));
+			try
+			{
+				results.getString("Job");
+				fail("Should not find the column 'Job'");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": Job", "" + e);
+			}
+			assertTrue(!results.next());
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": Job", "" + e);
-		}
-		assertTrue(!results.next());
 	}
 
 	/**
 	 * fields in different order than in source file.
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
 	public void testWhereShuffled() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT Job,ID,Name FROM sample4 WHERE ID='02'");
-		assertTrue("no results found - should be one", results.next());
-		assertEquals("The name is wrong", "Mauricio Hernandez", results
-				.getString("Name"));
-		assertEquals("The job is wrong", "Project Manager", results
-				.getString("Job"));
-		assertTrue("more than one matching records", !results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT Job,ID,Name FROM sample4 WHERE ID='02'"))
+		{
+			assertTrue("no results found - should be one", results.next());
+			assertEquals("The name is wrong", "Mauricio Hernandez", results
+					.getString("Name"));
+			assertEquals("The job is wrong", "Project Manager", results
+					.getString("Job"));
+			assertTrue("more than one matching records", !results.next());
+		}
 	}
 
 	@Test
@@ -219,119 +220,110 @@ public class TestCsvDriver
 		props.put("fileExtension", "");
 		props.put("separator", ";");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM sample");
+			ResultSet results = stmt
+				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM sample"))
+		{
+			results.next();
+			assertTrue("Incorrect ID Value", results.getString("ID").equals("Q123"));
+			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
+					"\"S;\""));
+			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
+					"EXTRA_FIELD").equals("F"));
 
-		results.next();
-		assertTrue("Incorrect ID Value", results.getString("ID").equals("Q123"));
-		assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-				"\"S;\""));
-		assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-				"EXTRA_FIELD").equals("F"));
+			results.next();
+			assertTrue("Incorrect ID Value", results.getString("ID").equals("A123"));
+			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
+					"Jonathan Ackerman"));
+			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
+					"EXTRA_FIELD").equals("A"));
 
-		results.next();
-		assertTrue("Incorrect ID Value", results.getString("ID").equals("A123"));
-		assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-				"Jonathan Ackerman"));
-		assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-				"EXTRA_FIELD").equals("A"));
+			results.next();
+			assertTrue("Incorrect ID Value", results.getString("ID").equals("B234"));
+			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
+					"Grady O'Neil"));
+			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
+					"EXTRA_FIELD").equals("B"));
 
-		results.next();
-		assertTrue("Incorrect ID Value", results.getString("ID").equals("B234"));
-		assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-				"Grady O'Neil"));
-		assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-				"EXTRA_FIELD").equals("B"));
+			results.next();
+			assertTrue("Incorrect ID Value", results.getString("ID").equals("C456"));
+			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
+					"Susan; Peter and Dave"));
+			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
+					"EXTRA_FIELD").equals("C"));
 
-		results.next();
-		assertTrue("Incorrect ID Value", results.getString("ID").equals("C456"));
-		assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-				"Susan; Peter and Dave"));
-		assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-				"EXTRA_FIELD").equals("C"));
+			results.next();
+			assertTrue("Incorrect ID Value", results.getString("ID").equals("D789"));
+			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
+					"Amelia \"meals\" Maurice"));
+			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
+					"EXTRA_FIELD").equals("E"));
 
-		results.next();
-		assertTrue("Incorrect ID Value", results.getString("ID").equals("D789"));
-		assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-				"Amelia \"meals\" Maurice"));
-		assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-				"EXTRA_FIELD").equals("E"));
-
-		results.next();
-		assertTrue("Incorrect ID Value", results.getString("ID").equals("X234"));
-		assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-				"Peter \"peg leg\"; Jimmy & Samantha \"Sam\""));
-		assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-				"EXTRA_FIELD").equals("G"));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			results.next();
+			assertTrue("Incorrect ID Value", results.getString("ID").equals("X234"));
+			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
+					"Peter \"peg leg\"; Jimmy & Samantha \"Sam\""));
+			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
+					"EXTRA_FIELD").equals("G"));
+		}
 	}
 
 	@Test
 	public void testFindColumn() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-
-		assertEquals("Incorrect Column", 1, results.findColumn("ID"));
-		assertEquals("Incorrect Column", 2, results.findColumn("Name"));
-		assertEquals("Incorrect Column", 3, results.findColumn("EXTRA_FIELD"));
-
-		try
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.findColumn("foo");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": foo", "" + e);
-		}
+			assertEquals("Incorrect Column", 1, results.findColumn("ID"));
+			assertEquals("Incorrect Column", 2, results.findColumn("Name"));
+			assertEquals("Incorrect Column", 3, results.findColumn("EXTRA_FIELD"));
 
-		results.close();
-		stmt.close();
-		conn.close();
+			try
+			{
+				results.findColumn("foo");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": foo", "" + e);
+			}
+		}
 	}
 
 	@Test
 	public void testMetadata() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample3");
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample3"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("Incorrect Table Name", "sample3", metadata
+					.getTableName(0));
 
-		assertEquals("Incorrect Table Name", "sample3", metadata
-				.getTableName(0));
-
-		assertEquals("Incorrect Column Name 1", "column 1", metadata
-				.getColumnName(1));
-		assertEquals("Incorrect Column Name 2", "column \"2\" two", metadata
-				.getColumnName(2));
-		assertEquals("Incorrect Column Name 3", "Column 3", metadata
-				.getColumnName(3));
-		assertEquals("Incorrect Column Name 4", "CoLuMn4", metadata
-				.getColumnName(4));
-		assertEquals("Incorrect Column Name 5", "COLumn5", metadata
-				.getColumnName(5));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			assertEquals("Incorrect Column Name 1", "column 1", metadata
+					.getColumnName(1));
+			assertEquals("Incorrect Column Name 2", "column \"2\" two", metadata
+					.getColumnName(2));
+			assertEquals("Incorrect Column Name 3", "Column 3", metadata
+					.getColumnName(3));
+			assertEquals("Incorrect Column Name 4", "CoLuMn4", metadata
+					.getColumnName(4));
+			assertEquals("Incorrect Column Name 5", "COLumn5", metadata
+					.getColumnName(5));
+		}
 	}
 
 	@Test
@@ -340,28 +332,25 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("suppressHeaders", "true");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
+			assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
+					"sample"));
 
-		assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
-				"sample"));
-
-		assertTrue("Incorrect Column Name 1", metadata.getColumnName(1).equals(
-				"COLUMN1"));
-		assertTrue("Incorrect Column Name 2", metadata.getColumnName(2).equals(
-				"COLUMN2"));
-		assertTrue("Incorrect Column Name 3", metadata.getColumnName(3).equals(
-				"COLUMN3"));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			assertTrue("Incorrect Column Name 1", metadata.getColumnName(1).equals(
+					"COLUMN1"));
+			assertTrue("Incorrect Column Name 2", metadata.getColumnName(2).equals(
+					"COLUMN2"));
+			assertTrue("Incorrect Column Name 3", metadata.getColumnName(3).equals(
+					"COLUMN3"));
+		}
 	}
 
 	@Test
@@ -369,37 +358,35 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT id, name, job, start FROM sample5");
+			ResultSet results = stmt
+				.executeQuery("SELECT id, name, job, start FROM sample5"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
+					.getColumnType(1));
+			assertEquals("type of column 2 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(2));
+			assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(3));
+			assertEquals("type of column 4 is incorrect", Types.TIMESTAMP, metadata
+					.getColumnType(4));
 
-		assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
-				.getColumnType(1));
-		assertEquals("type of column 2 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(2));
-		assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(3));
-		assertEquals("type of column 4 is incorrect", Types.TIMESTAMP, metadata
-				.getColumnType(4));
-
-		assertEquals("type of column 1 is incorrect", "Int", metadata
-				.getColumnTypeName(1));
-		assertEquals("type of column 2 is incorrect", "String", metadata
-				.getColumnTypeName(2));
-		assertEquals("type of column 3 is incorrect", "String", metadata
-				.getColumnTypeName(3));
-		assertEquals("type of column 4 is incorrect", "Timestamp", metadata
-				.getColumnTypeName(4));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			assertEquals("type of column 1 is incorrect", "Int", metadata
+					.getColumnTypeName(1));
+			assertEquals("type of column 2 is incorrect", "String", metadata
+					.getColumnTypeName(2));
+			assertEquals("type of column 3 is incorrect", "String", metadata
+					.getColumnTypeName(3));
+			assertEquals("type of column 4 is incorrect", "Timestamp", metadata
+					.getColumnTypeName(4));
+		}
 	}
 
 	@Test
@@ -407,28 +394,26 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT id+1 AS ID1, name, job, start FROM sample5");
+			ResultSet results = stmt
+				.executeQuery("SELECT id+1 AS ID1, name, job, start FROM sample5"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
-
-		assertEquals("size of column 1 is incorrect", 20, metadata
-				.getColumnDisplaySize(1));
-		assertEquals("size of column 2 is incorrect", 20, metadata
-				.getColumnDisplaySize(2));
-		assertEquals("size of column 3 is incorrect", 20, metadata
-				.getColumnDisplaySize(3));
-		assertEquals("size of column 4 is incorrect", 20, metadata
-				.getColumnDisplaySize(4));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			assertEquals("size of column 1 is incorrect", 20, metadata
+					.getColumnDisplaySize(1));
+			assertEquals("size of column 2 is incorrect", 20, metadata
+					.getColumnDisplaySize(2));
+			assertEquals("size of column 3 is incorrect", 20, metadata
+					.getColumnDisplaySize(3));
+			assertEquals("size of column 4 is incorrect", 20, metadata
+					.getColumnDisplaySize(4));
+		}
 	}
 
 	@Test
@@ -438,29 +423,27 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		// header in file: ID,Name,Job,Start,timeoffset
 		props.put("columnTypes", "Int,String,String,Timestamp");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT start, id, name, job FROM sample5");
+			ResultSet results = stmt
+				.executeQuery("SELECT start, id, name, job FROM sample5"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
-
-		// TODO - this fails
-		assertEquals("type of column 1 is incorrect", Types.TIMESTAMP, metadata
-				.getColumnType(1));
-		assertEquals("type of column 2 is incorrect", Types.INTEGER, metadata
-				.getColumnType(2));
-		assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(3));
-		assertEquals("type of column 4 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(4));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			// TODO - this fails
+			assertEquals("type of column 1 is incorrect", Types.TIMESTAMP, metadata
+					.getColumnType(1));
+			assertEquals("type of column 2 is incorrect", Types.INTEGER, metadata
+					.getColumnType(2));
+			assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(3));
+			assertEquals("type of column 4 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(4));
+		}
 	}
 
 	@Test
@@ -470,51 +453,55 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,String,String,Date,Time");
 		props.put("timeFormat", "HHmm");
 		props.put("dateFormat", "yyyy-MM-dd");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
+			ResultSet results = stmt
 				.executeQuery("SELECT id, start+timeoffset AS ts, 999 as C3, id - 4 as C4, " +
-						"ID * 1.1 as C5, Name+JOB AS c6, '.com' as C7, 'Mr '+Name as C8 FROM sample5");
-		ResultSetMetaData metadata = results.getMetaData();
+						"ID * 1.1 as C5, Name+JOB AS c6, '.com' as C7, 'Mr '+Name as C8 FROM sample5"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
-				.getColumnType(1));
-		assertEquals("type of column 2 is incorrect", Types.TIMESTAMP, metadata
-				.getColumnType(2));
-		assertEquals("type of column 3 is incorrect", Types.INTEGER, metadata
-				.getColumnType(3));
-		assertEquals("type of column 4 is incorrect", Types.INTEGER, metadata
-				.getColumnType(4));
-		assertEquals("type of column 5 is incorrect", Types.DOUBLE, metadata
-				.getColumnType(5));
-		assertEquals("type of column 6 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(6));
-		assertEquals("type of column 7 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(7));
-		assertEquals("type of column 8 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(8));
+			assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
+					.getColumnType(1));
+			assertEquals("type of column 2 is incorrect", Types.TIMESTAMP, metadata
+					.getColumnType(2));
+			assertEquals("type of column 3 is incorrect", Types.INTEGER, metadata
+					.getColumnType(3));
+			assertEquals("type of column 4 is incorrect", Types.INTEGER, metadata
+					.getColumnType(4));
+			assertEquals("type of column 5 is incorrect", Types.DOUBLE, metadata
+					.getColumnType(5));
+			assertEquals("type of column 6 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(6));
+			assertEquals("type of column 7 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(7));
+			assertEquals("type of column 8 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(8));
+		}
 	}
 
 	@Test
 	public void testMetadataWithTableAlias() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("select sx.id, sx.name as name from sample as sx");
+			ResultSet results = stmt
+				.executeQuery("select sx.id, sx.name as name from sample as sx"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("Incorrect Table Name", "sample", metadata.getTableName(0));
 
-		assertEquals("Incorrect Table Name", "sample", metadata.getTableName(0));
-
-		assertEquals("Incorrect Column Name 1", "ID", metadata.getColumnName(1));
-		assertEquals("Incorrect Column Name 2", "NAME", metadata.getColumnName(2));
+			assertEquals("Incorrect Column Name 1", "ID", metadata.getColumnName(1));
+			assertEquals("Incorrect Column Name 2", "NAME", metadata.getColumnName(2));
+		}
 	}
 
 	@Test
@@ -522,65 +509,66 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT id * 10 as XID, name, 1000 as dept FROM sample5");
+			ResultSet results = stmt
+				.executeQuery("SELECT id * 10 as XID, name, 1000 as dept FROM sample5"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
-
-		assertEquals("name of column 1 is incorrect", "XID", metadata.getColumnName(1));
-		assertEquals("label of column 1 is incorrect", "XID", metadata.getColumnLabel(1));
-		assertEquals("name of column 2 is incorrect", "Name", metadata.getColumnName(2));
-		assertEquals("label of column 2 is incorrect", "Name", metadata.getColumnLabel(2));
-		assertEquals("name of column 3 is incorrect", "DEPT", metadata.getColumnName(3));
-		assertEquals("label of column 3 is incorrect", "DEPT", metadata.getColumnLabel(3));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			assertEquals("name of column 1 is incorrect", "XID", metadata.getColumnName(1));
+			assertEquals("label of column 1 is incorrect", "XID", metadata.getColumnLabel(1));
+			assertEquals("name of column 2 is incorrect", "Name", metadata.getColumnName(2));
+			assertEquals("label of column 2 is incorrect", "Name", metadata.getColumnLabel(2));
+			assertEquals("name of column 3 is incorrect", "DEPT", metadata.getColumnName(3));
+			assertEquals("label of column 3 is incorrect", "DEPT", metadata.getColumnLabel(3));
+		}
 	}
 
 	@Test
 	public void testDatabaseMetadataTableTypes() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getTableTypes();
-		assertTrue(results.next());
-		assertEquals("Wrong table type", "TABLE", results.getString(1));
-		assertFalse(results.next());
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath))
+		{
+			DatabaseMetaData metadata = conn.getMetaData();
+			ResultSet results = metadata.getTableTypes();
+			assertTrue(results.next());
+			assertEquals("Wrong table type", "TABLE", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testDatabaseMetadataSchemas() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getSchemas();
-		assertFalse(results.next());
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath))
+		{
+			DatabaseMetaData metadata = conn.getMetaData();
+			ResultSet results = metadata.getSchemas();
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testDatabaseMetadataColumns() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getColumns(null, null, "C D", null);
-		assertTrue(results.next());
-		assertEquals("Wrong table name", "C D", results.getString("TABLE_NAME"));
-		assertEquals("Wrong column name", "A", results.getString("COLUMN_NAME"));
-		assertTrue(results.next());
-		assertEquals("Wrong table name", "C D", results.getString("TABLE_NAME"));
-		assertEquals("Wrong column name", "B", results.getString("COLUMN_NAME"));
-		results.close();
-		conn.close();
+			ResultSet results = conn.getMetaData().getColumns(null, null, "C D", null))
+		{
+			assertTrue(results.next());
+			assertEquals("Wrong table name", "C D", results.getString("TABLE_NAME"));
+			assertEquals("Wrong column name", "A", results.getString("COLUMN_NAME"));
+			assertTrue(results.next());
+			assertEquals("Wrong table name", "C D", results.getString("TABLE_NAME"));
+			assertEquals("Wrong column name", "B", results.getString("COLUMN_NAME"));
+		}
 	}
 
 	@Test
@@ -591,71 +579,76 @@ public class TestCsvDriver
 		props.put("fileTailPattern", "-([0-9]{3})-([0-9]{8})");
 		props.put("fileTailParts", "location,file_date");
 		props.put("indexedFiles", "True");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getColumns(null, null, "test", null);
-		assertTrue(results.next());
-		assertEquals("Wrong table name", "test", results.getString("TABLE_NAME"));
-		assertEquals("Wrong column name", "Datum", results.getString("COLUMN_NAME"));
-		assertTrue(results.next());
-		assertEquals("Wrong table name", "test", results.getString("TABLE_NAME"));
-		assertEquals("Wrong column name", "Tijd", results.getString("COLUMN_NAME"));
-		results.close();
-		conn.close();
+			ResultSet results = conn.getMetaData().getColumns(null, null, "test", null))
+		{
+			assertTrue(results.next());
+			assertEquals("Wrong table name", "test", results.getString("TABLE_NAME"));
+			assertEquals("Wrong column name", "Datum", results.getString("COLUMN_NAME"));
+			assertTrue(results.next());
+			assertEquals("Wrong table name", "test", results.getString("TABLE_NAME"));
+			assertEquals("Wrong column name", "Tijd", results.getString("COLUMN_NAME"));
+		}
 	}
 
 	@Test
 	public void testDatabaseMetadataProcedures() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getProcedures(null, null, "*");
-		assertFalse(results.next());
+			ResultSet results = conn.getMetaData().getProcedures(null, null, "*"))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testDatabaseMetadataUDTs() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getUDTs(null, null, "test", null);
-		assertFalse(results.next());
+			ResultSet results = conn.getMetaData().getUDTs(null, null, "test", null))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testDatabaseMetadataPrimaryKeys() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getPrimaryKeys(null, null, "sample");
-		assertFalse(results.next());
+			ResultSet results = conn.getMetaData().getPrimaryKeys(null, null, "sample"))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testDatabaseMetadataCatalogs() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getCatalogs();
-		assertFalse(results.next());
+			ResultSet results = conn.getMetaData().getCatalogs())
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testDatabaseMetadataTypeInfo() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		DatabaseMetaData metadata = conn.getMetaData();
-		ResultSet results = metadata.getTypeInfo();
-		assertTrue(results.next());
-		assertEquals("TYPE_NAME is wrong", "String", results.getString("TYPE_NAME"));
-		assertEquals("DATA_TYPE is wrong", Types.VARCHAR, results.getInt("DATA_TYPE"));
-		assertEquals("NULLABLE is wrong", DatabaseMetaData.typeNullable, results.getShort("NULLABLE"));
+			ResultSet results = conn.getMetaData().getTypeInfo())
+		{
+			assertTrue(results.next());
+			assertEquals("TYPE_NAME is wrong", "String", results.getString("TYPE_NAME"));
+			assertEquals("DATA_TYPE is wrong", Types.VARCHAR, results.getInt("DATA_TYPE"));
+			assertEquals("NULLABLE is wrong", DatabaseMetaData.typeNullable, results.getShort("NULLABLE"));
+		}
 	}
 
 	@Test
@@ -665,23 +658,24 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Date");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT ID, Name, Job, Start "
-				+ "FROM sample5 WHERE Job = 'Project Manager'");
-
-		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
-				.getObject("id"));
-		assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
-				.getObject(1));
-		java.sql.Date shouldBe = java.sql.Date.valueOf("2001-01-02");
-		assertEquals("Date column Start is wrong", shouldBe, results
-				.getObject("start"));
-		assertEquals("Date column 4 is wrong", shouldBe, results.getObject(4));
-		assertEquals("The Name is wrong", "Juan Pablo Morales", results
-				.getObject("name"));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT ID, Name, Job, Start "
+				+ "FROM sample5 WHERE Job = 'Project Manager'"))
+		{
+			assertTrue(results.next());
+			assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
+					.getObject("id"));
+			assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
+					.getObject(1));
+			java.sql.Date shouldBe = java.sql.Date.valueOf("2001-01-02");
+			assertEquals("Date column Start is wrong", shouldBe, results
+					.getObject("start"));
+			assertEquals("Date column 4 is wrong", shouldBe, results.getObject(4));
+			assertEquals("The Name is wrong", "Juan Pablo Morales", results
+					.getObject("name"));
+		}
 	}
 
 	@Test
@@ -691,23 +685,24 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Date");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT ID, Start, Name, Job "
-				+ "FROM sample5 WHERE Job = 'Project Manager'");
-
-		assertTrue(results.next());
-		assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
-				.getObject("id"));
-		assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
-				.getObject(1));
-		java.sql.Date shouldBe = java.sql.Date.valueOf("2001-01-02");
-		assertEquals("Date column Start is wrong", shouldBe, results
-				.getObject("start"));
-		assertEquals("Date column 4 is wrong", shouldBe, results.getObject(2));
-		assertEquals("The Name is wrong", "Juan Pablo Morales", results
-				.getObject("name"));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT ID, Start, Name, Job "
+				+ "FROM sample5 WHERE Job = 'Project Manager'"))
+		{
+			assertTrue(results.next());
+			assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
+					.getObject("id"));
+			assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
+					.getObject(1));
+			java.sql.Date shouldBe = java.sql.Date.valueOf("2001-01-02");
+			assertEquals("Date column Start is wrong", shouldBe, results
+					.getObject("start"));
+			assertEquals("Date column 4 is wrong", shouldBe, results.getObject(2));
+			assertEquals("The Name is wrong", "Juan Pablo Morales", results
+					.getObject("name"));
+		}
 	}
 
 	@Test
@@ -717,24 +712,25 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT ID, Name, Job, Start "
-				+ "FROM sample5 WHERE Job = 'Project Manager'");
-
-		assertTrue(results.next());
-		DateFormat dfp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
-				.getObject("id"));
-		assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
-				.getObject(1));
-		assertEquals("Date column Start is wrong", dfp.parse(results
-				.getString("start")), results.getObject("start"));
-		assertEquals("Date column 4 is wrong", dfp.parse(results
-				.getString("start")), results.getObject(4));
-		assertEquals("The Name is wrong", "Juan Pablo Morales", results
-				.getObject("name"));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT ID, Name, Job, Start "
+				+ "FROM sample5 WHERE Job = 'Project Manager'"))
+		{
+			assertTrue(results.next());
+			DateFormat dfp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+			assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
+					.getObject("id"));
+			assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
+					.getObject(1));
+			assertEquals("Date column Start is wrong", dfp.parse(results
+					.getString("start")), results.getObject("start"));
+			assertEquals("Date column 4 is wrong", dfp.parse(results
+					.getString("start")), results.getObject(4));
+			assertEquals("The Name is wrong", "Juan Pablo Morales", results
+					.getObject("name"));
+		}
 	}
 
 	/**
@@ -748,22 +744,23 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT ID, Name, Job, Start "
-				+ "FROM sample5");
-
-		assertTrue(results.next());
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
-				.getColumnType(1));
-		assertEquals("type of column 2 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(2));
-		assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
-				.getColumnType(3));
-		assertEquals("type of column 4 is incorrect", Types.TIMESTAMP, metadata
-				.getColumnType(4));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT ID, Name, Job, Start "
+				+ "FROM sample5"))
+		{
+			assertTrue(results.next());
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
+					.getColumnType(1));
+			assertEquals("type of column 2 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(2));
+			assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
+					.getColumnType(3));
+			assertEquals("type of column 4 is incorrect", Types.TIMESTAMP, metadata
+					.getColumnType(4));
+		}
 	}
 
 	@Test
@@ -782,20 +779,21 @@ public class TestCsvDriver
 			props.put("locale", Locale.US.toString());
 		}
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT ID, D, T "
-				+ "FROM sunil_date_time");
-
-		assertTrue(results.next());
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
-				.getColumnType(1));
-		assertEquals("type of column 2 is incorrect", Types.DATE, metadata
-				.getColumnType(2));
-		assertEquals("type of column 3 is incorrect", Types.TIME, metadata
-				.getColumnType(3));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT ID, D, T "
+				+ "FROM sunil_date_time"))
+		{
+			assertTrue(results.next());
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
+					.getColumnType(1));
+			assertEquals("type of column 2 is incorrect", Types.DATE, metadata
+					.getColumnType(2));
+			assertEquals("type of column 3 is incorrect", Types.TIME, metadata
+					.getColumnType(3));
+		}
 	}
 
 	@Test
@@ -805,19 +803,20 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
-
-		try
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample5"))
 		{
-			results.getMetaData();
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("cannotInferColumns"), "" + e);
+			try
+			{
+				results.getMetaData();
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("cannotInferColumns"), "" + e);
+			}
 		}
 	}
 
@@ -832,28 +831,29 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Byte,Short,Integer,Long,Float,Double,BigDecimal");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT C1, C2, C3, C4, C5, C6, C7 "
-				+ "FROM numeric");
-
-		assertTrue(results.next());
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("type of column 1 is incorrect", Types.TINYINT, metadata
-				.getColumnType(1));
-		assertEquals("type of column 2 is incorrect", Types.SMALLINT, metadata
-				.getColumnType(2));
-		assertEquals("type of column 3 is incorrect", Types.INTEGER, metadata
-				.getColumnType(3));
-		assertEquals("type of column 4 is incorrect", Types.BIGINT, metadata
-				.getColumnType(4));
-		assertEquals("type of column 5 is incorrect", Types.FLOAT, metadata
-				.getColumnType(5));
-		assertEquals("type of column 6 is incorrect", Types.DOUBLE, metadata
-				.getColumnType(6));
-		assertEquals("type of column 7 is incorrect", Types.DECIMAL, metadata
-				.getColumnType(7));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT C1, C2, C3, C4, C5, C6, C7 "
+				+ "FROM numeric"))
+		{
+			assertTrue(results.next());
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("type of column 1 is incorrect", Types.TINYINT, metadata
+					.getColumnType(1));
+			assertEquals("type of column 2 is incorrect", Types.SMALLINT, metadata
+					.getColumnType(2));
+			assertEquals("type of column 3 is incorrect", Types.INTEGER, metadata
+					.getColumnType(3));
+			assertEquals("type of column 4 is incorrect", Types.BIGINT, metadata
+					.getColumnType(4));
+			assertEquals("type of column 5 is incorrect", Types.FLOAT, metadata
+					.getColumnType(5));
+			assertEquals("type of column 6 is incorrect", Types.DOUBLE, metadata
+					.getColumnType(6));
+			assertEquals("type of column 7 is incorrect", Types.DECIMAL, metadata
+					.getColumnType(7));
+		}
 	}
 
 	@Test
@@ -862,34 +862,36 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT ID, Name, Job, Start "
-				+ "FROM sample5 WHERE Job = 'Project Manager'");
-
-		assertTrue(results.next());
-		assertEquals("the start time is wrong", "2001-01-02 12:30:00", results
-				.getObject("start"));
-		assertEquals("The ID is wrong", "01", results.getObject("id"));
-		assertEquals("The Name is wrong", "Juan Pablo Morales", results
-				.getObject("name"));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT ID, Name, Job, Start "
+				+ "FROM sample5 WHERE Job = 'Project Manager'"))
+		{
+			assertTrue(results.next());
+			assertEquals("the start time is wrong", "2001-01-02 12:30:00", results
+					.getObject("start"));
+			assertEquals("The ID is wrong", "01", results.getObject("id"));
+			assertEquals("The Name is wrong", "Juan Pablo Morales", results
+					.getObject("name"));
+		}
 	}
 
 	@Test
 	public void testBadColumnTypesFails() throws SQLException
-	{		
+	{
 		try
 		{
 			Properties props = new Properties();
 			props.put("columnTypes", "Varchar,Varchar");
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+			try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
-			Statement stmt = conn.createStatement();
-
-			stmt.executeQuery("SELECT Id, Name FROM sample");
-			fail("Should raise a java.sqlSQLException");
+				Statement stmt = conn.createStatement())
+			{
+				stmt.executeQuery("SELECT Id, Name FROM sample");
+				fail("Should raise a java.sqlSQLException");
+			}
 		}
 		catch (SQLException e)
 		{
@@ -899,17 +901,18 @@ public class TestCsvDriver
 
 	@Test
 	public void testBadColumnNameFails() throws SQLException
-	{		
+	{
 		try
 		{
 			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+			try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
-			Statement stmt = conn.createStatement();
-
-			stmt.executeQuery("SELECT Id, XXXX FROM sample");
-			fail("Should raise a java.sqlSQLException");
+				Statement stmt = conn.createStatement())
+			{
+				stmt.executeQuery("SELECT Id, XXXX FROM sample");
+				fail("Should raise a java.sqlSQLException");
+			}
 		}
 		catch (SQLException e)
 		{
@@ -919,18 +922,20 @@ public class TestCsvDriver
 
 	@Test
 	public void testEmptyColumnTypesFails() throws SQLException
-	{		
+	{
 		try
 		{
 			Properties props = new Properties();
 			props.put("columnTypes", ",");
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+			try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
-			Statement stmt = conn.createStatement();
-
-			stmt.executeQuery("SELECT * FROM sample");
-			fail("Should raise a java.sqlSQLException");
+				Statement stmt = conn.createStatement())
+			{
+				stmt.executeQuery("SELECT * FROM sample");
+				fail("Should raise a java.sqlSQLException");
+			}
 		}
 		catch (SQLException e)
 		{
@@ -945,19 +950,20 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * "
-				+ "FROM sample5 WHERE Job = 'Project Manager'");
-
-		assertTrue(results.next());
-		String target = "2001-01-02 12:30:00";
-		assertEquals("the start time is wrong", target, toUTC.format(results
-				.getObject("start")));
-		assertEquals("The ID is wrong", Integer.valueOf(1), results.getObject("id"));
-		assertEquals("The Name is wrong", "Juan Pablo Morales", results
-				.getObject("name"));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * "
+				+ "FROM sample5 WHERE Job = 'Project Manager'"))
+		{
+			assertTrue(results.next());
+			String target = "2001-01-02 12:30:00";
+			assertEquals("the start time is wrong", target, toUTC.format(results
+					.getObject("start")));
+			assertEquals("The ID is wrong", Integer.valueOf(1), results.getObject("id"));
+			assertEquals("The Name is wrong", "Juan Pablo Morales", results
+					.getObject("name"));
+		}
 	}
 
 	@Test
@@ -970,25 +976,31 @@ public class TestCsvDriver
 		// Give empty list so column types are inferred from data.
 		props.put("columnTypes.numeric", "");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * from sample5");
-		assertTrue(results.next());
-		assertEquals("The sample5 ID is wrong", Integer.valueOf(41), results.getObject("id"));
-		assertEquals("The sample5 Job is wrong", "Piloto", results.getObject("job"));
-		results.close();
-		results = stmt.executeQuery("SELECT ID,EXTRA_FIELD from sample");
-		assertTrue(results.next());
-		assertEquals("The sample ID is wrong", "Q123", results.getObject(1));
-		assertEquals("The sample EXTRA_FIELD is wrong", "F", results.getObject(2));
-		results.close();
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("SELECT * from sample5"))
+			{
+				assertTrue(results.next());
+				assertEquals("The sample5 ID is wrong", Integer.valueOf(41), results.getObject("id"));
+				assertEquals("The sample5 Job is wrong", "Piloto", results.getObject("job"));
+			}
+			try (ResultSet results = stmt.executeQuery("SELECT ID,EXTRA_FIELD from sample"))
+			{
+				assertTrue(results.next());
+				assertEquals("The sample ID is wrong", "Q123", results.getObject(1));
+				assertEquals("The sample EXTRA_FIELD is wrong", "F", results.getObject(2));
+			}
 
-		// column types are inferred from data.
-		results = stmt.executeQuery("SELECT C2, 'X' as X from numeric");
-		assertTrue(results.next());
-		assertEquals("The numeric C2 is wrong", Integer.valueOf(-1010), results.getObject(1));
-		assertEquals("The numeric X is wrong", "X", results.getObject(2));
+			// column types are inferred from data.
+			try (ResultSet results = stmt.executeQuery("SELECT C2, 'X' as X from numeric"))
+			{
+				assertTrue(results.next());
+				assertEquals("The numeric C2 is wrong", Integer.valueOf(-1010), results.getObject(1));
+				assertEquals("The numeric X is wrong", "X", results.getObject(2));
+			}
+		}
 	}
 
 	@Test
@@ -997,73 +1009,69 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("suppressHeaders", "true");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
+		{
+			// header is now treated as normal data line
+			results.next();
+			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
+					.equals("ID"));
+			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
+					.equals("NAME"));
+			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
+					.equals("EXTRA_FIELD"));
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
+			results.next();
+			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
+					.equals("Q123"));
+			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
+					.equals("\"S,\""));
+			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
+					.equals("F"));
 
-		// header is now treated as normal data line
-		results.next();
-		assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-				.equals("ID"));
-		assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-				.equals("NAME"));
-		assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-				.equals("EXTRA_FIELD"));
+			results.next();
+			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
+					.equals("A123"));
+			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
+					.equals("Jonathan Ackerman"));
+			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
+					.equals("A"));
 
-		results.next();
-		assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-				.equals("Q123"));
-		assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-				.equals("\"S,\""));
-		assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-				.equals("F"));
+			results.next();
+			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
+					.equals("B234"));
+			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
+					.equals("Grady O'Neil"));
+			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
+					.equals("B"));
 
-		results.next();
-		assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-				.equals("A123"));
-		assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-				.equals("Jonathan Ackerman"));
-		assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-				.equals("A"));
+			results.next();
+			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
+					.equals("C456"));
+			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
+					.equals("Susan, Peter and Dave"));
+			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
+					.equals("C"));
 
-		results.next();
-		assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-				.equals("B234"));
-		assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-				.equals("Grady O'Neil"));
-		assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-				.equals("B"));
+			results.next();
+			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
+					.equals("D789"));
+			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
+					.equals("Amelia \"meals\" Maurice"));
+			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
+					.equals("E"));
 
-		results.next();
-		assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-				.equals("C456"));
-		assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-				.equals("Susan, Peter and Dave"));
-		assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-				.equals("C"));
-
-		results.next();
-		assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-				.equals("D789"));
-		assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-				.equals("Amelia \"meals\" Maurice"));
-		assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-				.equals("E"));
-
-		results.next();
-		assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-				.equals("X234"));
-		assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-				.equals("Peter \"peg leg\", Jimmy & Samantha \"Sam\""));
-		assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-				.equals("G"));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			results.next();
+			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
+					.equals("X234"));
+			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
+					.equals("Peter \"peg leg\", Jimmy & Samantha \"Sam\""));
+			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
+					.equals("G"));
+		}
 	}
 
 	@Test
@@ -1073,18 +1081,19 @@ public class TestCsvDriver
 		props.put("suppressHeaders", "true");
 		props.put("fileExtension", ".txt");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM embassies");
-
-		// Test selecting from a file with a multi-line value as the first record.
-		assertTrue(results.next());
-		assertEquals("Incorrect COLUMN1 Value", "Germany", results.getString("COLUMN1"));
-		assertEquals("Incorrect COLUMN2 Value", "Wallstrasse 76-79,\n10179 Berlin", results.getString("COLUMN2"));
-		assertTrue(results.next());
+			ResultSet results = stmt.executeQuery("SELECT * FROM embassies"))
+		{
+			// Test selecting from a file with a multi-line value as the first record.
+			assertTrue(results.next());
+			assertEquals("Incorrect COLUMN1 Value", "Germany", results.getString("COLUMN1"));
+			assertEquals("Incorrect COLUMN2 Value", "Wallstrasse 76-79,\n10179 Berlin", results.getString("COLUMN2"));
+			assertTrue(results.next());
+		}
 	}
 
 	@Test
@@ -1094,136 +1103,143 @@ public class TestCsvDriver
 		String parentPath = new File(filePath).getParent();
 		String subPath = new File(filePath).getName();
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ parentPath);
 
 		Statement stmt = conn.createStatement();
 
 		ResultSet results = stmt
 				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM ."
-						+ File.separator + subPath + File.separator + "sample");
-
-		results.next();
-		assertTrue("Incorrect ID Value", results.getString("ID").equals("Q123"));
-		assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-				"\"S,\""));
-		assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-				"EXTRA_FIELD").equals("F"));
-
-		results.close();
-		stmt.close();
-		conn.close();
+						+ File.separator + subPath + File.separator + "sample"))
+		{
+			results.next();
+			assertTrue("Incorrect ID Value", results.getString("ID").equals("Q123"));
+			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
+					"\"S,\""));
+			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
+					"EXTRA_FIELD").equals("F"));
+		}
 	}
 
 	@Test
 	public void testWhereMultipleResult() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ID, Name, Job FROM sample4 WHERE Job = 'Project Manager'");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "01", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "02", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "04", results.getString("ID"));
-		assertTrue(!results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT ID, Name, Job FROM sample4 WHERE Job = 'Project Manager'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
 	public void testFieldAsAlias() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		//TODO using alias j in the WHERE clause is not valid SQL.  Should we really test this?
-		ResultSet results = stmt
-				.executeQuery("SELECT ID as i, Name as n, Job as j FROM sample4 WHERE j='Project Manager'");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "01", results.getString("i"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "02", results.getString("i"));
-		assertEquals("The name is wrong", "Mauricio Hernandez", results
-				.getString("N"));
-		assertEquals("The name is wrong", "Mauricio Hernandez", results
-				.getString(2));
-		assertEquals("The job is wrong", "Project Manager", results
-				.getString("J"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "04", results.getString("i"));
-		assertTrue(!results.next());
+			//TODO using alias j in the WHERE clause is not valid SQL.  Should we really test this?
+			ResultSet results = stmt
+				.executeQuery("SELECT ID as i, Name as n, Job as j FROM sample4 WHERE j='Project Manager'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "01", results.getString("i"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "02", results.getString("i"));
+			assertEquals("The name is wrong", "Mauricio Hernandez", results
+					.getString("N"));
+			assertEquals("The name is wrong", "Mauricio Hernandez", results
+					.getString(2));
+			assertEquals("The job is wrong", "Project Manager", results
+					.getString("J"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "04", results.getString("i"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
 	public void testSelectStar() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		CsvResultSet results = (CsvResultSet) stmt
-				.executeQuery("SELECT * FROM sample4");
-		assertEquals("ID", results.getMetaData().getColumnName(1).toString());
-		assertEquals("ID", results.getMetaData().getColumnLabel(1).toString());
+			CsvResultSet results = (CsvResultSet) stmt
+				.executeQuery("SELECT * FROM sample4"))
+		{
+			assertEquals("ID", results.getMetaData().getColumnName(1).toString());
+			assertEquals("ID", results.getMetaData().getColumnLabel(1).toString());
 
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "01", results.getString("id"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "02", results.getString("id"));
-		assertEquals("The name is wrong", "Mauricio Hernandez", results
-				.getString("Name"));
-		assertEquals("The name is wrong", "Mauricio Hernandez", results
-				.getString(2));
-		assertEquals("The job is wrong", "Project Manager", results
-				.getString("Job"));
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "04", results.getString("id"));
-		assertTrue(!results.next());
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "01", results.getString("id"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "02", results.getString("id"));
+			assertEquals("The name is wrong", "Mauricio Hernandez", results
+					.getString("Name"));
+			assertEquals("The name is wrong", "Mauricio Hernandez", results
+					.getString(2));
+			assertEquals("The job is wrong", "Project Manager", results
+					.getString("Job"));
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "04", results.getString("id"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
 	public void testSelectNull() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ID, null as ID2 FROM sample4");
-		assertEquals("ID2", results.getMetaData().getColumnName(2));
-		assertTrue(results.next());
-		assertEquals("The ID2 is wrong", null, results.getString("id2"));
-		assertTrue(results.next());
-		assertEquals("The ID2 is wrong", null, results.getObject("id2"));
+			ResultSet results = stmt
+				.executeQuery("SELECT ID, null as ID2 FROM sample4"))
+		{
+			assertEquals("ID2", results.getMetaData().getColumnName(2));
+			assertTrue(results.next());
+			assertEquals("The ID2 is wrong", null, results.getString("id2"));
+			assertTrue(results.next());
+			assertEquals("The ID2 is wrong", null, results.getObject("id2"));
+		}
 	}
 
 	@Test
 	public void testLiteralAsAlias() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT Job j,ID i,Name n, 0 c FROM sample4");
-		assertTrue("no results found - should be all", results.next());
-		assertTrue("no results found - should be all", results.next());
-		assertEquals("The literal c is wrong", "0", results.getString("c"));
-		assertEquals("The literal c is wrong", "0", results.getString(4));
-		assertEquals("The name is wrong", "Mauricio Hernandez", results
-				.getString("N"));
-		assertEquals("The job is wrong", "Project Manager", results
-				.getString("J"));
+			ResultSet results = stmt
+				.executeQuery("SELECT Job j,ID i,Name n, 0 c FROM sample4"))
+		{
+			assertTrue("no results found - should be all", results.next());
+			assertTrue("no results found - should be all", results.next());
+			assertEquals("The literal c is wrong", "0", results.getString("c"));
+			assertEquals("The literal c is wrong", "0", results.getString(4));
+			assertEquals("The name is wrong", "Mauricio Hernandez", results
+					.getString("N"));
+			assertEquals("The job is wrong", "Project Manager", results
+					.getString("J"));
+		}
 	}
 
 	@Test
@@ -1231,102 +1247,114 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT 44, lower(job), ID*2, 'hello', 44 from sample4");
-		assertTrue("no results found", results.next());
-		assertEquals("Number 44 is wrong", 44, results.getInt(1));
-		assertEquals("lower(job) is wrong", "project manager", results.getString(2));
-		assertEquals("ID*2 is wrong", 2, results.getInt(3));
-		assertEquals("String 'hello' is wrong", "hello", results.getString(4));
-		assertEquals("Number 44 is wrong", 44, results.getInt(5));
+			ResultSet results = stmt
+				.executeQuery("SELECT 44, lower(job), ID*2, 'hello', 44 from sample4"))
+		{
+			assertTrue("no results found", results.next());
+			assertEquals("Number 44 is wrong", 44, results.getInt(1));
+			assertEquals("lower(job) is wrong", "project manager", results.getString(2));
+			assertEquals("ID*2 is wrong", 2, results.getInt(3));
+			assertEquals("String 'hello' is wrong", "hello", results.getString(4));
+			assertEquals("Number 44 is wrong", 44, results.getInt(5));
+		}
 	}
 
 	/**
 	 * This returns no results with where and tests if this still works
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
 	public void testWhereNoResults() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT ID,Name FROM sample4 WHERE ID='05'");
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT ID,Name FROM sample4 WHERE ID='05'"))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testSelectStarWhereMultipleResult() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample4 WHERE Job = 'Project Manager'");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "01", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "02", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "04", results.getString("ID"));
-		assertTrue(!results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample4 WHERE Job = 'Project Manager'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
 	public void testSelectStarWithTableAlias() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT tbl.* FROM sample4 tbl");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "01", results.getString("ID"));
-		assertEquals("The Job is wrong", "Project Manager", results.getString(3));
+			ResultSet results = stmt
+				.executeQuery("SELECT tbl.* FROM sample4 tbl"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertEquals("The Job is wrong", "Project Manager", results.getString(3));
+		}
 	}
 
 	@Test
 	public void testWhereWithAndOperator() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample4 WHERE Job = 'Project Manager' AND Name = 'Mauricio Hernandez'");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "02", results.getString("ID"));
-		assertTrue(!results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample4 WHERE Job = 'Project Manager' AND Name = 'Mauricio Hernandez'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
 	public void testWhereWithBetweenOperator() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample4 WHERE id BETWEEN '02' AND '03'");
-
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt("ID"));
-		assertTrue(!results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample4 WHERE id BETWEEN '02' AND '03'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
@@ -1336,21 +1364,22 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,Int,Int,Date,Time");
 		props.put("dateFormat", "M/D/YYYY");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM Purchase WHERE PurchaseDate BETWEEN '1/11/2013' AND '1/15/2013'");
-
-		assertTrue(results.next());
-		assertEquals("The AccountNo is wrong", 58375, results.getInt("AccountNo"));
-		assertTrue(results.next());
-		assertEquals("The AccountNo is wrong", 34625, results.getInt("AccountNo"));
-		assertTrue(results.next());
-		assertEquals("The AccountNo is wrong", 34771, results.getInt("AccountNo"));
-		assertTrue(!results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM Purchase WHERE PurchaseDate BETWEEN '1/11/2013' AND '1/15/2013'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The AccountNo is wrong", 58375, results.getInt("AccountNo"));
+			assertTrue(results.next());
+			assertEquals("The AccountNo is wrong", 34625, results.getInt("AccountNo"));
+			assertTrue(results.next());
+			assertEquals("The AccountNo is wrong", 34771, results.getInt("AccountNo"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
@@ -1360,17 +1389,18 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,Int,Int,Date,Time");
 		props.put("dateFormat", "M/D/YYYY");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime BETWEEN '08:30:00' AND '10:00:00'");
-
-		assertTrue(results.next());
-		assertEquals("The AccountNo is wrong", 51002, results.getInt("AccountNo"));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime BETWEEN '08:30:00' AND '10:00:00'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The AccountNo is wrong", 51002, results.getInt("AccountNo"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -1380,153 +1410,164 @@ public class TestCsvDriver
 		props.put("columnTypes", "Integer,String,String,Timestamp,Time");
 		props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample5 WHERE Start BETWEEN '2003-03-01 08:30:00' AND '2003-03-02 17:30:00'");
-
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt("ID"));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample5 WHERE Start BETWEEN '2003-03-01 08:30:00' AND '2003-03-02 17:30:00'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testWhereWithLikeOperatorPercent() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample4 WHERE Name LIKE 'Ma%'");
-
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt("ID"));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample4 WHERE Name LIKE 'Ma%'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testWhereWithLikeOperatorUnderscore() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("select id from sample where id like '_234'");
-
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "B234", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "X234", results.getString("ID"));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("select id from sample where id like '_234'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "B234", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "X234", results.getString("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testWhereWithLikeOperatorEscape() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt
+				.executeQuery("select ID from escape where ID like 'index\\__'"))
+			{
+				assertTrue(results.next());
+				assertEquals("The ID is wrong", "index_1", results.getString("ID"));
+				assertTrue(results.next());
+				assertEquals("The ID is wrong", "index_2", results.getString("ID"));
+				assertTrue(results.next());
+				assertEquals("The ID is wrong", "index_3", results.getString("ID"));
+				assertFalse(results.next());
+			}
 
-		ResultSet results = stmt
-				.executeQuery("select ID from escape where ID like 'index\\__'");
+			try (ResultSet results2 = stmt
+				.executeQuery("select ID from escape where ID like 'index^__' escape '^'"))
+			{
+				assertTrue(results2.next());
+				assertEquals("The ID is wrong", "index_1", results2.getString("ID"));
+				assertTrue(results2.next());
+				assertEquals("The ID is wrong", "index_2", results2.getString("ID"));
+				assertTrue(results2.next());
+				assertEquals("The ID is wrong", "index_3", results2.getString("ID"));
+				assertFalse(results2.next());
+			}
 
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "index_1", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "index_2", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "index_3", results.getString("ID"));
-		assertFalse(results.next());
-
-		ResultSet results2 = stmt
-				.executeQuery("select ID from escape where ID like 'index^__' escape '^'");
-
-		assertTrue(results2.next());
-		assertEquals("The ID is wrong", "index_1", results2.getString("ID"));
-		assertTrue(results2.next());
-		assertEquals("The ID is wrong", "index_2", results2.getString("ID"));
-		assertTrue(results2.next());
-		assertEquals("The ID is wrong", "index_3", results2.getString("ID"));
-		assertFalse(results2.next());
-		
-		ResultSet results3 = stmt
-				.executeQuery("select ID from escape where ID like 'index^%%' escape '^'");
-
-		assertTrue(results3.next());
-		assertEquals("The ID is wrong", "index%%", results3.getString("ID"));
-		assertTrue(results3.next());
-		assertEquals("The ID is wrong", "index%3", results3.getString("ID"));
-		assertFalse(results3.next());
+			try (ResultSet results3 = stmt
+				.executeQuery("select ID from escape where ID like 'index^%%' escape '^'"))
+			{
+				assertTrue(results3.next());
+				assertEquals("The ID is wrong", "index%%", results3.getString("ID"));
+				assertTrue(results3.next());
+				assertEquals("The ID is wrong", "index%3", results3.getString("ID"));
+				assertFalse(results3.next());
+			}
+		}
 	}
 
 	@Test
 	public void testWhereWithLikeMultiLine() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("select N from nikesh where Message like '%SSL%'");
-
-		assertTrue(results.next());
-		assertEquals("N is wrong", 1, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("N is wrong", 2, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("N is wrong", 4, results.getInt(1));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("select N from nikesh where Message like '%SSL%'"))
+		{
+			assertTrue(results.next());
+			assertEquals("N is wrong", 1, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("N is wrong", 2, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("N is wrong", 4, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testWhereWithUnselectedColumn() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT Name, Job FROM sample4 WHERE id = '04'");
-		assertTrue(results.next());
-		try
+			ResultSet results = stmt
+				.executeQuery("SELECT Name, Job FROM sample4 WHERE id = '04'"))
 		{
-			results.getString("id");
-			fail("Should not find the column 'id'");
+			assertTrue(results.next());
+			try
+			{
+				results.getString("id");
+				fail("Should not find the column 'id'");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": id", "" + e);
+			}
+			assertEquals("The name is wrong", "Felipe Grajales", results
+					.getString("name"));
+			assertTrue(!results.next());
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": id", "" + e);
-		}
-		assertEquals("The name is wrong", "Felipe Grajales", results
-				.getString("name"));
-		assertTrue(!results.next());
 	}
 
 	@Test
 	public void testWhereWithBadColumnName() throws SQLException
-	{		
+	{
 		try
 		{
 			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+			try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
-			Statement stmt = conn.createStatement();
-
-			stmt.executeQuery("SELECT Id FROM sample where XXXX='123'");
-			fail("Should raise a java.sqlSQLException");
+				Statement stmt = conn.createStatement())
+			{
+				stmt.executeQuery("SELECT Id FROM sample where XXXX='123'");
+				fail("Should raise a java.sqlSQLException");
+			}
 		}
 		catch (SQLException e)
 		{
@@ -1539,19 +1580,22 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT c4 FROM numeric WHERE c4 >= 2.00e+6 and c4 <= 9e15 and c1 < 1.e-1");
-		assertTrue(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT c4 FROM numeric WHERE c4 >= 2.00e+6 and c4 <= 9e15 and c1 < 1.e-1"))
+		{
+			assertTrue(results.next());
 
-		double d = results.getDouble("c4");
-		long l = Math.round(d);
-		assertEquals("The c4 is wrong", l, 990000000000l);
-		assertFalse(results.next());
+			double d = results.getDouble("c4");
+			long l = Math.round(d);
+			assertEquals("The c4 is wrong", l, 990000000000l);
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -1560,22 +1604,28 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,Date,Time");
 		props.put("dateFormat", "yyyy-MM-dd");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("SELECT ID from sample8 where d = '2010-02-02'"))
+			{
+				assertTrue(results.next());
+				assertEquals("The ID is wrong", 2, results.getInt(1));
+				assertFalse(results.next());
+			}
 
-		ResultSet results = stmt.executeQuery("SELECT ID from sample8 where d = '2010-02-02'");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt(1));
-		assertFalse(results.next());
-
-		results = stmt.executeQuery("SELECT ID from sample8 where '2010-03-24' < d");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 6, results.getInt(1));
-		assertFalse(results.next());
+			try (ResultSet results = stmt.executeQuery("SELECT ID from sample8 where '2010-03-24' < d"))
+			{
+				assertTrue(results.next());
+				assertEquals("The ID is wrong", 3, results.getInt(1));
+				assertTrue(results.next());
+				assertEquals("The ID is wrong", 6, results.getInt(1));
+				assertFalse(results.next());
+			}
+		}
 	}
 
 	@Test
@@ -1585,17 +1635,18 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,Int,Int,Date,Time");
 		props.put("dateFormat", "M/D/YYYY");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime >= '12:00:00' and '12:59:59' >= PurchaseTime");
-
-		assertTrue(results.next());
-		assertEquals("The AccountNo is wrong", 34771, results.getInt("AccountNo"));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime >= '12:00:00' and '12:59:59' >= PurchaseTime"))
+		{
+			assertTrue(results.next());
+			assertEquals("The AccountNo is wrong", 34771, results.getInt("AccountNo"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -1605,19 +1656,20 @@ public class TestCsvDriver
 		props.put("columnTypes", "Integer,String,String,Timestamp,Time");
 		props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample5 WHERE Start >= '2002-01-01 00:00:00' and '2003-12-31 23:59:59' >= Start");
-
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt("ID"));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample5 WHERE Start >= '2002-01-01 00:00:00' and '2003-12-31 23:59:59' >= Start"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -1625,19 +1677,21 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Timestamp,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select Name from sample5 where id in (3, 4, 5)");
+			Statement stmt = conn.createStatement();
 
-		assertTrue(results.next());
-		assertEquals("The Name is wrong", "Maria Cristina Lucero", results.getString("Name"));
-		assertTrue(results.next());
-		assertEquals("The Name is wrong", "Felipe Grajales", results.getString("Name"));
-		assertTrue(results.next());
-		assertEquals("The Name is wrong", "Melquisedec Rojas Castillo", results.getString("Name"));
-		assertFalse(results.next());
+			ResultSet results = stmt.executeQuery("select Name from sample5 where id in (3, 4, 5)"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Name is wrong", "Maria Cristina Lucero", results.getString("Name"));
+			assertTrue(results.next());
+			assertEquals("The Name is wrong", "Felipe Grajales", results.getString("Name"));
+			assertTrue(results.next());
+			assertEquals("The Name is wrong", "Melquisedec Rojas Castillo", results.getString("Name"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -1645,48 +1699,52 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Timestamp,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select Name from sample5 where id in (23, 24, 25)");
+			Statement stmt = conn.createStatement();
 
-		assertFalse(results.next());
+			ResultSet results = stmt.executeQuery("select Name from sample5 where id in (23, 24, 25)"))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testWhereWithNotIn() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("select Id from sample where Id not in ('A123', 'B234', 'X234')");
-
-		assertTrue(results.next());
-		assertEquals("The Id is wrong", "Q123", results.getString("Id"));
-		assertTrue(results.next());
-		assertEquals("The Id is wrong", "C456", results.getString("Id"));
-		assertTrue(results.next());
-		assertEquals("The Id is wrong", "D789", results.getString("Id"));
-		assertFalse(results.next());
+			ResultSet results = stmt.executeQuery("select Id from sample where Id not in ('A123', 'B234', 'X234')"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Id is wrong", "Q123", results.getString("Id"));
+			assertTrue(results.next());
+			assertEquals("The Id is wrong", "C456", results.getString("Id"));
+			assertTrue(results.next());
+			assertEquals("The Id is wrong", "D789", results.getString("Id"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testWhereWithInEmpty() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("select * from sample where Name in ()");
-			fail("SQL Query should fail");
-		}
-		catch (SQLException e)
-		{
-			assertTrue(e.getMessage().startsWith(CsvResources.getString("syntaxError")));
+			try
+			{
+				stmt.executeQuery("select * from sample where Name in ()");
+				fail("SQL Query should fail");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.getMessage().startsWith(CsvResources.getString("syntaxError")));
+			}
 		}
 	}
 
@@ -1697,19 +1755,20 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,Int,Int,Date,Time");
 		props.put("dateFormat", "M/D/YYYY");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM Purchase WHERE PurchaseDate IN ('1/9/2013', '1/16/2013')");
-
-		assertTrue(results.next());
-		assertEquals("The AccountNo is wrong", 19685, results.getInt("AccountNo"));
-		assertTrue(results.next());
-		assertEquals("The AccountNo is wrong", 51002, results.getInt("AccountNo"));
-		assertTrue(!results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM Purchase WHERE PurchaseDate IN ('1/9/2013', '1/16/2013')"))
+		{
+			assertTrue(results.next());
+			assertEquals("The AccountNo is wrong", 19685, results.getInt("AccountNo"));
+			assertTrue(results.next());
+			assertEquals("The AccountNo is wrong", 51002, results.getInt("AccountNo"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
@@ -1719,17 +1778,18 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,Int,Int,Date,Time");
 		props.put("dateFormat", "M/D/YYYY");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime IN ('10:10:06', '11:10:06')");
-
-		assertTrue(results.next());
-		assertEquals("The AccountNo is wrong", 22021, results.getInt("AccountNo"));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime IN ('10:10:06', '11:10:06')"))
+		{
+			assertTrue(results.next());
+			assertEquals("The AccountNo is wrong", 22021, results.getInt("AccountNo"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -1739,19 +1799,20 @@ public class TestCsvDriver
 		props.put("columnTypes", "Integer,String,String,Timestamp,Time");
 		props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		// Note that final Timestamp is wrong format.
-		ResultSet results = stmt
+			// Note that final Timestamp is wrong format.
+			ResultSet results = stmt
 				.executeQuery("SELECT * FROM sample5 " +
-					"WHERE Start IN ('2002-02-02 12:30:00', '2004-04-02 12:00:00', '2004-04-02')");
-
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt("ID"));
-		assertFalse(results.next());
+					"WHERE Start IN ('2002-02-02 12:30:00', '2004-04-02 12:00:00', '2004-04-02')"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -1760,31 +1821,34 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("separator", "\t");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM jo");
-		assertTrue(results.next());
-		try
+			ResultSet results = stmt.executeQuery("SELECT * FROM jo"))
 		{
-			results.getString("id");
-			fail("Should not find the column 'id'");
+			assertTrue(results.next());
+			try
+			{
+				results.getString("id");
+				fail("Should not find the column 'id'");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": id", "" + e);
+			}
+			assertEquals("The name is wrong", "3", results.getString("rc"));
+			// would like to test the full_name_nd, but can't insert the Arabic
+			// string in the code
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "3", results.getString("rc"));
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "3", results.getString("rc"));
+			assertEquals("The name is wrong", "Tall Dhayl", results
+					.getString("full_name_nd"));
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": id", "" + e);
-		}
-		assertEquals("The name is wrong", "3", results.getString("rc"));
-		// would like to test the full_name_nd, but can't insert the Arabic
-		// string in the code
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "3", results.getString("rc"));
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "3", results.getString("rc"));
-		assertEquals("The name is wrong", "Tall Dhayl", results
-				.getString("full_name_nd"));
 	}
 
 	@Test
@@ -1792,23 +1856,26 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM witheol");
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "1", results.getString("key"));
-		// would like to test the full_name_nd, but can't insert the Arabic
-		// string in the code
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "2", results.getString("key"));
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "3", results.getString("key"));
-		assertEquals("The name is wrong", "123\n456\n789", results
-				.getString("value"));
-		assertTrue(!results.next());
+			ResultSet results = stmt.executeQuery("SELECT * FROM witheol"))
+		{
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "1", results.getString("key"));
+			// would like to test the full_name_nd, but can't insert the Arabic
+			// string in the code
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "2", results.getString("key"));
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "3", results.getString("key"));
+			assertEquals("The name is wrong", "123\n456\n789", results
+					.getString("value"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
@@ -1817,26 +1884,29 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("fileExtension", ".csv");
 		props.put("separator", ";");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM badquoted");
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "Rechtsform unbekannt", results.getString("F2"));
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "Rechtsform \nunbekannt", results.getString("F2"));
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "Rechtsform unbekannt", results.getString("F2"));
-		try
+			ResultSet results = stmt.executeQuery("SELECT * FROM badquoted"))
 		{
-			results.next();
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("eofInQuotes") + ": 6", "" + e);
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "Rechtsform unbekannt", results.getString("F2"));
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "Rechtsform \nunbekannt", results.getString("F2"));
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "Rechtsform unbekannt", results.getString("F2"));
+			try
+			{
+				results.next();
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("eofInQuotes") + ": 6", "" + e);
+			}
 		}
 	}
 
@@ -1845,25 +1915,28 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT datum, tijd, station, ai007.000 as value FROM test-001-20081112");
-		assertTrue(results.next());
-		assertEquals("The name is wrong", "20-12-2007", results
-				.getString("datum"));
-		assertEquals("The name is wrong", "10:59:00", results.getString("tijd"));
-		assertEquals("The name is wrong", "007", results.getString("station"));
-		assertEquals("The name is wrong", "0.0", results.getString("value"));
+			ResultSet results = stmt
+				.executeQuery("SELECT datum, tijd, station, ai007.000 as value FROM test-001-20081112"))
+		{
+			assertTrue(results.next());
+			assertEquals("The name is wrong", "20-12-2007", results
+					.getString("datum"));
+			assertEquals("The name is wrong", "10:59:00", results.getString("tijd"));
+			assertEquals("The name is wrong", "007", results.getString("station"));
+			assertEquals("The name is wrong", "0.0", results.getString("value"));
+		}
 	}
 
 	/**
 	 * accessing indexed files that do not exist is the same as accessing an
 	 * empty table. no "file not found" error
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
@@ -1874,15 +1947,17 @@ public class TestCsvDriver
 		props.put("fileTailPattern", "-([0-9]{3})-([0-9]{8})");
 		props.put("fileTailParts", "location,file_date");
 		props.put("indexedFiles", "True");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT location,station,datum,tijd,file_date FROM test57");
-
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT location,station,datum,tijd,file_date FROM test57"))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -1893,54 +1968,56 @@ public class TestCsvDriver
 		props.put("fileTailPattern", "-([0-9]{3})-([0-9]{8})");
 		props.put("fileTailParts", "location,file_date");
 		props.put("indexedFiles", "True");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT location,station,datum,tijd,file_date FROM test");
+			ResultSet results = stmt
+				.executeQuery("SELECT location,station,datum,tijd,file_date FROM test"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
+			assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
+					"test"));
 
-		assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
-				"test"));
+			assertEquals("Incorrect Column Name 1", metadata.getColumnName(1),
+					"location");
+			assertEquals("Incorrect Column Name 2", metadata.getColumnName(2),
+					"Station");
+			assertEquals("Incorrect Column Name 3", metadata.getColumnName(3),
+					"Datum");
+			assertEquals("Incorrect Column Name 4", metadata.getColumnName(4),
+					"Tijd");
 
-		assertEquals("Incorrect Column Name 1", metadata.getColumnName(1),
-				"location");
-		assertEquals("Incorrect Column Name 2", metadata.getColumnName(2),
-				"Station");
-		assertEquals("Incorrect Column Name 3", metadata.getColumnName(3),
-				"Datum");
-		assertEquals("Incorrect Column Name 4", metadata.getColumnName(4),
-				"Tijd");
-
-		assertTrue(results.next());
-		for (int i = 1; i < 12; i++)
-		{
 			assertTrue(results.next());
+			for (int i = 1; i < 12; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 12; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 12; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 36; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 36; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 36; i++)
+			{
+				assertTrue(results.next());
+			}
+			assertFalse(results.next());
 		}
-		for (int i = 0; i < 12; i++)
-		{
-			assertTrue(results.next());
-		}
-		for (int i = 0; i < 12; i++)
-		{
-			assertTrue(results.next());
-		}
-		for (int i = 0; i < 36; i++)
-		{
-			assertTrue(results.next());
-		}
-		for (int i = 0; i < 36; i++)
-		{
-			assertTrue(results.next());
-		}
-		for (int i = 0; i < 36; i++)
-		{
-			assertTrue(results.next());
-		}
-		assertFalse(results.next());
 	}
 
 	@Test
@@ -1952,103 +2029,109 @@ public class TestCsvDriver
 		props.put("fileTailParts", "location,file_date");
 		props.put("indexedFiles", "True");
 		props.put("fileTailPrepend", "True");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT location,file_date,datum,tijd,station FROM test");
+			ResultSet results = stmt
+				.executeQuery("SELECT location,file_date,datum,tijd,station FROM test"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
+			assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
+					"test"));
 
-		assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
-				"test"));
+			assertEquals("Incorrect Column Name 1", metadata.getColumnName(1),
+					"location");
+			assertEquals("Incorrect Column Name 1", metadata.getColumnName(2),
+					"file_date");
+			assertEquals("Incorrect Column Name 1", metadata.getColumnName(3),
+					"Datum");
+			assertEquals("Incorrect Column Name 2", metadata.getColumnName(4),
+					"Tijd");
+			assertEquals("Incorrect Column Name 3", metadata.getColumnName(5),
+					"Station");
 
-		assertEquals("Incorrect Column Name 1", metadata.getColumnName(1),
-				"location");
-		assertEquals("Incorrect Column Name 1", metadata.getColumnName(2),
-				"file_date");
-		assertEquals("Incorrect Column Name 1", metadata.getColumnName(3),
-				"Datum");
-		assertEquals("Incorrect Column Name 2", metadata.getColumnName(4),
-				"Tijd");
-		assertEquals("Incorrect Column Name 3", metadata.getColumnName(5),
-				"Station");
-
-		assertTrue(results.next());
-		for (int i = 1; i < 12; i++)
-		{
 			assertTrue(results.next());
+			for (int i = 1; i < 12; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 12; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 12; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 36; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 36; i++)
+			{
+				assertTrue(results.next());
+			}
+			for (int i = 0; i < 36; i++)
+			{
+				assertTrue(results.next());
+			}
+			assertFalse(results.next());
 		}
-		for (int i = 0; i < 12; i++)
-		{
-			assertTrue(results.next());
-		}
-		for (int i = 0; i < 12; i++)
-		{
-			assertTrue(results.next());
-		}
-		for (int i = 0; i < 36; i++)
-		{
-			assertTrue(results.next());
-		}
-		for (int i = 0; i < 36; i++)
-		{
-			assertTrue(results.next());
-		}
-		for (int i = 0; i < 36; i++)
-		{
-			assertTrue(results.next());
-		}
-		assertFalse(results.next());
 	}
 
 	@Test
 	public void testNoPatternGroupFromIndexedTable() throws SQLException
 	{
 		Properties props = new Properties();
-        props.put("fileExtension", ".txt");
-        props.put("commentChar", "#");
-        props.put("indexedFiles", "true");
+		props.put("fileExtension", ".txt");
+		props.put("commentChar", "#");
+		props.put("indexedFiles", "true");
 
-        // No groups in ()'s used in regular expression
-        props.put("fileTailPattern", ".*");
-        props.put("suppressHeaders", "true");
-        props.put("headerline", "BLZ,BANK_NAME");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		// No groups in ()'s used in regular expression
+		props.put("fileTailPattern", ".*");
+		props.put("suppressHeaders", "true");
+		props.put("headerline", "BLZ,BANK_NAME");
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM banks");
+			Statement stmt = conn.createStatement();
 
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", "10000000", results.getString("BLZ"));
+			ResultSet results = stmt.executeQuery("SELECT * FROM banks"))
+		{
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", "10000000", results.getString("BLZ"));
+		}
 	}
 
 	@Test
 	public void testAddingFields() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT id + ' ' + job as mix FROM sample4");
-		assertTrue(results.next());
-		assertEquals("The mix is wrong", "01 Project Manager", results
-				.getString("mix"));
-		assertTrue(results.next());
-		assertEquals("The mix is wrong", "02 Project Manager", results
-				.getString("mix"));
-		assertTrue(results.next());
-		assertEquals("The mix is wrong", "03 Finance Manager", results
-				.getString("mix"));
-		assertTrue(results.next());
-		assertEquals("The mix is wrong", "04 Project Manager", results
-				.getString("mix"));
-		assertTrue(!results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT id + ' ' + job as mix FROM sample4"))
+		{
+			assertTrue(results.next());
+			assertEquals("The mix is wrong", "01 Project Manager", results
+					.getString("mix"));
+			assertTrue(results.next());
+			assertEquals("The mix is wrong", "02 Project Manager", results
+					.getString("mix"));
+			assertTrue(results.next());
+			assertEquals("The mix is wrong", "03 Finance Manager", results
+					.getString("mix"));
+			assertTrue(results.next());
+			assertEquals("The mix is wrong", "04 Project Manager", results
+					.getString("mix"));
+			assertTrue(!results.next());
+		}
 	}
 
 	@Test
@@ -2057,76 +2140,77 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Date,Time");
 		props.put("timeFormat", "HHmm");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Object expect;
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT id, timeoffset FROM sample5");
+			ResultSet results = stmt
+				.executeQuery("SELECT id, timeoffset FROM sample5"))
+		{
+			assertTrue(results.next());
+			Object expect = java.sql.Time.valueOf("12:30:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("12:30:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("12:35:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("12:35:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("12:40:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("12:40:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("12:45:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("12:45:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("01:00:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("01:00:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("01:00:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("01:00:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("01:00:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("01:00:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("00:00:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("00:00:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("00:10:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("00:10:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertTrue(results.next());
+			expect = java.sql.Time.valueOf("01:23:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
 
-		assertTrue(results.next());
-		expect = java.sql.Time.valueOf("01:23:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2136,46 +2220,47 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,String,String,Date,Time");
 		props.put("timeFormat", "HHmm");
 		props.put("dateFormat", "yyyy-MM-dd");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Object expect;
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT id, start, timeoffset, start+timeoffset AS ts FROM sample5 WHERE id=41 OR id=4");
+			ResultSet results = stmt
+				.executeQuery("SELECT id, start, timeoffset, start+timeoffset AS ts FROM sample5 WHERE id=41 OR id=4"))
+		{
+			assertTrue(results.next());
+			Object expect = java.sql.Date.valueOf("2001-04-02");
+			assertEquals("Date is a Date", expect.getClass(), results.getObject(
+					"start").getClass());
+			assertEquals("Date is a Date", expect, results.getObject("start"));
+			expect = java.sql.Time.valueOf("12:30:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			expect = java.sql.Timestamp.valueOf("2001-04-02 12:30:00");
+			assertEquals("adding Date to Time", expect.getClass(), results
+					.getObject("ts").getClass());
+			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
+					.format(results.getObject("ts")) + ".0");
 
-		assertTrue(results.next());
-		expect = java.sql.Date.valueOf("2001-04-02");
-		assertEquals("Date is a Date", expect.getClass(), results.getObject(
-				"start").getClass());
-		assertEquals("Date is a Date", expect, results.getObject("start"));
-		expect = java.sql.Time.valueOf("12:30:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
-		expect = java.sql.Timestamp.valueOf("2001-04-02 12:30:00");
-		assertEquals("adding Date to Time", expect.getClass(), results
-				.getObject("ts").getClass());
-		assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-				.format(results.getObject("ts")) + ".0");
+			assertTrue(results.next());
+			expect = java.sql.Date.valueOf("2004-04-02");
+			assertEquals("Date is a Date", expect.getClass(), results.getObject(
+					"start").getClass());
+			assertEquals("Date is a Date", expect, results.getObject("start"));
+			expect = java.sql.Time.valueOf("01:00:00");
+			assertEquals("Time is a Time", expect.getClass(), results.getObject(
+					"timeoffset").getClass());
+			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			expect = java.sql.Timestamp.valueOf("2004-04-02 01:00:00");
+			assertEquals("adding Date to Time", expect.getClass(), results
+					.getObject("ts").getClass());
+			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
+					.format(results.getObject("ts")) + ".0");
 
-		assertTrue(results.next());
-		expect = java.sql.Date.valueOf("2004-04-02");
-		assertEquals("Date is a Date", expect.getClass(), results.getObject(
-				"start").getClass());
-		assertEquals("Date is a Date", expect, results.getObject("start"));
-		expect = java.sql.Time.valueOf("01:00:00");
-		assertEquals("Time is a Time", expect.getClass(), results.getObject(
-				"timeoffset").getClass());
-		assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
-		expect = java.sql.Timestamp.valueOf("2004-04-02 01:00:00");
-		assertEquals("adding Date to Time", expect.getClass(), results
-				.getObject("ts").getClass());
-		assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-				.format(results.getObject("ts")) + ".0");
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2187,40 +2272,41 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,String,String,Date,Time");
 		props.put("timeFormat", "HHmm");
 		props.put("dateFormat", "yyyy-MM-dd");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Object expect;
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT id, start+timeoffset+61000 AS ts, start+timeoffset-61000 AS ts2 FROM sample5 WHERE id=41 OR id=4");
+			ResultSet results = stmt
+				.executeQuery("SELECT id, start+timeoffset+61000 AS ts, start+timeoffset-61000 AS ts2 FROM sample5 WHERE id=41 OR id=4"))
+		{
+			assertTrue(results.next());
+			Object expect = java.sql.Timestamp.valueOf("2001-04-02 12:31:01");
+			assertEquals("adding Date + Time + Int", expect.getClass(), results
+					.getObject("ts").getClass());
+			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
+					.format(results.getObject("ts")) + ".0");
+			expect = java.sql.Timestamp.valueOf("2001-04-02 12:28:59");
+			assertEquals("adding Date + Time - Int", expect.getClass(), results
+					.getObject("ts2").getClass());
+			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
+					.format(results.getObject("ts2")) + ".0");
 
-		assertTrue(results.next());
-		expect = java.sql.Timestamp.valueOf("2001-04-02 12:31:01");
-		assertEquals("adding Date + Time + Int", expect.getClass(), results
-				.getObject("ts").getClass());
-		assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-				.format(results.getObject("ts")) + ".0");
-		expect = java.sql.Timestamp.valueOf("2001-04-02 12:28:59");
-		assertEquals("adding Date + Time - Int", expect.getClass(), results
-				.getObject("ts2").getClass());
-		assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-				.format(results.getObject("ts2")) + ".0");
+			assertTrue(results.next());
+			expect = java.sql.Timestamp.valueOf("2004-04-02 01:01:01");
+			assertEquals("adding Date to Time", expect.getClass(), results
+					.getObject("ts").getClass());
+			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
+					.format(results.getObject("ts")) + ".0");
+			expect = java.sql.Timestamp.valueOf("2004-04-02 00:58:59");
+			assertEquals("adding Date to Time", expect.getClass(), results
+					.getObject("ts2").getClass());
+			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
+					.format(results.getObject("ts2")) + ".0");
 
-		assertTrue(results.next());
-		expect = java.sql.Timestamp.valueOf("2004-04-02 01:01:01");
-		assertEquals("adding Date to Time", expect.getClass(), results
-				.getObject("ts").getClass());
-		assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-				.format(results.getObject("ts")) + ".0");
-		expect = java.sql.Timestamp.valueOf("2004-04-02 00:58:59");
-		assertEquals("adding Date to Time", expect.getClass(), results
-				.getObject("ts2").getClass());
-		assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-				.format(results.getObject("ts2")) + ".0");
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2228,17 +2314,20 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT 1 + ID * 2 as N1, ID * -3 + 1 as N2, ID+1+2*3+4 as N3 FROM sample5");
-		assertTrue(results.next());
-		assertEquals("N1 is wrong", 83, results.getInt("N1"));
-		assertEquals("N2 is wrong", -122, results.getInt("N2"));
-		assertEquals("N3 is wrong", 52, results.getInt("N3"));
+			ResultSet results = stmt
+				.executeQuery("SELECT 1 + ID * 2 as N1, ID * -3 + 1 as N2, ID+1+2*3+4 as N3 FROM sample5"))
+		{
+			assertTrue(results.next());
+			assertEquals("N1 is wrong", 83, results.getInt("N1"));
+			assertEquals("N2 is wrong", -122, results.getInt("N2"));
+			assertEquals("N3 is wrong", 52, results.getInt("N3"));
+		}
 	}
 
 	@Test
@@ -2246,17 +2335,20 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ( ID + 1 ) as N1, ((ID + 2) * 3) as N2, (3) as N3 FROM sample5 where ( Job = 'Piloto' )");
-		assertTrue(results.next());
-		assertEquals("N1 is wrong", 42, results.getInt("N1"));
-		assertEquals("N2 is wrong", 129, results.getInt("N2"));
-		assertEquals("N3 is wrong", 3, results.getInt("N3"));
+			ResultSet results = stmt
+				.executeQuery("SELECT ( ID + 1 ) as N1, ((ID + 2) * 3) as N2, (3) as N3 FROM sample5 where ( Job = 'Piloto' )"))
+		{
+			assertTrue(results.next());
+			assertEquals("N1 is wrong", 42, results.getInt("N1"));
+			assertEquals("N2 is wrong", 129, results.getInt("N2"));
+			assertEquals("N3 is wrong", 3, results.getInt("N3"));
+		}
 	}
 
 	@Test
@@ -2264,19 +2356,21 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT ((ID + 1) as N1 FROM sample5");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertTrue(e.getMessage().startsWith(CsvResources.getString("syntaxError")));	
+			try
+			{
+				stmt.executeQuery("SELECT ((ID + 1) as N1 FROM sample5");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.getMessage().startsWith(CsvResources.getString("syntaxError")));
+			}
 		}
 	}
 
@@ -2285,22 +2379,28 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select lower(job) as ljob, lower('AA') as CAT from sample5");
-		assertTrue(results.next());
-		assertEquals("The JOB is wrong", "piloto", results.getString(1));
-		assertEquals("The CAT is wrong", "aa", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("The JOB is wrong", "project manager", results.getString(1));
-		assertEquals("The CAT is wrong", "aa", results.getString(2));
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("select lower(job) as ljob, lower('AA') as CAT from sample5"))
+			{
+				assertTrue(results.next());
+				assertEquals("The JOB is wrong", "piloto", results.getString(1));
+				assertEquals("The CAT is wrong", "aa", results.getString(2));
+				assertTrue(results.next());
+				assertEquals("The JOB is wrong", "project manager", results.getString(1));
+				assertEquals("The CAT is wrong", "aa", results.getString(2));
+			}
 
-		results = stmt.executeQuery("select ID from sample5 where lower(job) = lower('FINANCE MANAGER')");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt(1));
-		assertFalse(results.next());		
+			try (ResultSet results = stmt.executeQuery("select ID from sample5 where lower(job) = lower('FINANCE MANAGER')"))
+			{
+				assertTrue(results.next());
+				assertEquals("The ID is wrong", 2, results.getInt(1));
+				assertFalse(results.next());
+			}
+		}
 	}
 
 	@Test
@@ -2312,20 +2412,26 @@ public class TestCsvDriver
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Integer,String");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select UPPER(BANK_NAME) as UC, UPPER('Credit' + 'a') as N2, upper(7) as N3 from banks");
-		assertTrue(results.next());
-		assertEquals("The BANK_NAME is wrong", "BUNDESBANK (BERLIN)", results.getString(1));
-		assertEquals("N2 is wrong", "CREDITA", results.getString(2));
-		assertEquals("N3 is wrong", "7", results.getString(3));
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("select UPPER(BANK_NAME) as UC, UPPER('Credit' + 'a') as N2, upper(7) as N3 from banks"))
+			{
+				assertTrue(results.next());
+				assertEquals("The BANK_NAME is wrong", "BUNDESBANK (BERLIN)", results.getString(1));
+				assertEquals("N2 is wrong", "CREDITA", results.getString(2));
+				assertEquals("N3 is wrong", "7", results.getString(3));
+			}
 
-		results = stmt.executeQuery("select BLZ from banks where UPPER(BANK_NAME) = 'POSTBANK (BERLIN)'");
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010010, results.getInt(1));
-		assertFalse(results.next());		
+			try (ResultSet results = stmt.executeQuery("select BLZ from banks where UPPER(BANK_NAME) = 'POSTBANK (BERLIN)'"))
+			{
+				assertTrue(results.next());
+				assertEquals("The BLZ is wrong", 10010010, results.getInt(1));
+				assertFalse(results.next());
+			}
+		}
 	}
 
 	@Test
@@ -2334,16 +2440,19 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
 		props.put("charset", "UTF-8");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select length(Name) as X, length(Job) as Y, length('') as Z from sample5 where id = 8");
-		assertTrue(results.next());
-		assertEquals("The Length is wrong", 27, results.getInt(1));
-		assertEquals("The Length is wrong", 15, results.getInt(2));
-		assertEquals("The Length is wrong", 0, results.getInt(3));
-		assertFalse(results.next());		
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select length(Name) as X, length(Job) as Y, length('') as Z from sample5 where id = 8"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Length is wrong", 27, results.getInt(1));
+			assertEquals("The Length is wrong", 15, results.getInt(2));
+			assertEquals("The Length is wrong", 0, results.getInt(3));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2353,90 +2462,105 @@ public class TestCsvDriver
 		props.put("columnTypes", "String,Int,Float,String");
 		props.put("commentChar", "#");
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select TRIM(comment), TRIM('\tfoo bar\n') from with_comments");
-		assertTrue(results.next());
-		assertEquals("The comment is wrong", "some field", results.getString(1));
-		assertEquals("The trimmed value is wrong", "foo bar", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("The comment is wrong", "other parameter", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("The comment is wrong", "still a field", results.getString(1));
-		assertFalse(results.next());		
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("select TRIM(comment), TRIM('\tfoo bar\n') from with_comments"))
+			{
+				assertTrue(results.next());
+				assertEquals("The comment is wrong", "some field", results.getString(1));
+				assertEquals("The trimmed value is wrong", "foo bar", results.getString(2));
+				assertTrue(results.next());
+				assertEquals("The comment is wrong", "other parameter", results.getString(1));
+				assertTrue(results.next());
+				assertEquals("The comment is wrong", "still a field", results.getString(1));
+				assertFalse(results.next());
+			}
 
-		results = stmt.executeQuery("select TRIM(name, '#'), TRIM(name, '#h'), TRIM('00000', '0') from with_comments");
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "alpha", results.getString(1));
-		assertEquals("The trimmed value is wrong", "alpha", results.getString(2));
-		assertEquals("The trimmed value is wrong", "", results.getString(3));
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "beta", results.getString(1));
-		assertEquals("The trimmed value is wrong", "beta", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "hash", results.getString(1));
-		assertEquals("The trimmed value is wrong", "as", results.getString(2));
-		assertFalse(results.next());
+			try (ResultSet results = stmt.executeQuery("select TRIM(name, '#'), TRIM(name, '#h'), TRIM('00000', '0') from with_comments"))
+			{
+				assertTrue(results.next());
+				assertEquals("The trimmed value is wrong", "alpha", results.getString(1));
+				assertEquals("The trimmed value is wrong", "alpha", results.getString(2));
+				assertEquals("The trimmed value is wrong", "", results.getString(3));
+				assertTrue(results.next());
+				assertEquals("The trimmed value is wrong", "beta", results.getString(1));
+				assertEquals("The trimmed value is wrong", "beta", results.getString(2));
+				assertTrue(results.next());
+				assertEquals("The trimmed value is wrong", "hash", results.getString(1));
+				assertEquals("The trimmed value is wrong", "as", results.getString(2));
+				assertFalse(results.next());
+			}
+		}
 	}
 
 	@Test
 	public void testLTrimFunction() throws SQLException
 	{
-		Properties props = new Properties(); 
+		Properties props = new Properties();
 		props.put("headerline", "TRANS_DATE,FROM_ACCT,FROM_BLZ,TO_ACCT,TO_BLZ,AMOUNT");
 		props.put("suppressHeaders", "true");
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT LTRIM(TO_ACCT,'0'), LTRIM('0000','0'), LTRIM('','0'), LTRIM('  X  ') FROM transactions");
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "27853256", results.getString(1));
-		assertEquals("The trimmed value is wrong", "", results.getString(2));
-		assertEquals("The trimmed value is wrong", "", results.getString(3));
-		assertEquals("The trimmed value is wrong", "X  ", results.getString(4));
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "27234813", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "81824588", results.getString(1));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT LTRIM(TO_ACCT,'0'), LTRIM('0000','0'), LTRIM('','0'), LTRIM('  X  ') FROM transactions"))
+		{
+			assertTrue(results.next());
+			assertEquals("The trimmed value is wrong", "27853256", results.getString(1));
+			assertEquals("The trimmed value is wrong", "", results.getString(2));
+			assertEquals("The trimmed value is wrong", "", results.getString(3));
+			assertEquals("The trimmed value is wrong", "X  ", results.getString(4));
+			assertTrue(results.next());
+			assertEquals("The trimmed value is wrong", "27234813", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("The trimmed value is wrong", "81824588", results.getString(1));
+		}
 	}
 
 	@Test
 	public void testRTrimFunction() throws SQLException
 	{
-		Properties props = new Properties(); 
+		Properties props = new Properties();
 		props.put("headerline", "BLZ,BANK_NAME");
 		props.put("suppressHeaders", "true");
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT RTRIM(BLZ,'0'), RTRIM(' ZZ ') FROM banks");
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "1", results.getString(1));
-		assertEquals("The trimmed value is wrong", " ZZ", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "1001001", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("The trimmed value is wrong", "10010111", results.getString(1));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT RTRIM(BLZ,'0'), RTRIM(' ZZ ') FROM banks"))
+		{
+			assertTrue(results.next());
+			assertEquals("The trimmed value is wrong", "1", results.getString(1));
+			assertEquals("The trimmed value is wrong", " ZZ", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("The trimmed value is wrong", "1001001", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("The trimmed value is wrong", "10010111", results.getString(1));
+		}
 	}
 
 	@Test
 	public void testSubstringFunction() throws SQLException
 	{
-		Properties props = new Properties(); 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT substring(name, 2), substring(name, 3, 4), substring(name, 200) FROM sample4");
-		assertTrue(results.next());
-		assertEquals("The substring is wrong", "uan Pablo Morales", results.getString(1));
-		assertEquals("The substring is wrong", "an P", results.getString(2));
-		assertEquals("The substring is wrong", "", results.getString(3));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT substring(name, 2), substring(name, 3, 4), substring(name, 200) FROM sample4"))
+		{
+			assertTrue(results.next());
+			assertEquals("The substring is wrong", "uan Pablo Morales", results.getString(1));
+			assertEquals("The substring is wrong", "an P", results.getString(2));
+			assertEquals("The substring is wrong", "", results.getString(3));
+		}
 	}
 
 	/**
@@ -2452,19 +2576,22 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Byte,Short,Integer,Long,Float,Double,BigDecimal");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select ABS(C2) as R1, ABS(C5) as R2, ABS('-123456') as R3 from numeric");
-		assertTrue(results.next());
-		assertEquals("R1 is wrong", 1010, results.getInt(1));
-		assertTrue("R2 is wrong", fuzzyEquals(results.getDouble(2), 3.14));
-		assertTrue("R3 is wrong", fuzzyEquals(results.getDouble(3), 123456));
-		assertTrue(results.next());
-		assertEquals("R1 is wrong", 15, results.getInt(1));
-		assertTrue("R2 is wrong", fuzzyEquals(results.getDouble(2), 0.0));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select ABS(C2) as R1, ABS(C5) as R2, ABS('-123456') as R3 from numeric"))
+		{
+			assertTrue(results.next());
+			assertEquals("R1 is wrong", 1010, results.getInt(1));
+			assertTrue("R2 is wrong", fuzzyEquals(results.getDouble(2), 3.14));
+			assertTrue("R3 is wrong", fuzzyEquals(results.getDouble(3), 123456));
+			assertTrue(results.next());
+			assertEquals("R1 is wrong", 15, results.getInt(1));
+			assertTrue("R2 is wrong", fuzzyEquals(results.getDouble(2), 0.0));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2472,17 +2599,20 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Byte,Short,Integer,Long,Float,Double,BigDecimal");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select ROUND(11.77) as R1, ROUND('11.77') as R2, ROUND(C2) as R3, round(C3/7.0) as R4 from numeric where ROUND(C5) = 3");
-		assertTrue(results.next());
-		assertEquals("R1 is wrong", 12, results.getInt(1));
-		assertEquals("R2 is wrong", 12, results.getInt(2));
-		assertEquals("R3 is wrong", -1010, results.getInt(3));
-		assertEquals("R4 is wrong", 42871, results.getInt(4));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select ROUND(11.77) as R1, ROUND('11.77') as R2, ROUND(C2) as R3, round(C3/7.0) as R4 from numeric where ROUND(C5) = 3"))
+		{
+			assertTrue(results.next());
+			assertEquals("R1 is wrong", 12, results.getInt(1));
+			assertEquals("R2 is wrong", 12, results.getInt(2));
+			assertEquals("R3 is wrong", -1010, results.getInt(3));
+			assertEquals("R4 is wrong", 42871, results.getInt(4));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2491,19 +2621,22 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Date,Time");
 		props.put("timeZoneName", TimeZone.getDefault().getID());
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select dayofmonth(d) as dom, " +
-				"dayofmonth('2013-10-13') as today from sample8");
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 2, results.getInt(1));
-		assertEquals("today is wrong", 13, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 2, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 28, results.getInt(1));
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select dayofmonth(d) as dom, " +
+				"dayofmonth('2013-10-13') as today from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 2, results.getInt(1));
+			assertEquals("today is wrong", 13, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 2, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 28, results.getInt(1));
+		}
 	}
 
 	@Test
@@ -2511,19 +2644,22 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select month(d) as month, " +
-				"month('2013-10-13') as today from sample8");
-		assertTrue(results.next());
-		assertEquals("month is wrong", 1, results.getInt(1));
-		assertEquals("today is wrong", 10, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 2, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 3, results.getInt(1));
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select month(d) as month, " +
+				"month('2013-10-13') as today from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("month is wrong", 1, results.getInt(1));
+			assertEquals("today is wrong", 10, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 2, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 3, results.getInt(1));
+		}
 	}
 
 	@Test
@@ -2532,23 +2668,26 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Date,Time");
 		props.put("timeZoneName", TimeZone.getDefault().getID());
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select year(d) as year, " +
-				"year('2013-10-13') as today from sample8");
-		assertTrue(results.next());
-		assertEquals("month is wrong", 2010, results.getInt(1));
-		assertEquals("today is wrong", 2013, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 2010, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 2010, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 2010, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("dom is wrong", 2009, results.getInt(1));
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select year(d) as year, " +
+				"year('2013-10-13') as today from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("month is wrong", 2010, results.getInt(1));
+			assertEquals("today is wrong", 2013, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 2010, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 2010, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 2010, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("dom is wrong", 2009, results.getInt(1));
+		}
 	}
 
 	@Test
@@ -2556,21 +2695,24 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select hourofday(t) as hour, " +
-				"hourofday('23:41:17') as h from sample8");
-		assertTrue(results.next());
-		assertEquals("hour is wrong", 1, results.getInt(1));
-		assertEquals("h is wrong", 23, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("hour is wrong", 1, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("hour is wrong", 1, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("hour is wrong", 5, results.getInt(1));
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select hourofday(t) as hour, " +
+				"hourofday('23:41:17') as h from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("hour is wrong", 1, results.getInt(1));
+			assertEquals("h is wrong", 23, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("hour is wrong", 1, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("hour is wrong", 1, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("hour is wrong", 5, results.getInt(1));
+		}
 	}
 
 	@Test
@@ -2578,15 +2720,18 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select minute(t) as minute, " +
-				"minute('23:41:17') as m from sample8");
-		assertTrue(results.next());
-		assertEquals("minute is wrong", 30, results.getInt(1));
-		assertEquals("m is wrong", 41, results.getInt(2));
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select minute(t) as minute, " +
+				"minute('23:41:17') as m from sample8"))
+		{
+			assertTrue(results.next());
+			assertEquals("minute is wrong", 30, results.getInt(1));
+			assertEquals("m is wrong", 41, results.getInt(2));
+		}
 	}
 
 	@Test
@@ -2595,32 +2740,38 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
 		props.put("timeZoneName", TimeZone.getDefault().getID());
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select dayofmonth(Start), month(Start), year(Start), " +
-				"hourofday(Start), minute(Start), second(Start) from sample5");
-		assertTrue(results.next());
-		assertEquals("dayofmonth is wrong", 2, results.getInt(1));
-		assertEquals("month is wrong", 4, results.getInt(2));
-		assertEquals("year is wrong", 2001, results.getInt(3));
-		assertEquals("hourofday is wrong", 12, results.getInt(4));
-		assertEquals("minute is wrong", 30, results.getInt(5));
-		assertEquals("second is wrong", 0, results.getInt(6));
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("select dayofmonth(Start), month(Start), year(Start), " +
+				"hourofday(Start), minute(Start), second(Start) from sample5"))
+			{
+				assertTrue(results.next());
+				assertEquals("dayofmonth is wrong", 2, results.getInt(1));
+				assertEquals("month is wrong", 4, results.getInt(2));
+				assertEquals("year is wrong", 2001, results.getInt(3));
+				assertEquals("hourofday is wrong", 12, results.getInt(4));
+				assertEquals("minute is wrong", 30, results.getInt(5));
+				assertEquals("second is wrong", 0, results.getInt(6));
+			}
 
-		String timestamp = "2013-10-13 14:33:55";
-		results = stmt.executeQuery("select dayofmonth('" + timestamp + "')," +
-			"month('" + timestamp + "'), year('" + timestamp + "'), " +
-			"hourofday('" + timestamp + "'), minute('" + timestamp + "'), " +
-			"second('" + timestamp + "') from sample5");
-		assertTrue(results.next());
-		assertEquals("dayofmonth is wrong", 13, results.getInt(1));
-		assertEquals("month is wrong", 10, results.getInt(2));
-		assertEquals("year is wrong", 2013, results.getInt(3));
-		assertEquals("hourofday is wrong", 14, results.getInt(4));
-		assertEquals("minute is wrong", 33, results.getInt(5));
-		assertEquals("second is wrong", 55, results.getInt(6));
+			String timestamp = "2013-10-13 14:33:55";
+			try (ResultSet results = stmt.executeQuery("select dayofmonth('" + timestamp + "')," +
+				"month('" + timestamp + "'), year('" + timestamp + "'), " +
+				"hourofday('" + timestamp + "'), minute('" + timestamp + "'), " +
+				"second('" + timestamp + "') from sample5"))
+			{
+				assertTrue(results.next());
+				assertEquals("dayofmonth is wrong", 13, results.getInt(1));
+				assertEquals("month is wrong", 10, results.getInt(2));
+				assertEquals("year is wrong", 2013, results.getInt(3));
+				assertEquals("hourofday is wrong", 14, results.getInt(4));
+				assertEquals("minute is wrong", 33, results.getInt(5));
+				assertEquals("second is wrong", 55, results.getInt(6));
+			}
+		}
 	}
 
 	@Test
@@ -2629,22 +2780,25 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("trimHeaders", "true");
 		props.put("trimValues", "true");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select nullif(key, ' - ') as k2 from foodstuffs");
-		assertTrue(results.next());
-		assertEquals("K2 is wrong", "orange", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("K2 is wrong", "apple", results.getString(1));
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertEquals("K2 is wrong", null, results.getString(1));
-		assertTrue(results.wasNull());
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select nullif(key, ' - ') as k2 from foodstuffs"))
+		{
+			assertTrue(results.next());
+			assertEquals("K2 is wrong", "orange", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("K2 is wrong", "apple", results.getString(1));
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertEquals("K2 is wrong", null, results.getString(1));
+			assertTrue(results.wasNull());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2652,18 +2806,21 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("SELECT COALESCE(ID, 999) FROM bad_values");
-		assertTrue(results.next());
-		assertEquals("ID is wrong", 999, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("ID is wrong", 999, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("ID is wrong", 3, results.getInt(1));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("SELECT COALESCE(ID, 999) FROM bad_values"))
+		{
+			assertTrue(results.next());
+			assertEquals("ID is wrong", 999, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("ID is wrong", 999, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("ID is wrong", 3, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2673,24 +2830,26 @@ public class TestCsvDriver
 		props.put("columnTypes", "String,Int,Float,String");
 		props.put("commentChar", "#");
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM with_comments");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM with_comments"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("name", metadata.getColumnName(1));
+			assertEquals("id", metadata.getColumnName(2));
+			assertEquals("value", metadata.getColumnName(3));
+			assertEquals("comment", metadata.getColumnName(4));
 
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("name", metadata.getColumnName(1));
-		assertEquals("id", metadata.getColumnName(2));
-		assertEquals("value", metadata.getColumnName(3));
-		assertEquals("comment", metadata.getColumnName(4));
-
-		assertTrue(results.next());
-		assertEquals(Integer.valueOf(1), results.getObject(2));
-		assertTrue(results.next());
-		assertEquals(Integer.valueOf(2), results.getObject(2));
-		assertTrue(results.next());
-		assertEquals(Integer.valueOf(3), results.getObject(2));
-		assertFalse(results.next());
+			assertTrue(results.next());
+			assertEquals(Integer.valueOf(1), results.getObject(2));
+			assertTrue(results.next());
+			assertEquals(Integer.valueOf(2), results.getObject(2));
+			assertTrue(results.next());
+			assertEquals(Integer.valueOf(3), results.getObject(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2698,38 +2857,40 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("commentChar", "");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample5"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("ID", metadata.getColumnName(1));
+			assertEquals("Name", metadata.getColumnName(2));
+			assertEquals("Job", metadata.getColumnName(3));
+			assertEquals("Start", metadata.getColumnName(4));
 
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("ID", metadata.getColumnName(1));
-		assertEquals("Name", metadata.getColumnName(2));
-		assertEquals("Job", metadata.getColumnName(3));
-		assertEquals("Start", metadata.getColumnName(4));
-
-		assertTrue(results.next());
-		assertEquals("41", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("01", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("02", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("03", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("04", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("05", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("06", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("07", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("08", results.getObject(1));
-		assertTrue(results.next());
-		assertEquals("09", results.getObject(1));
-		assertFalse(results.next());
+			assertTrue(results.next());
+			assertEquals("41", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("01", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("02", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("03", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("04", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("05", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("06", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("07", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("08", results.getObject(1));
+			assertTrue(results.next());
+			assertEquals("09", results.getObject(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2741,17 +2902,18 @@ public class TestCsvDriver
 		/*
 		 * Check that the 3 byte Byte Order Mark at start of file is skipped.
 		 */
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM utf8_bom");
-
-		assertTrue(results.next());
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("name of column 1 is incorrect", "foo", metadata.getColumnName(1));
-		assertEquals("name of column 2 is incorrect", "bar", metadata.getColumnName(2));
-		assertEquals("Incorrect value 1", "1", results.getString(1));
-		assertEquals("Incorrect value 2", "3", results.getString(2));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM utf8_bom"))
+		{
+			assertTrue(results.next());
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("name of column 1 is incorrect", "foo", metadata.getColumnName(1));
+			assertEquals("name of column 2 is incorrect", "bar", metadata.getColumnName(2));
+			assertEquals("Incorrect value 1", "1", results.getString(1));
+			assertEquals("Incorrect value 2", "3", results.getString(2));
+		}
 	}
 
 	@Test
@@ -2761,24 +2923,26 @@ public class TestCsvDriver
 		props.put("columnTypes", "String,Int,Float,String");
 		props.put("skipLeadingLines", "3");
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM with_comments");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM with_comments"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("name", metadata.getColumnName(1));
+			assertEquals("id", metadata.getColumnName(2));
+			assertEquals("value", metadata.getColumnName(3));
+			assertEquals("comment", metadata.getColumnName(4));
 
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("name", metadata.getColumnName(1));
-		assertEquals("id", metadata.getColumnName(2));
-		assertEquals("value", metadata.getColumnName(3));
-		assertEquals("comment", metadata.getColumnName(4));
-
-		assertTrue(results.next());
-		assertEquals(Integer.valueOf(1), results.getObject(2));
-		assertTrue(results.next());
-		assertEquals(Integer.valueOf(2), results.getObject(2));
-		assertTrue(results.next());
-		assertEquals(Integer.valueOf(3), results.getObject(2));
-		assertFalse(results.next());
+			assertTrue(results.next());
+			assertEquals(Integer.valueOf(1), results.getObject(2));
+			assertTrue(results.next());
+			assertEquals(Integer.valueOf(2), results.getObject(2));
+			assertTrue(results.next());
+			assertEquals(Integer.valueOf(3), results.getObject(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2790,19 +2954,21 @@ public class TestCsvDriver
 		props.put("separator", ";");
 		props.put("fileExtension", ".txt");
 		props.put("suppressHeaders", "true");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM with_leading_trash");
 
-		assertTrue(results.next());
-		assertEquals("12:20", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("12:30", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("12:40", results.getObject(2));
-		assertFalse(results.next());
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM with_leading_trash"))
+		{
+			assertTrue(results.next());
+			assertEquals("12:20", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("12:30", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("12:40", results.getObject(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2814,19 +2980,21 @@ public class TestCsvDriver
 		props.put("separator", ";");
 		props.put("fileExtension", ".txt");
 		props.put("suppressHeaders", "true");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM with_leading_trash");
 
-		assertTrue(results.next());
-		assertEquals("12:20", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("12:30", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("12:40", results.getObject(2));
-		assertFalse(results.next());
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM with_leading_trash"))
+		{
+			assertTrue(results.next());
+			assertEquals("12:20", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("12:30", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("12:40", results.getObject(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2836,20 +3004,22 @@ public class TestCsvDriver
 		props.put("ignoreNonParseableLines", "True");
 		props.put("separator", ";");
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM with_leading_trash");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM with_leading_trash"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("12:20", metadata.getColumnName(2));
 
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("12:20", metadata.getColumnName(2));
-
-		assertTrue(results.next());
-		assertEquals("12:30", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("12:40", results.getObject(2));
-		assertFalse(results.next());
+			assertTrue(results.next());
+			assertEquals("12:30", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("12:40", results.getObject(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2860,17 +3030,19 @@ public class TestCsvDriver
 		props.put("suppressHeaders", "true");
 		props.put("ignoreNonParseableLines", "True");
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM embassies");
 
-		assertTrue(results.next());
-		assertEquals("Germany", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("United Kingdom", results.getString(1));
-		assertFalse(results.next());
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM embassies"))
+		{
+			assertTrue(results.next());
+			assertEquals("Germany", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("United Kingdom", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2880,26 +3052,30 @@ public class TestCsvDriver
 		props.put("ignoreNonParseableLines", "True");
 		props.put("separator", ";");
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		
-		StringWriter sw = new StringWriter();
-		PrintWriter logger = new PrintWriter(sw, true);
-		DriverManager.setLogWriter(logger);
-
-		ResultSet results = stmt.executeQuery("SELECT * FROM with_leading_trash");
-		while (results.next())
+			Statement stmt = conn.createStatement())
 		{
-			
-		}
-		String logMessages = sw.getBuffer().toString();
+			StringWriter sw = new StringWriter();
+			PrintWriter logger = new PrintWriter(sw, true);
+			DriverManager.setLogWriter(logger);
 
-		/*
-		 * Check that non-parseables lines were logged.
-		 */
-		assertTrue(logMessages.contains("Databank=MSW"));
-		assertTrue(logMessages.contains("Locatie=DENH"));
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM with_leading_trash"))
+			{
+				while (results.next())
+				{
+
+				}
+			}
+			String logMessages = sw.getBuffer().toString();
+
+			/*
+			 * Check that non-parseables lines were logged.
+			 */
+			assertTrue(logMessages.contains("Databank=MSW"));
+			assertTrue(logMessages.contains("Locatie=DENH"));
+		}
 	}
 
 	@Test
@@ -2909,28 +3085,30 @@ public class TestCsvDriver
 		props.put("separator", ":");
 		props.put("fileExtension", ".log");
 		props.put("missingValue", "$$");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM recording-2015-06-28");
 
-		assertTrue(results.next());
-		assertEquals("2015-01-01", results.getString(1));
-		assertEquals("start", results.getString(2));
-		assertEquals("$$", results.getString(3));
-		assertEquals("$$", results.getString(4));
-		assertTrue(results.next());
-		assertEquals("2015-01-02", results.getString(1));
-		assertEquals("new", results.getString(2));
-		assertEquals("event", results.getString(3));
-		assertEquals("$$", results.getString(4));
-		assertTrue(results.next());
-		assertEquals("2015-01-03", results.getString(1));
-		assertEquals("repeat", results.getString(2));
-		assertEquals("previous", results.getString(3));
-		assertEquals("100", results.getString(4));
-		assertFalse(results.next());
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM recording-2015-06-28"))
+		{
+			assertTrue(results.next());
+			assertEquals("2015-01-01", results.getString(1));
+			assertEquals("start", results.getString(2));
+			assertEquals("$$", results.getString(3));
+			assertEquals("$$", results.getString(4));
+			assertTrue(results.next());
+			assertEquals("2015-01-02", results.getString(1));
+			assertEquals("new", results.getString(2));
+			assertEquals("event", results.getString(3));
+			assertEquals("$$", results.getString(4));
+			assertTrue(results.next());
+			assertEquals("2015-01-03", results.getString(1));
+			assertEquals("repeat", results.getString(2));
+			assertEquals("previous", results.getString(3));
+			assertEquals("100", results.getString(4));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -2938,46 +3116,49 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select ID, ID + 1, NAME, START_DATE, START_DATE + 1, START_TIME from bad_values");
-		assertTrue(results.next());
+			Statement stmt = conn.createStatement();
 
-		/*
-		 * Check that SQL NULL is returned for empty or invalid numeric, date and time fields,
-		 * and that zero is returned from methods that return a number.
-		 */
-		assertEquals("ID is wrong", 0, results.getInt("ID"));
-		assertTrue(results.wasNull());
-		assertEquals("ID + 1 is wrong", 0, results.getInt(2));
-		assertTrue(results.wasNull());
-		assertEquals("NAME is wrong", "Simon", results.getString(3));
-		assertFalse(results.wasNull());
-		assertNull("START_DATE is wrong", results.getDate(4));
-		assertTrue(results.wasNull());
-		assertNull("START_DATE + 1 is wrong", results.getDate(5));
-		assertTrue(results.wasNull());
-		assertNull("START_TIME is wrong", results.getTime(6));
-		assertTrue(results.wasNull());
+			ResultSet results = stmt.executeQuery("select ID, ID + 1, NAME, START_DATE, START_DATE + 1, START_TIME from bad_values"))
+		{
+			assertTrue(results.next());
 
-		assertTrue(results.next());
+			/*
+			 * Check that SQL NULL is returned for empty or invalid numeric, date and time fields,
+			 * and that zero is returned from methods that return a number.
+			 */
+			assertEquals("ID is wrong", 0, results.getInt("ID"));
+			assertTrue(results.wasNull());
+			assertEquals("ID + 1 is wrong", 0, results.getInt(2));
+			assertTrue(results.wasNull());
+			assertEquals("NAME is wrong", "Simon", results.getString(3));
+			assertFalse(results.wasNull());
+			assertNull("START_DATE is wrong", results.getDate(4));
+			assertTrue(results.wasNull());
+			assertNull("START_DATE + 1 is wrong", results.getDate(5));
+			assertTrue(results.wasNull());
+			assertNull("START_TIME is wrong", results.getTime(6));
+			assertTrue(results.wasNull());
 
-		assertNull("ID is wrong", results.getObject("ID"));
-		assertTrue(results.wasNull());
-		assertNull("ID + 1 is wrong", results.getObject(2));
-		assertTrue(results.wasNull());
-		assertEquals("NAME is wrong", "Wally", results.getString(3));
-		assertFalse(results.wasNull());
-		assertNull("START_DATE is wrong", results.getObject(4));
-		assertTrue(results.wasNull());
-		assertNull("START_DATE + 1 is wrong", results.getObject(5));
-		assertTrue(results.wasNull());
-		assertNull("START_TIME is wrong", results.getObject(6));
-		assertTrue(results.wasNull());
+			assertTrue(results.next());
 
-		assertTrue(results.next());
+			assertNull("ID is wrong", results.getObject("ID"));
+			assertTrue(results.wasNull());
+			assertNull("ID + 1 is wrong", results.getObject(2));
+			assertTrue(results.wasNull());
+			assertEquals("NAME is wrong", "Wally", results.getString(3));
+			assertFalse(results.wasNull());
+			assertNull("START_DATE is wrong", results.getObject(4));
+			assertTrue(results.wasNull());
+			assertNull("START_DATE + 1 is wrong", results.getObject(5));
+			assertTrue(results.wasNull());
+			assertNull("START_TIME is wrong", results.getObject(6));
+			assertTrue(results.wasNull());
+
+			assertTrue(results.next());
+		}
 	}
 
 	@Test
@@ -2991,58 +3172,64 @@ public class TestCsvDriver
 		props.put("fileTailPrepend", "True");
 		props.put("columnTypes", "String,Date,Time,String,Double");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM varlen1"))
+			{
+				ResultSetMetaData metadata = results.getMetaData();
+				assertEquals("file_date", metadata.getColumnName(1));
+				assertEquals("Datum", metadata.getColumnName(2));
+				assertEquals("Tijd", metadata.getColumnName(3));
+				assertEquals("Station", metadata.getColumnName(4));
+				assertEquals("P000", metadata.getColumnName(5));
+				assertEquals("P001", metadata.getColumnName(6));
+				assertEquals("P002", metadata.getColumnName(7));
+				assertEquals("P003", metadata.getColumnName(8));
+			}
 
-		ResultSet results = null;
-		ResultSetMetaData metadata;
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM varlen2"))
+			{
+				ResultSetMetaData metadata = results.getMetaData();
+				assertEquals("file_date", metadata.getColumnName(1));
+				assertEquals("Datum", metadata.getColumnName(2));
+				assertEquals("Tijd", metadata.getColumnName(3));
+				assertEquals("Station", metadata.getColumnName(4));
+				assertEquals("P000", metadata.getColumnName(5));
+				assertEquals("P001", metadata.getColumnName(6));
+			}
 
-		results = stmt.executeQuery("SELECT * FROM varlen1");
-		metadata = results.getMetaData();
-		assertEquals("file_date", metadata.getColumnName(1));
-		assertEquals("Datum", metadata.getColumnName(2));
-		assertEquals("Tijd", metadata.getColumnName(3));
-		assertEquals("Station", metadata.getColumnName(4));
-		assertEquals("P000", metadata.getColumnName(5));
-		assertEquals("P001", metadata.getColumnName(6));
-		assertEquals("P002", metadata.getColumnName(7));
-		assertEquals("P003", metadata.getColumnName(8));
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM varlen1"))
+			{
+				assertTrue(results.next());
+				assertEquals("007", results.getObject("Station"));
+				assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
+				assertTrue(results.next());
+				assertEquals("007", results.getObject("Station"));
+				assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
+				assertTrue(results.next());
+				assertEquals("007", results.getObject("Station"));
+				assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
+				assertTrue(results.next());
+				assertEquals("001", results.getObject("Station"));
+				assertEquals(Double.valueOf("26.55"), results.getObject("P003"));
+				assertFalse(results.next());
+			}
 
-		results = stmt.executeQuery("SELECT * FROM varlen2");
-		metadata = results.getMetaData();
-		assertEquals("file_date", metadata.getColumnName(1));
-		assertEquals("Datum", metadata.getColumnName(2));
-		assertEquals("Tijd", metadata.getColumnName(3));
-		assertEquals("Station", metadata.getColumnName(4));
-		assertEquals("P000", metadata.getColumnName(5));
-		assertEquals("P001", metadata.getColumnName(6));
-
-		results = stmt.executeQuery("SELECT * FROM varlen1");
-		assertTrue(results.next());
-		assertEquals("007", results.getObject("Station"));
-		assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
-		assertTrue(results.next());
-		assertEquals("007", results.getObject("Station"));
-		assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
-		assertTrue(results.next());
-		assertEquals("007", results.getObject("Station"));
-		assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
-		assertTrue(results.next());
-		assertEquals("001", results.getObject("Station"));
-		assertEquals(Double.valueOf("26.55"), results.getObject("P003"));
-		assertFalse(results.next());
-
-		results = stmt.executeQuery("SELECT * FROM varlen2");
-		assertTrue(results.next());
-		assertEquals("007", results.getObject("Station"));
-		assertTrue(results.next());
-		assertEquals("007", results.getObject("Station"));
-		assertTrue(results.next());
-		assertEquals("013", results.getObject("Station"));
-		assertTrue(results.next());
-		assertEquals("013", results.getObject("Station"));
-		assertFalse(results.next());
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM varlen2"))
+			{
+				assertTrue(results.next());
+				assertEquals("007", results.getObject("Station"));
+				assertTrue(results.next());
+				assertEquals("007", results.getObject("Station"));
+				assertTrue(results.next());
+				assertEquals("013", results.getObject("Station"));
+				assertTrue(results.next());
+				assertEquals("013", results.getObject("Station"));
+				assertFalse(results.next());
+			}
+		}
 	}
 
 	@Test
@@ -3055,61 +3242,68 @@ public class TestCsvDriver
 		props.put("fileTailParts", "file_date");
 		props.put("fileTailPrepend", "True");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM varlen1"))
+			{
+				ResultSetMetaData metadata = results.getMetaData();
+				assertEquals("file_date", metadata.getColumnName(1));
+				assertEquals("Datum", metadata.getColumnName(2));
+				assertEquals("Tijd", metadata.getColumnName(3));
+				assertEquals("Station", metadata.getColumnName(4));
+				assertEquals("P000", metadata.getColumnName(5));
+				assertEquals("P001", metadata.getColumnName(6));
+				assertEquals("P002", metadata.getColumnName(7));
+				assertEquals("P003", metadata.getColumnName(8));
+			}
 
-		ResultSet results = null;
-		ResultSetMetaData metadata = null;
-
-		results = stmt.executeQuery("SELECT * FROM varlen1");
-		metadata = results.getMetaData();
-		assertEquals("file_date", metadata.getColumnName(1));
-		assertEquals("Datum", metadata.getColumnName(2));
-		assertEquals("Tijd", metadata.getColumnName(3));
-		assertEquals("Station", metadata.getColumnName(4));
-		assertEquals("P000", metadata.getColumnName(5));
-		assertEquals("P001", metadata.getColumnName(6));
-		assertEquals("P002", metadata.getColumnName(7));
-		assertEquals("P003", metadata.getColumnName(8));
-
-		results = stmt.executeQuery("SELECT * FROM varlen2");
-		metadata = results.getMetaData();
-		assertEquals("file_date", metadata.getColumnName(1));
-		assertEquals("Datum", metadata.getColumnName(2));
-		assertEquals("Tijd", metadata.getColumnName(3));
-		assertEquals("Station", metadata.getColumnName(4));
-		assertEquals("P000", metadata.getColumnName(5));
-		assertEquals("P001", metadata.getColumnName(6));
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM varlen2"))
+			{
+				ResultSetMetaData metadata = results.getMetaData();
+				assertEquals("file_date", metadata.getColumnName(1));
+				assertEquals("Datum", metadata.getColumnName(2));
+				assertEquals("Tijd", metadata.getColumnName(3));
+				assertEquals("Station", metadata.getColumnName(4));
+				assertEquals("P000", metadata.getColumnName(5));
+				assertEquals("P001", metadata.getColumnName(6));
+			}
+		}
 	}
 
 	@Test
 	public void testNonExistingTable() throws SQLException
 	{
-		Statement stmt = DriverManager.getConnection(
-				"jdbc:relique:csv:" + filePath).createStatement();
-
-		try
+		try (Connection conn = DriverManager.getConnection(
+				"jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM not_there");
-			fail("Should not find the table 'not_there'");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("fileNotFound") + ": "
-				+ filePath + File.separator + "not_there.csv", "" + e);
+			try
+			{
+				stmt.executeQuery("SELECT * FROM not_there");
+				fail("Should not find the table 'not_there'");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("fileNotFound") + ": "
+					+ filePath + File.separator + "not_there.csv", "" + e);
+			}
 		}
 
 		Properties props = new Properties();
 		props.put("indexedFiles", "True");
 		props.put("fileTailPattern", "-([0-9]{8})");
 		props.put("fileTailParts", "file_date");
-		stmt = DriverManager.getConnection("jdbc:relique:csv:" + filePath,
-				props).createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM not_there");
-		assertFalse("non existing indexed tables are seen as empty", results
+		try (Connection conn = DriverManager.getConnection(
+				"jdbc:relique:csv:" + filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM not_there"))
+		{
+			assertFalse("non existing indexed tables are seen as empty", results
 				.next());
+		}
 	}
 
 	@Test
@@ -3118,22 +3312,23 @@ public class TestCsvDriver
 		// no bug report, check discussion thread
 		// https://sourceforge.net/projects/csvjdbc/forums/forum/56965/topic/2608197
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		// load CSV driver
-		try
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM duplicate_headers");
-			fail("expected exception java.sql.SQLException: " + CsvResources.getString("duplicateColumns"));
-		}
-		catch (SQLException e)
-		{
-			assertEquals("wrong exception and/or exception text!",
-				"java.sql.SQLException: " + CsvResources.getString("duplicateColumns"),
-				"" + e);
+			// load CSV driver
+			try
+			{
+				stmt.executeQuery("SELECT * FROM duplicate_headers");
+				fail("expected exception java.sql.SQLException: " + CsvResources.getString("duplicateColumns"));
+			}
+			catch (SQLException e)
+			{
+				assertEquals("wrong exception and/or exception text!",
+					"java.sql.SQLException: " + CsvResources.getString("duplicateColumns"),
+					"" + e);
+			}
 		}
 	}
 
@@ -3146,32 +3341,33 @@ public class TestCsvDriver
 		props.put("suppressHeaders", "true");
 		props.put("skipLeadingLines", "1");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM duplicate_headers");
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM duplicate_headers"))
+		{
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "1", results.getString(1));
+			assertEquals("2:ID is wrong", "2", results.getString(2));
+			assertEquals("3:ID is wrong", "george", results.getString(3));
+			assertEquals("4:ID is wrong", "joe", results.getString(4));
 
-		assertTrue(results.next());
-		assertEquals("1:ID is wrong", "1", results.getString(1));
-		assertEquals("2:ID is wrong", "2", results.getString(2));
-		assertEquals("3:ID is wrong", "george", results.getString(3));
-		assertEquals("4:ID is wrong", "joe", results.getString(4));
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "2", results.getString(1));
+			assertEquals("2:ID is wrong", "2", results.getString(2));
+			assertEquals("3:ID is wrong", "aworth", results.getString(3));
+			assertEquals("4:ID is wrong", "smith", results.getString(4));
 
-		assertTrue(results.next());
-		assertEquals("1:ID is wrong", "2", results.getString(1));
-		assertEquals("2:ID is wrong", "2", results.getString(2));
-		assertEquals("3:ID is wrong", "aworth", results.getString(3));
-		assertEquals("4:ID is wrong", "smith", results.getString(4));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	/**
 	 * This creates several sentences with where and tests they work
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
@@ -3181,16 +3377,18 @@ public class TestCsvDriver
 		props.put("separator", ";");
 		props.put("quotechar", "'");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM doublequoted");
-		assertTrue(results.next());
-		assertEquals(
-			"\"Rechtsform unbekannt\" entsteht durch die Simulation zTELKUS. Es werden Simulationsregeln angewandt.",
-			results.getString(10));
+			ResultSet results = stmt.executeQuery("SELECT * FROM doublequoted"))
+		{
+			assertTrue(results.next());
+			assertEquals(
+				"\"Rechtsform unbekannt\" entsteht durch die Simulation zTELKUS. Es werden Simulationsregeln angewandt.",
+				results.getString(10));
+		}
 	}
 
 	@Test
@@ -3202,16 +3400,18 @@ public class TestCsvDriver
 		props.put("quotestyle", "SQL");
 		props.put("commentChar", "C");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM doublequoted");
-		assertTrue(results.next());
-		assertEquals(
-			"\"Rechtsform unbekannt\" entsteht durch die Simulation zTELKUS. Es werden Simulationsregeln angewandt.",
-			results.getString(10));
+			ResultSet results = stmt.executeQuery("SELECT * FROM doublequoted"))
+		{
+			assertTrue(results.next());
+			assertEquals(
+				"\"Rechtsform unbekannt\" entsteht durch die Simulation zTELKUS. Es werden Simulationsregeln angewandt.",
+				results.getString(10));
+		}
 	}
 
 	@Test
@@ -3222,17 +3422,19 @@ public class TestCsvDriver
 		props.put("quotechar", "'");
 		props.put("quoteStyle", "C");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM doublequoted");
-		// TODO: this should actually fail!  have a look at testEscapingQuotecharExplicitSQLStyle for the way to check an exception.
-		assertTrue(results.next());
-		assertEquals(
-			"\"Rechtsform unbekannt\" entsteht durch die Simulation zTELKUS. Es werden Simulationsregeln angewandt.",
-			results.getString(10));
+			ResultSet results = stmt.executeQuery("SELECT * FROM doublequoted"))
+		{
+			// TODO: this should actually fail!  have a look at testEscapingQuotecharExplicitSQLStyle for the way to check an exception.
+			assertTrue(results.next());
+			assertEquals(
+				"\"Rechtsform unbekannt\" entsteht durch die Simulation zTELKUS. Es werden Simulationsregeln angewandt.",
+				results.getString(10));
+		}
 	}
 
 	@Test
@@ -3243,17 +3445,19 @@ public class TestCsvDriver
 		props.put("quotechar", "'");
 		props.put("quoteStyle", "C");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT F1 FROM doublequoted");
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertEquals("doubling \"\"quotechar", results.getObject("F1"));
-		assertTrue(results.next());
-		assertEquals("escaping quotechar\"", results.getObject("F1"));
+			ResultSet results = stmt.executeQuery("SELECT F1 FROM doublequoted"))
+		{
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertEquals("doubling \"\"quotechar", results.getObject("F1"));
+			assertTrue(results.next());
+			assertEquals("escaping quotechar\"", results.getObject("F1"));
+		}
 	}
 
 	@Test
@@ -3264,25 +3468,27 @@ public class TestCsvDriver
 		props.put("quotechar", "'");
 		props.put("quoteStyle", "SQL");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT F1 FROM doublequoted");
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertEquals("doubling \\\"\\\"quotechar", results.getObject("F1"));
-		assertTrue(results.next());
-		assertTrue(results.next());
-		try
+			ResultSet results = stmt.executeQuery("SELECT F1 FROM doublequoted"))
 		{
-			results.next();
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("eofInQuotes") + ": 6", "" + e);
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertEquals("doubling \\\"\\\"quotechar", results.getObject("F1"));
+			assertTrue(results.next());
+			assertTrue(results.next());
+			try
+			{
+				results.next();
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("eofInQuotes") + ": 6", "" + e);
+			}
 		}
 	}
 
@@ -3311,24 +3517,26 @@ public class TestCsvDriver
 		props.put("quotechar", "");
 		props.put("fileExtension", ".txt");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM uses_quotes");
-		assertTrue(results.next());
-		assertEquals("COLUMN1 is wrong", "1", results.getString(1));
-		assertEquals("COLUMN2 is wrong", "uno", results.getString(2));
-		assertEquals("COLUMN3 is wrong", "one", results.getString(3));
-		assertTrue(results.next());
-		assertEquals("COLUMN1 is wrong", "2", results.getString(1));
-		assertEquals("COLUMN2 is wrong", "a 'quote' (source unknown)", results.getString(2));
-		assertEquals("COLUMN3 is wrong", "two", results.getString(3));
-		assertTrue(results.next());
-		assertEquals("COLUMN1 is wrong", "3", results.getString(1));
-		assertEquals("COLUMN2 is wrong", "another \"quote\" (also unkown)", results.getString(2));
-		assertEquals("COLUMN3 is wrong", "three", results.getString(3));
+			ResultSet results = stmt.executeQuery("SELECT * FROM uses_quotes"))
+		{
+			assertTrue(results.next());
+			assertEquals("COLUMN1 is wrong", "1", results.getString(1));
+			assertEquals("COLUMN2 is wrong", "uno", results.getString(2));
+			assertEquals("COLUMN3 is wrong", "one", results.getString(3));
+			assertTrue(results.next());
+			assertEquals("COLUMN1 is wrong", "2", results.getString(1));
+			assertEquals("COLUMN2 is wrong", "a 'quote' (source unknown)", results.getString(2));
+			assertEquals("COLUMN3 is wrong", "two", results.getString(3));
+			assertTrue(results.next());
+			assertEquals("COLUMN1 is wrong", "3", results.getString(1));
+			assertEquals("COLUMN2 is wrong", "another \"quote\" (also unkown)", results.getString(2));
+			assertEquals("COLUMN3 is wrong", "three", results.getString(3));
+		}
 	}
 
 	@Test
@@ -3337,36 +3545,38 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("separator", "#@");
 		props.put("skipLeadingLines", "2");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM evonix");
 
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("ID", metadata.getColumnName(1));
-		assertEquals("Name", metadata.getColumnName(2));
-		assertEquals("Birthday", metadata.getColumnName(3));
-		assertTrue(results.next());
-		assertEquals("1:ID is wrong", "0", results.getString(1));
-		assertEquals("2:Name is wrong", "(Florian)", results.getString(2));
-		assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
-		assertTrue(results.next());
-		assertEquals("1:ID is wrong", "1", results.getString(1));
-		assertEquals("2:Name is wrong", "(Tobias)", results.getString(2));
-		assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
-		assertTrue(results.next());
-		assertEquals("1:ID is wrong", "2", results.getString(1));
-		assertEquals("2:Name is wrong", "(#Mark)", results.getString(2));
-		assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
-		assertTrue(results.next());
-		assertEquals("1:ID is wrong", "3", results.getString(1));
-		assertEquals("2:Name is wrong", "(@Jason)", results.getString(2));
-		assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
-		assertTrue(results.next());
-		assertEquals("1:ID is wrong", "4", results.getString(1));
-		assertEquals("2:Name is wrong", "Robert", results.getString(2));
-		assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
-		assertFalse(results.next());
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM evonix"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("ID", metadata.getColumnName(1));
+			assertEquals("Name", metadata.getColumnName(2));
+			assertEquals("Birthday", metadata.getColumnName(3));
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "0", results.getString(1));
+			assertEquals("2:Name is wrong", "(Florian)", results.getString(2));
+			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "1", results.getString(1));
+			assertEquals("2:Name is wrong", "(Tobias)", results.getString(2));
+			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "2", results.getString(1));
+			assertEquals("2:Name is wrong", "(#Mark)", results.getString(2));
+			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "3", results.getString(1));
+			assertEquals("2:Name is wrong", "(@Jason)", results.getString(2));
+			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "4", results.getString(1));
+			assertEquals("2:Name is wrong", "Robert", results.getString(2));
+			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -3375,19 +3585,21 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("separator", "#@");
 		props.put("commentChar", "rem");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM evonix");
 
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("ID", metadata.getColumnName(1));
-		assertEquals("Name", metadata.getColumnName(2));
-		assertEquals("Birthday", metadata.getColumnName(3));
-		assertTrue(results.next());
-		assertEquals("1:ID is wrong", "0", results.getString(1));
-		assertEquals("2:Name is wrong", "(Florian)", results.getString(2));
-		assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM evonix"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("ID", metadata.getColumnName(1));
+			assertEquals("Name", metadata.getColumnName(2));
+			assertEquals("Birthday", metadata.getColumnName(3));
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "0", results.getString(1));
+			assertEquals("2:Name is wrong", "(Florian)", results.getString(2));
+			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+		}
 	}
 
 	@Test
@@ -3396,18 +3608,20 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("commentChar", "#");
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM nodata");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM nodata"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("Aleph", metadata.getColumnName(1));
+			assertEquals("Beth", metadata.getColumnName(2));
+			assertEquals("Ghimel", metadata.getColumnName(3));
+			assertEquals("Daleth", metadata.getColumnName(4));
 
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("Aleph", metadata.getColumnName(1));
-		assertEquals("Beth", metadata.getColumnName(2));
-		assertEquals("Ghimel", metadata.getColumnName(3));
-		assertEquals("Daleth", metadata.getColumnName(4));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -3416,117 +3630,128 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("commentChar", "#");
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM only_comments");
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM only_comments"))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testConnectionName() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath);
-		String url = conn.getMetaData().getURL();
-		assertTrue(url.startsWith("jdbc:relique:csv:"));
-		assertTrue(url.endsWith(File.separator + "testdata" + File.separator) || url.endsWith(File.separator + "testdata"));
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath))
+		{
+			String url = conn.getMetaData().getURL();
+			assertTrue(url.startsWith("jdbc:relique:csv:"));
+			assertTrue(url.endsWith(File.separator + "testdata" + File.separator) || url.endsWith(File.separator + "testdata"));
+		}
 	}
 
 	@Test
 	public void testConnectionClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath);
-		assertTrue(conn.isValid(0));
-		assertFalse(conn.isClosed());
-		conn.close();
-		assertTrue(conn.isClosed());
-		assertFalse(conn.isValid(0));
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath))
+		{
+			assertTrue(conn.isValid(0));
+			assertFalse(conn.isClosed());
+			conn.close();
+			assertTrue(conn.isClosed());
+			assertFalse(conn.isValid(0));
 
-		/*
-		 * Second close is ignored.
-		 */
-		conn.close();
-		try
-		{
-			conn.createStatement();
-			fail("expected exception java.sql.SQLException");			
-		}
-		catch (SQLException e)
-		{
-			assertEquals("wrong exception and/or exception text!",
-				"java.sql.SQLException: " + CsvResources.getString("closedConnection"), "" + e);
+			/*
+			 * Second close is ignored.
+			 */
+			conn.close();
+			try
+			{
+				conn.createStatement();
+				fail("expected exception java.sql.SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("wrong exception and/or exception text!",
+					"java.sql.SQLException: " + CsvResources.getString("closedConnection"), "" + e);
+			}
 		}
 	}
 
 	@Test
 	public void testStatementClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		Statement stmt = conn.createStatement();
-		assertFalse(stmt.isClosed());
-		stmt.close();
-		assertTrue(stmt.isClosed());
-
-		/*
-		 * Second close is ignored.
-		 */
-		stmt.close();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM sample");
-			fail("expected exception java.sql.SQLException");			
-		}
-		catch (SQLException e)
-		{
-			assertEquals("wrong exception and/or exception text!",
-				"java.sql.SQLException: " + CsvResources.getString("statementClosed"), "" + e);
+			assertFalse(stmt.isClosed());
+			stmt.close();
+			assertTrue(stmt.isClosed());
+
+			/*
+			 * Second close is ignored.
+			 */
+			stmt.close();
+
+			try
+			{
+				stmt.executeQuery("SELECT * FROM sample");
+				fail("expected exception java.sql.SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("wrong exception and/or exception text!",
+					"java.sql.SQLException: " + CsvResources.getString("statementClosed"), "" + e);
+			}
 		}
 	}
 
 	@Test
 	public void testConnectionClosesStatements() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		Statement stmt1 = conn.createStatement();
-		Statement stmt2 = conn.createStatement();
-		Statement stmt3 = conn.createStatement();
-		Statement stmt4 = conn.createStatement();
+			Statement stmt1 = conn.createStatement();
+			Statement stmt2 = conn.createStatement();
+			Statement stmt3 = conn.createStatement();
+			Statement stmt4 = conn.createStatement())
+		{
+			conn.close();
 
-		conn.close();
-
-		assertTrue(stmt1.isClosed());
-		assertTrue(stmt2.isClosed());
-		assertTrue(stmt3.isClosed());
-		assertTrue(stmt4.isClosed());
+			assertTrue(stmt1.isClosed());
+			assertTrue(stmt2.isClosed());
+			assertTrue(stmt3.isClosed());
+			assertTrue(stmt4.isClosed());
+		}
 	}
 
 	@Test
 	public void testStatementCancelled() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-			stmt.cancel();
-			results.next();
-			fail("expected exception java.sql.SQLException: Statement cancelled");
+			try
+			{
+				try (ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
+				{
+					stmt.cancel();
+					results.next();
+				}
+				fail("expected exception java.sql.SQLException: Statement cancelled");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("wrong exception and/or exception text!",
+						"java.sql.SQLException: " + CsvResources.getString("statementCancelled"),
+						"" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("wrong exception and/or exception text!",
-					"java.sql.SQLException: " + CsvResources.getString("statementCancelled"),
-					"" + e);
-		}
-
-		conn.close();
 	}
 
 	@Test
@@ -3536,46 +3761,47 @@ public class TestCsvDriver
 		props.put("trimHeaders", "true");
 		props.put("trimValues", "true");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM foodstuffs");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM foodstuffs"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("Column Count", 2, metadata.getColumnCount());
+			assertEquals("Column Name 1", "key", metadata.getColumnName(1));
+			assertEquals("Column Name 2", "value", metadata.getColumnName(2));
 
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("Column Count", 2, metadata.getColumnCount());
-		assertEquals("Column Name 1", "key", metadata.getColumnName(1));
-		assertEquals("Column Name 2", "value", metadata.getColumnName(2));
-		
-		assertTrue(results.next());
-		assertEquals("Row 1 key", "orange", results.getString(1));
-		assertEquals("Row 1 value", "fruit", results.getString(2));
-		
-		assertTrue(results.next());
-		assertEquals("Row 2 key", "apple", results.getString(1));
-		assertEquals("Row 2 value", "fruit", results.getString(2));
-		
-		assertTrue(results.next());
-		assertEquals("Row 3 key", "corn", results.getString(1));
-		assertEquals("Row 3 value", "vegetable", results.getString(2));
-		
-		assertTrue(results.next());
-		assertEquals("Row 4 key", "lemon", results.getString(1));
-		assertEquals("Row 4 value", "fruit", results.getString(2));
-		
-		assertTrue(results.next());
-		assertEquals("Row 5 key", "tomato", results.getString(1));
-		assertEquals("Row 5 value", "who knows?", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("Row 1 key", "orange", results.getString(1));
+			assertEquals("Row 1 value", "fruit", results.getString(2));
 
-		assertTrue(results.next());
-		assertEquals("Row 6 key", " - ", results.getString(1));
-		assertEquals("Row 6 value", " - ", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("Row 2 key", "apple", results.getString(1));
+			assertEquals("Row 2 value", "fruit", results.getString(2));
 
-		assertFalse(results.next());
+			assertTrue(results.next());
+			assertEquals("Row 3 key", "corn", results.getString(1));
+			assertEquals("Row 3 value", "vegetable", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals("Row 4 key", "lemon", results.getString(1));
+			assertEquals("Row 4 value", "fruit", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals("Row 5 key", "tomato", results.getString(1));
+			assertEquals("Row 5 value", "who knows?", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals("Row 6 key", " - ", results.getString(1));
+			assertEquals("Row 6 value", " - ", results.getString(2));
+
+			assertFalse(results.next());
+		}
 	}
 
 	/**
 	 * you can access columns that do not have a name by number
-	 * 
+	 *
 	 * @throws SQLException
 	 * @throws ParseException
 	 */
@@ -3585,37 +3811,38 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		//props.put("defectiveHeaders", "True");
-		
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM twoheaders");
-
-		ResultSetMetaData metadata = results.getMetaData();
-
-		assertEquals("Empty Column Name 1", "", metadata.getColumnName(1));
-
-		assertTrue(results.next());
-		assertEquals("1 is wrong", "", results.getString(1));
-		try
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM twoheaders"))
 		{
-			results.getString("");
-			fail("expected exception java.sql.SQLException: Can't access columns with empty name by name");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("wrong exception and/or exception text!",
-					"java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": ",
-					"" + e);
-		}
+			ResultSetMetaData metadata = results.getMetaData();
 
-		assertEquals("2 is wrong", "WNS925", results.getString(2));
-		assertEquals("2 is wrong", "WNS925", results.getString("600-P1201"));
+			assertEquals("Empty Column Name 1", "", metadata.getColumnName(1));
 
-		assertTrue(results.next());
-		assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject(1));
-		assertEquals("2 is wrong", "21", results.getString(2));
-		assertEquals("3 is wrong", "20", results.getString(3));
+			assertTrue(results.next());
+			assertEquals("1 is wrong", "", results.getString(1));
+			try
+			{
+				results.getString("");
+				fail("expected exception java.sql.SQLException: Can't access columns with empty name by name");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("wrong exception and/or exception text!",
+						"java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": ",
+						"" + e);
+			}
+
+			assertEquals("2 is wrong", "WNS925", results.getString(2));
+			assertEquals("2 is wrong", "WNS925", results.getString("600-P1201"));
+
+			assertTrue(results.next());
+			assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject(1));
+			assertEquals("2 is wrong", "21", results.getString(2));
+			assertEquals("3 is wrong", "20", results.getString(3));
+		}
 	}
 
 	@Test
@@ -3624,29 +3851,30 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("defectiveHeaders", "True");
-		
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM twoheaders");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM twoheaders"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("Incorrect Column Name 1", "COLUMN1", metadata.getColumnName(1));
+			assertEquals("Incorrect Column Name 2", "600-P1201", metadata.getColumnName(2));
 
-		assertEquals("Incorrect Column Name 1", "COLUMN1", metadata.getColumnName(1));
-		assertEquals("Incorrect Column Name 2", "600-P1201", metadata.getColumnName(2));
+			assertTrue(results.next());
+			assertEquals("1 is wrong", "", results.getString(1));
+			assertEquals("1 is wrong", "", results.getString("COLUMN1"));
 
-		assertTrue(results.next());
-		assertEquals("1 is wrong", "", results.getString(1));
-		assertEquals("1 is wrong", "", results.getString("COLUMN1"));
+			assertEquals("2 is wrong", "WNS925", results.getString(2));
+			assertEquals("2 is wrong", "WNS925", results.getString("600-P1201"));
 
-		assertEquals("2 is wrong", "WNS925", results.getString(2));
-		assertEquals("2 is wrong", "WNS925", results.getString("600-P1201"));
-
-		assertTrue(results.next());
-		assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject(1));
-		assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject("COLUMN1"));
-		assertEquals("2 is wrong", "21", results.getObject(2));
-		assertEquals("3 is wrong", "20", results.getObject(3));
+			assertTrue(results.next());
+			assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject(1));
+			assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject("COLUMN1"));
+			assertEquals("2 is wrong", "21", results.getObject(2));
+			assertEquals("3 is wrong", "20", results.getObject(3));
+		}
 	}
 
 	@Test
@@ -3654,26 +3882,27 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("defectiveHeaders", "True");
-		
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM defectiveheader");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM defectiveheader"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
 
-		ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("Incorrect Column Name 1", "IDX", metadata.getColumnName(1));
+			assertEquals("Incorrect Column Name 2", "COLUMN2", metadata.getColumnName(2));
+			assertEquals("Incorrect Column Name 3", "COLUMN3", metadata.getColumnName(3));
+			assertEquals("Incorrect Column Name 4", "COMMENT", metadata.getColumnName(4));
+			assertEquals("Incorrect Column Name 5", "COLUMN5", metadata.getColumnName(5));
 
-		assertEquals("Incorrect Column Name 1", "IDX", metadata.getColumnName(1));
-		assertEquals("Incorrect Column Name 2", "COLUMN2", metadata.getColumnName(2));
-		assertEquals("Incorrect Column Name 3", "COLUMN3", metadata.getColumnName(3));
-		assertEquals("Incorrect Column Name 4", "COMMENT", metadata.getColumnName(4));
-		assertEquals("Incorrect Column Name 5", "COLUMN5", metadata.getColumnName(5));
-
-		assertTrue(results.next());
-		assertEquals("1 is wrong", "178", results.getString(1));
-		assertEquals("2 is wrong", "AAX", results.getString("COLUMN2"));
-		assertEquals("3 is wrong", "ED+", results.getString(3));
-		assertEquals("4 is wrong", "NONE", results.getString(4));
-		assertEquals("5 is wrong", "T", results.getString("COLUMN5"));
+			assertTrue(results.next());
+			assertEquals("1 is wrong", "178", results.getString(1));
+			assertEquals("2 is wrong", "AAX", results.getString("COLUMN2"));
+			assertEquals("3 is wrong", "ED+", results.getString(3));
+			assertEquals("4 is wrong", "NONE", results.getString(4));
+			assertEquals("5 is wrong", "T", results.getString("COLUMN5"));
+		}
 	}
 
 	@Test
@@ -3684,21 +3913,21 @@ public class TestCsvDriver
 		props.put("columnTypes", "Timestamp,Double");
 		props.put("defectiveHeaders", "True");
 		props.put("skipLeadingDataLines", "1");
-		
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM twoheaders");
-
-		assertTrue(results.next());
-		assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
-				.getObject(1)));
-		assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
-				.getObject("COLUMN1")));
-		assertEquals("2 is wrong", Double.valueOf(21), results.getObject(2));
-		assertEquals("3 is wrong", Double.valueOf(20), results.getObject(3));
-		assertEquals("4 is wrong", Double.valueOf(24), results.getObject(4));
-
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM twoheaders"))
+		{
+			assertTrue(results.next());
+			assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
+					.getObject(1)));
+			assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
+					.getObject("COLUMN1")));
+			assertEquals("2 is wrong", Double.valueOf(21), results.getObject(2));
+			assertEquals("3 is wrong", Double.valueOf(20), results.getObject(3));
+			assertEquals("4 is wrong", Double.valueOf(24), results.getObject(4));
+		}
 	}
 
 	@Test
@@ -3714,20 +3943,19 @@ public class TestCsvDriver
 		// Datum,Tijd,Station,P000,P001,P002,P003
 		props.put("columnTypes", "String,Date,Time,String,Double");
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-
-		results = stmt.executeQuery("SELECT * FROM varlen1");
-		assertTrue(results.next());
-		assertEquals("007", results.getObject("Station"));
-		assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
-		assertTrue(results.next());
-		assertEquals("001", results.getObject("Station"));
-		assertEquals(Double.valueOf("26.55"), results.getObject("P003"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM varlen1"))
+		{
+			assertTrue(results.next());
+			assertEquals("007", results.getObject("Station"));
+			assertEquals(Double.valueOf("26.54"), results.getObject("P003"));
+			assertTrue(results.next());
+			assertEquals("001", results.getObject("Station"));
+			assertEquals(Double.valueOf("26.55"), results.getObject("P003"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -3742,47 +3970,45 @@ public class TestCsvDriver
 		props.put("columnNames", "Datum,Tijd,Station,P000,P001,P002,P003,INDEX");
 		props.put("ignoreNonParseableLines", "True");
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-
-		results = stmt.executeQuery("SELECT * FROM varlen");
-		assertTrue(results.next());
-		assertEquals("1", results.getObject("index"));
-		assertEquals("007", results.getObject("Station"));
-		assertEquals("26.54", results.getObject("P001"));
-		assertTrue(results.next());
-		assertEquals("007", results.getObject("Station"));
-		assertEquals("22.99", results.getObject("P001"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM varlen"))
+		{
+			assertTrue(results.next());
+			assertEquals("1", results.getObject("index"));
+			assertEquals("007", results.getObject("Station"));
+			assertEquals("26.54", results.getObject("P001"));
+			assertTrue(results.next());
+			assertEquals("007", results.getObject("Station"));
+			assertEquals("22.99", results.getObject("P001"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testWrongColumnCount() throws SQLException
 	{
 		Properties props = new Properties();
-		ResultSet results = null;
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-
-		results = stmt.executeQuery("SELECT * FROM wrong_column_count");
-
-		try
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM wrong_column_count"))
 		{
-			while(results.next())
+			try
 			{
+				while(results.next())
+				{
+				}
+				fail("Should raise a java.sqlSQLException");
 			}
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			// Should fail with the line number in message.
-			assertTrue(e.getMessage().contains(CsvResources.getString("wrongColumnCount")));
-			assertTrue(e.getMessage().contains("137"));
+			catch (SQLException e)
+			{
+				// Should fail with the line number in message.
+				assertTrue(e.getMessage().contains(CsvResources.getString("wrongColumnCount")));
+				assertTrue(e.getMessage().contains("137"));
+			}
 		}
 	}
 
@@ -3797,28 +4023,27 @@ public class TestCsvDriver
 		// Datum,Tijd,Station,P000,P001,P002,P003
 		props.put("columnNames", "Datum,Tijd,Station,P000,P001,P002,P003,INDEX");
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-
-		results = stmt.executeQuery("SELECT * FROM varlen");
-		assertTrue(results.next());
-		assertEquals("1", results.getObject("index"));
-		assertEquals("007", results.getObject("Station"));
-		assertEquals("26.54", results.getObject("P001"));
-		assertTrue(results.next());
-		assertEquals("007", results.getObject("Station"));
-		assertEquals("22.99", results.getObject("P001"));
-		try
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM varlen"))
 		{
-			results.next();
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertTrue(("" + e).contains(CsvResources.getString("wrongColumnCount")));
+			assertTrue(results.next());
+			assertEquals("1", results.getObject("index"));
+			assertEquals("007", results.getObject("Station"));
+			assertEquals("26.54", results.getObject("P001"));
+			assertTrue(results.next());
+			assertEquals("007", results.getObject("Station"));
+			assertEquals("22.99", results.getObject("P001"));
+			try
+			{
+				results.next();
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(("" + e).contains(CsvResources.getString("wrongColumnCount")));
+			}
 		}
 	}
 
@@ -3838,19 +4063,18 @@ public class TestCsvDriver
 			props.put("locale", Locale.US.toString());
 		}
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-
-		results = stmt.executeQuery("SELECT T FROM yogesh");
-		assertTrue(results.next());
-		Timestamp got = results.getTimestamp(1);
-		assertEquals("2013-11-25 13:29:07", toUTC.format(got));
-		assertTrue(results.next());
-		got = results.getTimestamp(1);
-		assertEquals("2013-12-06 11:52:21", toUTC.format(got));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT T FROM yogesh"))
+		{
+			assertTrue(results.next());
+			Timestamp got = results.getTimestamp(1);
+			assertEquals("2013-11-25 13:29:07", toUTC.format(got));
+			assertTrue(results.next());
+			got = results.getTimestamp(1);
+			assertEquals("2013-12-06 11:52:21", toUTC.format(got));
+		}
 	}
 
 	@Test
@@ -3864,22 +4088,21 @@ public class TestCsvDriver
 		props.put("columnTypes", "Int,Timestamp");
 		props.put("locale", Locale.GERMANY.toString());
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-
-		results = stmt.executeQuery("SELECT T FROM yogesh_de");
-		assertTrue(results.next());
-		Timestamp got = results.getTimestamp(1);
-		LocalDateTime gotLocalDateTimeUTC = LocalDateTime.ofInstant(got.toInstant(), ZoneId.of("UTC"));
-		// Expect formatted UTC timestamps to be identical to UTC timestamps read from file
-		assertEquals("2013-10-25 13:29:07", gotLocalDateTimeUTC.format(toUTCDateTimeFormatter));
-		assertTrue(results.next());
-		got = results.getTimestamp(1);
-		gotLocalDateTimeUTC = LocalDateTime.ofInstant(got.toInstant(), ZoneId.of("UTC"));
-		assertEquals("2013-12-06 11:52:21", gotLocalDateTimeUTC.format(toUTCDateTimeFormatter));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT T FROM yogesh_de"))
+		{
+			assertTrue(results.next());
+			Timestamp got = results.getTimestamp(1);
+			LocalDateTime gotLocalDateTimeUTC = LocalDateTime.ofInstant(got.toInstant(), ZoneId.of("UTC"));
+			// Expect formatted UTC timestamps to be identical to UTC timestamps read from file
+			assertEquals("2013-10-25 13:29:07", gotLocalDateTimeUTC.format(toUTCDateTimeFormatter));
+			assertTrue(results.next());
+			got = results.getTimestamp(1);
+			gotLocalDateTimeUTC = LocalDateTime.ofInstant(got.toInstant(), ZoneId.of("UTC"));
+			assertEquals("2013-12-06 11:52:21", gotLocalDateTimeUTC.format(toUTCDateTimeFormatter));
+		}
 	}
 
 	@Test
@@ -3890,25 +4113,26 @@ public class TestCsvDriver
 		props.put("timeZoneName", "Europe/Rome");
 		props.put("columnTypes", "Int,String,String,Timestamp");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample5 WHERE ID=9 OR ID=1");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample5 WHERE ID=9 OR ID=1"))
+		{
+			assertTrue(results.next());
+			// TODO: getString miserably fails!
+			//assertEquals("2001-01-02 12:30:00.0", results.getString("start"));
+			Timestamp got = (Timestamp) results.getObject("start");
+			assertEquals("2001-01-02 11:30:00", toUTC.format(got));
+			got = results.getTimestamp("start");
+			assertEquals("2001-01-02 11:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		// TODO: getString miserably fails!
-		//assertEquals("2001-01-02 12:30:00.0", results.getString("start"));
-		Timestamp got = (Timestamp) results.getObject("start");
-		assertEquals("2001-01-02 11:30:00", toUTC.format(got));
-		got = results.getTimestamp("start");
-		assertEquals("2001-01-02 11:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = results.getTimestamp("start");
+			assertEquals("2004-04-02 10:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = results.getTimestamp("start");
-		assertEquals("2004-04-02 10:30:00", toUTC.format(got));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -3919,25 +4143,26 @@ public class TestCsvDriver
 		props.put("timeZoneName", "America/Santiago");
 		props.put("columnTypes", "Int,String,String,Timestamp");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample5 WHERE ID=9 OR ID=1");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample5 WHERE ID=9 OR ID=1"))
+		{
+			assertTrue(results.next());
+			// TODO: getString miserably fails!
+			//assertEquals("2001-01-02 12:30:00", results.getString("start"));
+			Timestamp got = (Timestamp) results.getObject("start");
+			assertEquals("2001-01-02 15:30:00", toUTC.format(got));
+			got = results.getTimestamp("start");
+			assertEquals("2001-01-02 15:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		// TODO: getString miserably fails!
-		//assertEquals("2001-01-02 12:30:00", results.getString("start"));
-		Timestamp got = (Timestamp) results.getObject("start");
-		assertEquals("2001-01-02 15:30:00", toUTC.format(got));
-		got = results.getTimestamp("start");
-		assertEquals("2001-01-02 15:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = results.getTimestamp("start");
+			assertEquals("2004-04-02 16:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = results.getTimestamp("start");
-		assertEquals("2004-04-02 16:30:00", toUTC.format(got));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -3948,25 +4173,26 @@ public class TestCsvDriver
 		props.put("timeZoneName", "GMT+04:00");
 		props.put("columnTypes", "Int,String,String,Timestamp");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample5 WHERE ID=9 OR ID=1");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample5 WHERE ID=9 OR ID=1"))
+		{
+			assertTrue(results.next());
+			// TODO: getString miserably fails!
+			// assertEquals("2001-01-02 12:30:00", results.getString("start"));
+			Timestamp got = (Timestamp) results.getObject("start");
+			assertEquals("2001-01-02 08:30:00", toUTC.format(got));
+			got = results.getTimestamp("start");
+			assertEquals("2001-01-02 08:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		// TODO: getString miserably fails!
-		// assertEquals("2001-01-02 12:30:00", results.getString("start"));
-		Timestamp got = (Timestamp) results.getObject("start");
-		assertEquals("2001-01-02 08:30:00", toUTC.format(got));
-		got = results.getTimestamp("start");
-		assertEquals("2001-01-02 08:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = results.getTimestamp("start");
+			assertEquals("2004-04-02 08:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = results.getTimestamp("start");
-		assertEquals("2004-04-02 08:30:00", toUTC.format(got));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -3977,25 +4203,26 @@ public class TestCsvDriver
 		props.put("timeZoneName", "GMT-04:00");
 		props.put("columnTypes", "Int,String,String,Timestamp");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample5 WHERE ID=9 OR ID=1");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample5 WHERE ID=9 OR ID=1"))
+		{
+			assertTrue(results.next());
+			// TODO: getString miserably fails!
+			// assertEquals("2001-01-02 12:30:00", results.getString("start"));
+			Timestamp got = (Timestamp) results.getObject("start");
+			assertEquals("2001-01-02 16:30:00", toUTC.format(got));
+			got = results.getTimestamp("start");
+			assertEquals("2001-01-02 16:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		// TODO: getString miserably fails!
-		// assertEquals("2001-01-02 12:30:00", results.getString("start"));
-		Timestamp got = (Timestamp) results.getObject("start");
-		assertEquals("2001-01-02 16:30:00", toUTC.format(got));
-		got = results.getTimestamp("start");
-		assertEquals("2001-01-02 16:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = results.getTimestamp("start");
+			assertEquals("2004-04-02 16:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = results.getTimestamp("start");
-		assertEquals("2004-04-02 16:30:00", toUTC.format(got));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -4006,39 +4233,40 @@ public class TestCsvDriver
 		props.put("timeZoneName", "Europe/Athens");
 		props.put("columnTypes", "Int,String,Date,Time");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 		Statement stmt = conn.createStatement();
 		ResultSet results = stmt
-				.executeQuery("SELECT ID, NAME, D + T as DT FROM sample8");
+				.executeQuery("SELECT ID, NAME, D + T as DT FROM sample8"))
+		{
+			assertTrue(results.next());
+			// TODO: getString miserably fails!
+			//assertEquals("2001-01-02 12:30:00", results.getString("start"));
+			Timestamp got = (Timestamp) results.getObject("DT");
+			assertEquals("2010-01-01 23:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		// TODO: getString miserably fails!
-		//assertEquals("2001-01-02 12:30:00", results.getString("start"));
-		Timestamp got = (Timestamp) results.getObject("DT");
-		assertEquals("2010-01-01 23:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2010-02-01 23:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2010-02-01 23:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2010-03-27 23:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2010-03-27 23:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2010-03-28 02:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2010-03-28 02:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2009-10-24 22:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2009-10-24 22:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2009-10-25 03:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2009-10-25 03:30:00", toUTC.format(got));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -4049,39 +4277,40 @@ public class TestCsvDriver
 		props.put("timeZoneName", "GMT-05:00");
 		props.put("columnTypes", "Int,String,Date,Time");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT ID, NAME, D + T as DT FROM sample8");
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT ID, NAME, D + T as DT FROM sample8"))
+		{
+			assertTrue(results.next());
+			// TODO: getString miserably fails!
+			//assertEquals("2001-01-02 12:30:00", results.getString("start"));
+			Timestamp got = (Timestamp) results.getObject("DT");
+			assertEquals("2010-01-02 06:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		// TODO: getString miserably fails!
-		//assertEquals("2001-01-02 12:30:00", results.getString("start"));
-		Timestamp got = (Timestamp) results.getObject("DT");
-		assertEquals("2010-01-02 06:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2010-02-02 06:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2010-02-02 06:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2010-03-28 06:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2010-03-28 06:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2010-03-28 10:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2010-03-28 10:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2009-10-25 06:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2009-10-25 06:30:00", toUTC.format(got));
+			assertTrue(results.next());
+			got = (Timestamp) results.getObject("DT");
+			assertEquals("2009-10-25 10:30:00", toUTC.format(got));
 
-		assertTrue(results.next());
-		got = (Timestamp) results.getObject("DT");
-		assertEquals("2009-10-25 10:30:00", toUTC.format(got));
-
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -4092,25 +4321,27 @@ public class TestCsvDriver
 		props.put("quotechar", "'");
 		props.put("fileExtension", ".txt");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM uses_quotes");
-		assertTrue(results.next());
-		assertEquals("uno", results.getObject("COLUMN2"));
-		assertTrue(results.next());
-		assertEquals("a 'quote' (source unknown)", results.getObject("COLUMN2"));
-		assertTrue(results.next());
-		assertEquals("another \"quote\" (also unkown)", results.getObject("COLUMN2"));
-		assertTrue(results.next());
-		assertEquals("a 'quote\" that gives error", results.getObject("COLUMN2"));
-		assertTrue(results.next());
-		assertEquals("another not parsable \"quote'", results.getObject("COLUMN2"));
-		assertTrue(results.next());
-		assertEquals("collecting quotes \"\"''", results.getObject("COLUMN2"));
-		assertFalse(results.next());
+			ResultSet results = stmt.executeQuery("SELECT * FROM uses_quotes"))
+		{
+			assertTrue(results.next());
+			assertEquals("uno", results.getObject("COLUMN2"));
+			assertTrue(results.next());
+			assertEquals("a 'quote' (source unknown)", results.getObject("COLUMN2"));
+			assertTrue(results.next());
+			assertEquals("another \"quote\" (also unkown)", results.getObject("COLUMN2"));
+			assertTrue(results.next());
+			assertEquals("a 'quote\" that gives error", results.getObject("COLUMN2"));
+			assertTrue(results.next());
+			assertEquals("another not parsable \"quote'", results.getObject("COLUMN2"));
+			assertTrue(results.next());
+			assertEquals("collecting quotes \"\"''", results.getObject("COLUMN2"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -4121,216 +4352,235 @@ public class TestCsvDriver
 		props.put("separator", ";");
 		props.put("columnTypes", "String,String,Double");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM sample");
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next()); // Mackie Messer
-		assertEquals(Double.valueOf(34.1), results.getObject(3));
-		assertTrue(results.next()); // Polly Peachum
-		assertEquals(Double.valueOf(30.5), results.getObject(3));
+			ResultSet results = stmt
+				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM sample"))
+		{
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next()); // Mackie Messer
+			assertEquals(Double.valueOf(34.1), results.getObject(3));
+			assertTrue(results.next()); // Polly Peachum
+			assertEquals(Double.valueOf(30.5), results.getObject(3));
+		}
 	}
 
 	@Test
 	public void testLiteral() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT name, id, 'Bananas' as t FROM sample");
-
-		results.next();
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
-		assertEquals("Incorrect ID Value", "Bananas", results.getString("t"));
-		results.next();
-		assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
-		results.next();
-		assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
-		results.next();
-		assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
+			ResultSet results = stmt
+				.executeQuery("SELECT name, id, 'Bananas' as t FROM sample"))
+		{
+			results.next();
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
+			assertEquals("Incorrect ID Value", "Bananas", results.getString("t"));
+			results.next();
+			assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
+			results.next();
+			assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
+			results.next();
+			assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
+		}
 	}
 
 	@Test
 	public void testTableNameAsAlias() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT sample.id FROM sample");
-
-		results.next();
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			ResultSet results = stmt.executeQuery("SELECT sample.id FROM sample"))
+		{
+			results.next();
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+		}
 	}
 
 	@Test
 	public void testTableAlias() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT S.id, s.Extra_field FROM sample S");
-
-		results.next();
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect ID Value", "F", results.getString("EXTRA_FIELD"));
-		assertEquals("Incorrect ID Value", "Q123", results.getString(1));
-		assertEquals("Incorrect ID Value", "F", results.getString(2));
+			ResultSet results = stmt
+				.executeQuery("SELECT S.id, s.Extra_field FROM sample S"))
+		{
+			results.next();
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect ID Value", "F", results.getString("EXTRA_FIELD"));
+			assertEquals("Incorrect ID Value", "Q123", results.getString(1));
+			assertEquals("Incorrect ID Value", "F", results.getString(2));
+		}
 	}
 
 	@Test
 	public void testTableAliasWithWhere() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample AS S where S.ID='A123'");
-
-		results.next();
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect ID Value", "A", results.getString("EXTRA_FIELD"));
-		assertEquals("Incorrect ID Value", "A123", results.getString(1));
-		assertEquals("Incorrect ID Value", "A", results.getString(3));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample AS S where S.ID='A123'"))
+		{
+			results.next();
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect ID Value", "A", results.getString("EXTRA_FIELD"));
+			assertEquals("Incorrect ID Value", "A123", results.getString(1));
+			assertEquals("Incorrect ID Value", "A", results.getString(3));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testMaxRows() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
-		stmt.setMaxRows(4);
-		assertEquals("getMaxRows() incorrect", 4, stmt.getMaxRows());
+			Statement stmt = conn.createStatement())
+		{
+			stmt.setMaxRows(4);
+			assertEquals("getMaxRows() incorrect", 4, stmt.getMaxRows());
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
-		// The maxRows value at the time of the query should be used, not the value below.
-		stmt.setMaxRows(7);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
+			// The maxRows value at the time of the query should be used, not the value below.
+			stmt.setMaxRows(7);
 
-		assertTrue("Reading row 1 failed", results.next());
-		assertTrue("Reading row 2 failed", results.next());
-		assertTrue("Reading row 3 failed", results.next());
-		assertTrue("Reading row 4 failed", results.next());
-		assertFalse("Stopping after row 4 failed", results.next());
+			assertTrue("Reading row 1 failed", results.next());
+			assertTrue("Reading row 2 failed", results.next());
+			assertTrue("Reading row 3 failed", results.next());
+			assertTrue("Reading row 4 failed", results.next());
+			assertFalse("Stopping after row 4 failed", results.next());
+		}
 	}
 
 	@Test
 	public void testFetchSize() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
-		stmt.setFetchSize(50);
-		assertEquals("getFetchSize() incorrect", 50, stmt.getFetchSize());
+			Statement stmt = conn.createStatement())
+		{
+			stmt.setFetchSize(50);
+			assertEquals("getFetchSize() incorrect", 50, stmt.getFetchSize());
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
-		assertEquals("getFetchSize() incorrect", 50, results.getFetchSize());
-		results.setFetchSize(20);
-		assertEquals("getFetchSize() incorrect", 20, results.getFetchSize());
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
+			assertEquals("getFetchSize() incorrect", 50, results.getFetchSize());
+			results.setFetchSize(20);
+			assertEquals("getFetchSize() incorrect", 20, results.getFetchSize());
+		}
 	}
 
 	@Test
 	public void testFetchDirection() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
-		stmt.setFetchDirection(ResultSet.FETCH_UNKNOWN);
-		assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_UNKNOWN, stmt.getFetchDirection());
+			Statement stmt = conn.createStatement())
+		{
+			stmt.setFetchDirection(ResultSet.FETCH_UNKNOWN);
+			assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_UNKNOWN, stmt.getFetchDirection());
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
-		assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_UNKNOWN, results.getFetchDirection());
-		results.setFetchDirection(ResultSet.FETCH_FORWARD);
-		assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_FORWARD, results.getFetchDirection());
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample5"))
+			{
+				assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_UNKNOWN, results.getFetchDirection());
+				results.setFetchDirection(ResultSet.FETCH_FORWARD);
+				assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_FORWARD, results.getFetchDirection());
+			}
+		}
 	}
 
 	@Test
 	public void testResultSet() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
-		// No query executed yet.
-		assertNull(stmt.getResultSet());
-		assertFalse(stmt.getMoreResults());
-		assertEquals("Update count wrong", -1, stmt.getUpdateCount());
+			Statement stmt = conn.createStatement())
+		{
+			// No query executed yet.
+			assertNull(stmt.getResultSet());
+			assertFalse(stmt.getMoreResults());
+			assertEquals("Update count wrong", -1, stmt.getUpdateCount());
 
-		ResultSet results1 = stmt.executeQuery("SELECT * FROM sample5");		
-		ResultSet results2 = stmt.getResultSet();
-		assertEquals("Result sets not equal", results1, results2);
-		assertEquals("Update count wrong", -1, stmt.getUpdateCount());
-		assertFalse(stmt.getMoreResults());
-		assertNull("Result set not null", stmt.getResultSet());
-		assertTrue("Result set was not closed", results1.isClosed());
+			ResultSet results1 = stmt.executeQuery("SELECT * FROM sample5");
+			ResultSet results2 = stmt.getResultSet();
+			assertEquals("Result sets not equal", results1, results2);
+			assertEquals("Update count wrong", -1, stmt.getUpdateCount());
+			assertFalse(stmt.getMoreResults());
+			assertNull("Result set not null", stmt.getResultSet());
+			assertTrue("Result set was not closed", results1.isClosed());
+		}
 	}
 
 	@Test
 	public void testResultSetClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
-
-		ResultSet results1 = stmt.executeQuery("SELECT * FROM sample5");
-		ResultSet results2 = stmt.executeQuery("SELECT * FROM sample");
-		assertTrue("First result set is not closed", results1.isClosed());
-		assertFalse("Second result set is closed", results2.isClosed());
-		try
+			Statement stmt = conn.createStatement();
+			ResultSet results1 = stmt.executeQuery("SELECT * FROM sample5");
+			ResultSet results2 = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results1.next();
-			fail("Closed result set should throw SQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			assertTrue("First result set is not closed", results1.isClosed());
+			assertFalse("Second result set is closed", results2.isClosed());
+			try
+			{
+				results1.next();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
 	}
 
 	@Test
 	public void testResultSetGetFromClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT ID FROM sample");
-		assertTrue(results.next());
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		results.close();
-		try
+			ResultSet results = stmt.executeQuery("SELECT ID FROM sample"))
 		{
-			results.getString("ID");
-			fail("Closed result set should throw SQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			assertTrue(results.next());
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			results.close();
+			try
+			{
+				results.getString("ID");
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
 	}
 
@@ -4338,99 +4588,115 @@ public class TestCsvDriver
 	public void testHeaderlineWithMultipleTables() throws SQLException
 	{
 		Properties props = new Properties();
-		// Define different headerline values for table banks and table transactions. 
+		// Define different headerline values for table banks and table transactions.
 		props.put("headerline.banks", "BLZ,BANK_NAME");
 		props.put("headerline.transactions", "TRANS_DATE,FROM_ACCT,FROM_BLZ,TO_ACCT,TO_BLZ,AMOUNT");
 		props.put("suppressHeaders", "true");
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM banks where BANK_NAME like 'Sparkasse%'");
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM banks where BANK_NAME like 'Sparkasse%'"))
+			{
+				// Check that column names from headerline are used for table banks.
+				assertEquals("BLZ wrong", "BLZ", results.getMetaData().getColumnName(1));
+				assertEquals("BANK_NAME wrong", "BANK_NAME", results.getMetaData().getColumnName(2));
+				assertFalse(results.next());
+			}
 
-		// Check that column names from headerline are used for table banks.
-		assertEquals("BLZ wrong", "BLZ", results.getMetaData().getColumnName(1));
-		assertEquals("BANK_NAME wrong", "BANK_NAME", results.getMetaData().getColumnName(2));
-		assertFalse(results.next());
-		results.close();
-		results = stmt.executeQuery("SELECT * FROM transactions");
-		assertTrue(results.next());
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM transactions"))
+			{
+				assertTrue(results.next());
 
-		// Check that column names for table transactions are correct too.
-		assertEquals("TRANS_DATE wrong", "19-10-2011", results.getString("TRANS_DATE"));
-		assertEquals("FROM_ACCT wrong", "3670345", results.getString("FROM_ACCT"));
-		assertEquals("AMOUNT wrong", "250.00", results.getString("AMOUNT"));
+				// Check that column names for table transactions are correct too.
+				assertEquals("TRANS_DATE wrong", "19-10-2011", results.getString("TRANS_DATE"));
+				assertEquals("FROM_ACCT wrong", "3670345", results.getString("FROM_ACCT"));
+				assertEquals("AMOUNT wrong", "250.00", results.getString("AMOUNT"));
+			}
+		}
 	}
 
 	@Test
 	public void testWarnings() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		assertTrue(results.next());
-		assertNull("Warnings should be null", results.getWarnings());
-		results.clearWarnings();
-		assertNull("Warnings should still be null", results.getWarnings());
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
+		{
+			assertTrue(results.next());
+			assertNull("Warnings should be null", results.getWarnings());
+			results.clearWarnings();
+			assertNull("Warnings should still be null", results.getWarnings());
+		}
 	}
 
 	@Test
 	public void testStringWasNull() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT ID FROM sample");
-		assertTrue(results.next());
-		assertEquals("ID wrong", "Q123", results.getString(1));
-		assertFalse(results.wasNull());
+			ResultSet results = stmt.executeQuery("SELECT ID FROM sample"))
+		{
+			assertTrue(results.next());
+			assertEquals("ID wrong", "Q123", results.getString(1));
+			assertFalse(results.wasNull());
+		}
 	}
 
 	@Test
 	public void testObjectWasNull() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT ID FROM sample");
-		assertTrue(results.next());
-		assertEquals("ID wrong", "Q123", results.getObject(1));
-		assertFalse(results.wasNull());
+			ResultSet results = stmt.executeQuery("SELECT ID FROM sample"))
+		{
+			assertTrue(results.next());
+			assertEquals("ID wrong", "Q123", results.getObject(1));
+			assertFalse(results.wasNull());
+		}
 	}
 
 	@Test
 	public void testTableReader() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" +
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" +
 			TableReaderTester.class.getName());
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM airline where code='BA'");
-		assertTrue(results.next());
-		assertEquals("NAME wrong", "British Airways", results.getString("NAME"));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM airline where code='BA'"))
+		{
+			assertTrue(results.next());
+			assertEquals("NAME wrong", "British Airways", results.getString("NAME"));
+		}
 	}
 
 	@Test
 	public void testTableReaderWithBadTable() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" +
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" +
 			TableReaderTester.class.getName());
-		Statement stmt = conn.createStatement();
-		try
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM X");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: Table does not exist: X", "" + e);
+			try
+			{
+				stmt.executeQuery("SELECT * FROM X");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: Table does not exist: X", "" + e);
+			}
 		}
 	}
 
@@ -4451,29 +4717,33 @@ public class TestCsvDriver
 	@Test
 	public void testTableReaderTables() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" +
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" +
 			TableReaderTester.class.getName());
-		ResultSet results = conn.getMetaData().getTables(null, null, "%", null);
-		assertTrue(results.next());
-		assertEquals("TABLE_NAME wrong", "AIRLINE", results.getString("TABLE_NAME"));
-		assertTrue(results.next());
-		assertEquals("TABLE_NAME wrong", "AIRPORT", results.getString("TABLE_NAME"));
-		assertFalse(results.next());
+			ResultSet results = conn.getMetaData().getTables(null, null, "%", null))
+		{
+			assertTrue(results.next());
+			assertEquals("TABLE_NAME wrong", "AIRLINE", results.getString("TABLE_NAME"));
+			assertTrue(results.next());
+			assertEquals("TABLE_NAME wrong", "AIRPORT", results.getString("TABLE_NAME"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testTableReaderMetadata() throws SQLException
 	{
 		String url = "jdbc:relique:csv:class:" + TableReaderTester.class.getName();
-		Connection conn = DriverManager.getConnection(url);
-		assertEquals("URL is wrong", url, conn.getMetaData().getURL());
+		try (Connection conn = DriverManager.getConnection(url))
+		{
+			assertEquals("URL is wrong", url, conn.getMetaData().getURL());
+		}
 	}
 
 	@Test
 	public void testPropertiesInURL() throws SQLException
-	{		
+	{
 		Properties props = new Properties();
-		
+
 		/*
 		 * Use same directory name logic as in CsvDriver.connect.
 		 */
@@ -4481,15 +4751,18 @@ public class TestCsvDriver
 		if (!path.endsWith(File.separator))
 			path += File.separator;
 		String url = "jdbc:relique:csv:" + path + "?suppressHeaders=true&headerline=BLZ,NAME&commentChar=%23&fileExtension=.txt";
-		Connection conn = DriverManager.getConnection(url, props);
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection(url, props);
+			Statement stmt = conn.createStatement())
+		{
+			assertEquals("The URL is wrong", url, conn.getMetaData().getURL());
 
-		assertEquals("The URL is wrong", url, conn.getMetaData().getURL());
-
-		ResultSet results = stmt.executeQuery("SELECT * FROM banks");
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", "10000000", results.getString("BLZ"));
-		assertEquals("The NAME is wrong", "Bundesbank (Berlin)", results.getString("NAME"));
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM banks"))
+			{
+				assertTrue(results.next());
+				assertEquals("The BLZ is wrong", "10000000", results.getString("BLZ"));
+				assertEquals("The NAME is wrong", "Bundesbank (Berlin)", results.getString("NAME"));
+			}
+		}
 	}
 
 	@Test
@@ -4504,12 +4777,14 @@ public class TestCsvDriver
 		if (!path.endsWith(File.separator))
 			path += File.separator;
 		String url = "jdbc:relique:csv:" + path + "?separator=;&fileExtension=";
-		Connection conn = DriverManager.getConnection(url, props);
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection(url, props);
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "Q123", results.getString("ID"));
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "Q123", results.getString("ID"));
+		}
 	}
 
 	@Test
@@ -4517,63 +4792,66 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("charset", "UTF-8");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("select id from sample5 where name = '\u00C9rica Jeanine M\u00e9ndez M\u00e9ndez'");
-
-		assertTrue(results.next());
-		assertEquals("Incorrect ID Value", "08", results.getString(1));
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("select id from sample5 where name = '\u00C9rica Jeanine M\u00e9ndez M\u00e9ndez'"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect ID Value", "08", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testDistinct() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("select distinct job from sample5");
-
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 1", "Piloto", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 2", "Project Manager", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 3", "Finance Manager", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 4", "Office Manager", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 5", "Office Employee", results.getString(1));
-		assertFalse(results.next());
+			ResultSet results = stmt.executeQuery("select distinct job from sample5"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 1", "Piloto", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 2", "Project Manager", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 3", "Finance Manager", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 4", "Office Manager", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 5", "Office Employee", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testDistinctWithAlias() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("select distinct S.job from sample5 S");
-
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 1", "Piloto", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 2", "Project Manager", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 3", "Finance Manager", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 4", "Office Manager", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct value 5", "Office Employee", results.getString(1));
-		assertFalse(results.next());
+			ResultSet results = stmt.executeQuery("select distinct S.job from sample5 S"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 1", "Piloto", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 2", "Project Manager", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 3", "Finance Manager", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 4", "Office Manager", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct value 5", "Office Employee", results.getString(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -4585,40 +4863,43 @@ public class TestCsvDriver
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select distinct TO_ACCT, TO_BLZ from transactions where AMOUNT<50");
+			Statement stmt = conn.createStatement();
 
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct TO_ACCT value 1", 27234813, results.getInt(1));
-		assertEquals("Incorrect distinct TO_BLZ value 1", 10020500, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("Incorrect distinct TO_ACCT value 2", 3670345, results.getInt(1));
-		assertEquals("Incorrect distinct TO_BLZ value 2", 10010010, results.getInt(2));
-		assertFalse(results.next());
+			ResultSet results = stmt.executeQuery("select distinct TO_ACCT, TO_BLZ from transactions where AMOUNT<50"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct TO_ACCT value 1", 27234813, results.getInt(1));
+			assertEquals("Incorrect distinct TO_BLZ value 1", 10020500, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("Incorrect distinct TO_ACCT value 2", 3670345, results.getInt(1));
+			assertEquals("Incorrect distinct TO_BLZ value 2", 10010010, results.getInt(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testNoTable() throws SQLException, ParseException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT 'Hello', 'World' as W, 5+7");
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT 'Hello', 'World' as W, 5+7"))
+		{
+			assertTrue(results.next());
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("column 1 type is incorrect", Types.VARCHAR, metadata.getColumnType(1));
+			assertEquals("column 2 type is incorrect", Types.VARCHAR, metadata.getColumnType(2));
+			assertEquals("column 3 type is incorrect", Types.INTEGER, metadata.getColumnType(3));
 
-		assertTrue(results.next());
-		ResultSetMetaData metadata = results.getMetaData();
-		assertEquals("column 1 type is incorrect", Types.VARCHAR, metadata.getColumnType(1));
-		assertEquals("column 2 type is incorrect", Types.VARCHAR, metadata.getColumnType(2));
-		assertEquals("column 3 type is incorrect", Types.INTEGER, metadata.getColumnType(3));
+			assertEquals("column 2 name is incorrect", "W", metadata.getColumnName(2));
 
-		assertEquals("column 2 name is incorrect", "W", metadata.getColumnName(2));
-
-		assertEquals("column 1 value is incorrect", "Hello", results.getString(1));
-		assertEquals("column 2 value is incorrect", "World", results.getString(2));
-		assertEquals("column 3 value is incorrect", 12, results.getInt(3));
-		assertFalse(results.next());
+			assertEquals("column 1 value is incorrect", "Hello", results.getString(1));
+			assertEquals("column 2 value is incorrect", "World", results.getString(2));
+			assertEquals("column 3 value is incorrect", 12, results.getInt(3));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -4626,178 +4907,161 @@ public class TestCsvDriver
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Timestamp,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ID FROM sample5 WHERE ID < 3");
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertFalse(results.next());
-		assertFalse(results.next());
-		assertFalse(results.next());
+			ResultSet results = stmt
+				.executeQuery("SELECT ID FROM sample5 WHERE ID < 3"))
+		{
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertFalse(results.next());
+			assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGetRow() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement())
+		{
+			// Select the ID and NAME columns from sample.csv
+			try (ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample"))
+			{
+				assertEquals("incorrect row #", 0, results.getRow());
+				assertFalse(results.isAfterLast());
+				assertTrue(results.next());
+				assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+				assertEquals("incorrect row #", 1, results.getRow());
+				assertFalse(results.isAfterLast());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 2, results.getRow());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 3, results.getRow());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 4, results.getRow());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 5, results.getRow());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 6, results.getRow());
+				assertFalse(results.next());
+				assertEquals("incorrect row #", 0, results.getRow());
+				assertTrue(results.isAfterLast());
+			}
 
-		// Select the ID and NAME columns from sample.csv
-		ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample");
+			try (ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample ORDER BY ID"))
+			{
+				assertEquals("incorrect row #", 0, results.getRow());
+				assertFalse(results.isAfterLast());
+				assertTrue(results.next());
+				assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+				assertEquals("incorrect row #", 1, results.getRow());
+				assertFalse(results.isAfterLast());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 2, results.getRow());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 3, results.getRow());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 4, results.getRow());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 5, results.getRow());
+				assertTrue(results.next());
+				assertEquals("incorrect row #", 6, results.getRow());
+				assertFalse(results.next());
+				assertEquals("incorrect row #", 0, results.getRow());
+				assertTrue(results.isAfterLast());
+			}
 
-		assertEquals("incorrect row #", 0, results.getRow());
-		assertFalse(results.isAfterLast());
-		assertTrue(results.next());
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertFalse(results.isAfterLast());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 2, results.getRow());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 3, results.getRow());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 4, results.getRow());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 5, results.getRow());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 6, results.getRow());
-		assertFalse(results.next());
-		assertEquals("incorrect row #", 0, results.getRow());
-		assertTrue(results.isAfterLast());
+			try (ResultSet results = stmt.executeQuery("SELECT COUNT(*) FROM sample"))
+			{
+				assertEquals("incorrect row #", 0, results.getRow());
+				assertFalse(results.isAfterLast());
+				assertTrue(results.next());
+				assertEquals("Incorrect COUNT Value", 6, results.getInt(1));
+				assertEquals("incorrect row #", 1, results.getRow());
+				assertFalse(results.isAfterLast());
+				assertFalse(results.next());
+				assertEquals("incorrect row #", 0, results.getRow());
+				assertTrue(results.isAfterLast());
+			}
 
-		results.close();
-
-		results = stmt.executeQuery("SELECT ID,NAME FROM sample ORDER BY ID");
-
-		assertEquals("incorrect row #", 0, results.getRow());
-		assertFalse(results.isAfterLast());
-		assertTrue(results.next());
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertFalse(results.isAfterLast());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 2, results.getRow());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 3, results.getRow());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 4, results.getRow());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 5, results.getRow());
-		assertTrue(results.next());
-		assertEquals("incorrect row #", 6, results.getRow());
-		assertFalse(results.next());
-		assertEquals("incorrect row #", 0, results.getRow());
-		assertTrue(results.isAfterLast());
-
-		results.close();
-
-		results = stmt.executeQuery("SELECT COUNT(*) FROM sample");
-
-		assertEquals("incorrect row #", 0, results.getRow());
-		assertFalse(results.isAfterLast());
-		assertTrue(results.next());
-		assertEquals("Incorrect COUNT Value", 6, results.getInt(1));
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertFalse(results.isAfterLast());
-		assertFalse(results.next());
-		assertEquals("incorrect row #", 0, results.getRow());
-		assertTrue(results.isAfterLast());
-
-		results.close();
-
-		// Test result set returning no rows.
-		results = stmt.executeQuery("SELECT * FROM sample WHERE ID = 'unknown'");
-
-		assertEquals("incorrect row #", 0, results.getRow());
-		assertFalse(results.isAfterLast());
-		assertFalse(results.next());
-		assertFalse(results.isAfterLast());
-
-		// clean up
-		results.close();
-		stmt.close();
-		conn.close();
+			// Test result set returning no rows.
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample WHERE ID = 'unknown'"))
+			{
+				assertEquals("incorrect row #", 0, results.getRow());
+				assertFalse(results.isAfterLast());
+				assertFalse(results.next());
+				assertFalse(results.isAfterLast());
+			}
+		}
 	}
-	
+
 	@Test
 	public void testNoCurrentRow() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		// Select the ID and NAME columns from sample.csv
-		ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample");
-
-		try
+			// Select the ID and NAME columns from sample.csv
+			ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample"))
 		{
-			results.getString(1);
-			fail("Should raise a java.sqlSQLException");
+			try
+			{
+				results.getString(1);
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		
-		// clean up
-		results.close();
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testWriteToCsv() throws SQLException, UnsupportedEncodingException, IOException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
-		PrintStream printStream = new PrintStream(byteStream);
+			Statement stmt = conn.createStatement();
 
-		/*
-		 * Check that writing ResultSet to CSV file generates exactly the same CSV file
-		 * that the query was originally read from.
-		 */
-		CsvDriver.writeToCsv(results, printStream, true);
-
-		BufferedReader reader1 = null;
-		BufferedReader reader2 = null;
-		try
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			reader1 = new BufferedReader(new FileReader(filePath + File.separator + "sample.csv"));
-			reader2 = new BufferedReader(new StringReader(byteStream.toString("US-ASCII")));
-			String line1 = reader1.readLine();
-			String line2 = reader2.readLine();
-	
-			while (line1 != null || line2 != null)
+			ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+			PrintStream printStream = new PrintStream(byteStream);
+
+			/*
+			 * Check that writing ResultSet to CSV file generates exactly the same CSV file
+			 * that the query was originally read from.
+			 */
+			CsvDriver.writeToCsv(results, printStream, true);
+
+			try (BufferedReader reader1 = new BufferedReader(new FileReader(filePath + File.separator + "sample.csv"));
+				BufferedReader reader2 = new BufferedReader(new StringReader(byteStream.toString("US-ASCII"))))
 			{
-				assertTrue("line1 is null", line1 != null);
-				assertTrue("line2 is null", line2 != null);
-				assertEquals("lines do not match", line1, line2);
-				line1 = reader1.readLine();
-				line2 = reader2.readLine();
+				String line1 = reader1.readLine();
+				String line2 = reader2.readLine();
+
+				while (line1 != null || line2 != null)
+				{
+					assertTrue("line1 is null", line1 != null);
+					assertTrue("line2 is null", line2 != null);
+					assertEquals("lines do not match", line1, line2);
+					line1 = reader1.readLine();
+					line2 = reader2.readLine();
+				}
 			}
 		}
-		finally
-		{
-			if (reader1 != null)
-				reader1.close();
-			if (reader2 != null)
-				reader2.close();
-		}
-		results.close();
-		stmt.close();
-		conn.close();
 	}
-	
+
 	@Test
 	public void testWriteToCsvWithDates() throws SQLException, UnsupportedEncodingException, IOException
 	{
@@ -4814,46 +5078,38 @@ public class TestCsvDriver
 			props.put("locale", Locale.US.toString());
 		}
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM sunil_date_time");
-		ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
-		PrintStream printStream = new PrintStream(byteStream);
-
-		/*
-		 * Check that writing ResultSet to CSV file generates exactly the same CSV file
-		 * that the query was originally read from.
-		 */
-		boolean writeHeaderLine = true;
-		CsvDriver.writeToCsv(results, printStream, writeHeaderLine);
-
-		BufferedReader reader1 = null;
-		BufferedReader reader2 = null;
-		try
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM sunil_date_time"))
 		{
-			reader1 = new BufferedReader(new FileReader(filePath + File.separator + "sunil_date_time.csv"));
-			reader2 = new BufferedReader(new StringReader(byteStream.toString("US-ASCII")));
-			String line1 = reader1.readLine();
-			String line2 = reader2.readLine();
+			ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+			PrintStream printStream = new PrintStream(byteStream);
 
-			while (line1 != null || line2 != null)
+			/*
+			 * Check that writing ResultSet to CSV file generates exactly the same CSV file
+			 * that the query was originally read from.
+			 */
+			boolean writeHeaderLine = true;
+			CsvDriver.writeToCsv(results, printStream, writeHeaderLine);
+
+			try (BufferedReader reader1 = new BufferedReader(new FileReader(filePath + File.separator + "sunil_date_time.csv"));
+				BufferedReader reader2 = new BufferedReader(new StringReader(byteStream.toString("US-ASCII"))))
 			{
-				assertTrue("line1 is null", line1 != null);
-				assertTrue("line2 is null", line2 != null);
-				assertTrue("lines do not match", line1.equalsIgnoreCase(line2));
-				line1 = reader1.readLine();
-				line2 = reader2.readLine();
+				String line1 = reader1.readLine();
+				String line2 = reader2.readLine();
+
+				while (line1 != null || line2 != null)
+				{
+					assertTrue("line1 is null", line1 != null);
+					assertTrue("line2 is null", line2 != null);
+					assertTrue("lines do not match", line1.equalsIgnoreCase(line2));
+					line1 = reader1.readLine();
+					line2 = reader2.readLine();
+				}
+				assertNull("line1 not empty", line1);
+				assertNull("line2 not empty", line2);
 			}
-			assertNull("line1 not empty", line1);
-			assertNull("line2 not empty", line2);
-		}
-		finally
-		{
-			if (reader1 != null)
-				reader1.close();
-			if (reader2 != null)
-				reader2.close();
 		}
 	}
 
@@ -4864,73 +5120,70 @@ public class TestCsvDriver
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Boolean");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt.executeQuery("SELECT * FROM bool");
-
-		assertTrue(results.next());
-		assertEquals("incorrect I", false, results.getBoolean(1));
-		assertEquals("incorrect J", true, results.getBoolean(2));
-		assertEquals("incorrect K", false, results.getBoolean(3));
-		assertEquals("incorrect L", true, results.getBoolean(4));
-		assertTrue(results.next());
-		assertEquals("incorrect I", true, results.getBoolean("I"));
-		assertEquals("incorrect J", false, results.getBoolean("J"));
-		assertEquals("incorrect K", false, results.getBoolean("K"));
-		assertEquals("incorrect L", false, results.getBoolean("L"));
-
-		results.close();
-		stmt.close();
-		conn.close();
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM bool"))
+		{
+			assertTrue(results.next());
+			assertEquals("incorrect I", false, results.getBoolean(1));
+			assertEquals("incorrect J", true, results.getBoolean(2));
+			assertEquals("incorrect K", false, results.getBoolean(3));
+			assertEquals("incorrect L", true, results.getBoolean(4));
+			assertTrue(results.next());
+			assertEquals("incorrect I", true, results.getBoolean("I"));
+			assertEquals("incorrect J", false, results.getBoolean("J"));
+			assertEquals("incorrect K", false, results.getBoolean("K"));
+			assertEquals("incorrect L", false, results.getBoolean("L"));
+		}
 	}
 
 	@Test
 	public void testExecuteSingleStatement() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
-
-		boolean hasResults = stmt.execute("SELECT * FROM sample");
-		assertTrue("execute hasResults", hasResults);
-		ResultSet results = stmt.getResultSet();
-		assertNotNull(results);
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "Q123", results.getString(1));
-		assertFalse("getMoreResults", stmt.getMoreResults());
-
-		stmt.close();
-		conn.close();
+			Statement stmt = conn.createStatement())
+		{
+			boolean hasResults = stmt.execute("SELECT * FROM sample");
+			assertTrue("execute hasResults", hasResults);
+			ResultSet results = stmt.getResultSet();
+			assertNotNull(results);
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "Q123", results.getString(1));
+			assertFalse("getMoreResults", stmt.getMoreResults());
+		}
 	}
 
 	@Test
 	public void testExecuteMultipleStatements() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement())
+		{
+			boolean hasResults = stmt.execute("SELECT ID FROM sample;\nSELECT Name FROM sample2;");
+			assertTrue("execute hasResults", hasResults);
+			try (ResultSet results1 = stmt.getResultSet())
+			{
+				assertNotNull(results1);
+				assertTrue(results1.next());
+				assertEquals("The ID is wrong", "Q123", results1.getString(1));
 
-		boolean hasResults = stmt.execute("SELECT ID FROM sample;\nSELECT Name FROM sample2;");
-		assertTrue("execute hasResults", hasResults);
-		ResultSet results1 = stmt.getResultSet();
-		assertNotNull(results1);
-		assertTrue(results1.next());
-		assertEquals("The ID is wrong", "Q123", results1.getString(1));
-
-		assertTrue("getMoreResults", stmt.getMoreResults());
-		ResultSet results2 = stmt.getResultSet();
-		assertNotNull(results2);
-		assertTrue(results1.isClosed());
-		assertTrue(results2.next());
-		assertEquals("The Name is wrong", "Aman", results2.getString(1));
-		assertFalse("getMoreResults", stmt.getMoreResults());
-		assertTrue(results2.isClosed());
-
-		stmt.close();
-		conn.close();
+				assertTrue("getMoreResults", stmt.getMoreResults());
+				try (ResultSet results2 = stmt.getResultSet())
+				{
+					assertNotNull(results2);
+					assertTrue(results1.isClosed());
+					assertTrue(results2.next());
+					assertEquals("The Name is wrong", "Aman", results2.getString(1));
+					assertFalse("getMoreResults", stmt.getMoreResults());
+					assertTrue(results2.isClosed());
+				}
+			}
+		}
 	}
 
 	@Test
@@ -4942,42 +5195,54 @@ public class TestCsvDriver
 		props.put("function.PROPERTY", "java.lang.System.getProperty(String)");
 		props.put("function.RLIKE", "java.util.regex.Pattern.matches(String regex,CharSequence input)");
 		props.put("function.CURRENTTIMEMILLIS", "java.lang.System.currentTimeMillis()");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("SELECT POW(C1, 2) FROM numeric");
-		assertTrue(results.next());
-		assertEquals("pow is wrong", 99 * 99, Math.round(results.getDouble(1)));
-		assertTrue(results.next());
-		assertEquals("pow is wrong", -22 * -22, Math.round(results.getDouble(1)));
+			Statement stmt = conn.createStatement())
+		{
+			try (ResultSet results = stmt.executeQuery("SELECT POW(C1, 2) FROM numeric"))
+			{
+				assertTrue(results.next());
+				assertEquals("pow is wrong", 99 * 99, Math.round(results.getDouble(1)));
+				assertTrue(results.next());
+				assertEquals("pow is wrong", -22 * -22, Math.round(results.getDouble(1)));
+			}
 
-		results = stmt.executeQuery("SELECT BITCOUNT(C1) FROM numeric");
-		assertTrue(results.next());
-		assertEquals("bitcount is wrong", Integer.bitCount(99), results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("bitcount is wrong", Integer.bitCount(-22), results.getInt(1));
+			try (ResultSet results = stmt.executeQuery("SELECT BITCOUNT(C1) FROM numeric"))
+			{
+				assertTrue(results.next());
+				assertEquals("bitcount is wrong", Integer.bitCount(99), results.getInt(1));
+				assertTrue(results.next());
+				assertEquals("bitcount is wrong", Integer.bitCount(-22), results.getInt(1));
+			}
 
-		String separator = System.getProperty("file.separator");
-		results = stmt.executeQuery("SELECT PROPERTY('file.separator') || ID FROM sample");
-		assertTrue(results.next());
-		assertEquals("property is wrong", separator + "Q123", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("property is wrong", separator + "A123", results.getString(1));
+			String separator = System.getProperty("file.separator");
+			try (ResultSet results = stmt.executeQuery("SELECT PROPERTY('file.separator') || ID FROM sample"))
+			{
+				assertTrue(results.next());
+				assertEquals("property is wrong", separator + "Q123", results.getString(1));
+				assertTrue(results.next());
+				assertEquals("property is wrong", separator + "A123", results.getString(1));
+			}
 
-		results = stmt.executeQuery("SELECT * FROM sample WHERE RLIKE('.*234', ID) = 'true'");
-		assertTrue(results.next());
-		assertEquals("ID is wrong", "B234", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("ID is wrong", "X234", results.getString(1));
-		assertFalse(results.next());
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample WHERE RLIKE('.*234', ID) = 'true'"))
+			{
+				assertTrue(results.next());
+				assertEquals("ID is wrong", "B234", results.getString(1));
+				assertTrue(results.next());
+				assertEquals("ID is wrong", "X234", results.getString(1));
+				assertFalse(results.next());
+			}
 
-		long t1 = System.currentTimeMillis();
-		results = stmt.executeQuery("SELECT CurrentTimeMillis()");
-		assertTrue(results.next());
-		long t = results.getLong(1);
-		long t2 = System.currentTimeMillis();
-		assertTrue("CurrentTimeMillis is wrong", t >= t1 && t <= t2);
+			long t1 = System.currentTimeMillis();
+			try (ResultSet results = stmt.executeQuery("SELECT CurrentTimeMillis()"))
+			{
+				assertTrue(results.next());
+				long t = results.getLong(1);
+				long t2 = System.currentTimeMillis();
+				assertTrue("CurrentTimeMillis is wrong", t >= t1 && t <= t2);
+			}
+		}
 	}
 
 	@Test
@@ -4987,15 +5252,17 @@ public class TestCsvDriver
 		props.put("columnTypes", "Byte,Short,Integer,Long,Float,Double,BigDecimal");
 		props.put("function.FORMAT", "java.lang.String.format(String, Object...)");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("SELECT FORMAT('%04d%06d %x', C1, C2, 255) FROM numeric");
-		assertTrue(results.next());
-		assertEquals("format is wrong", "0099-01010 ff", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("format is wrong", "-022000015 ff", results.getString(1));
+			ResultSet results = stmt.executeQuery("SELECT FORMAT('%04d%06d %x', C1, C2, 255) FROM numeric"))
+		{
+			assertTrue(results.next());
+			assertEquals("format is wrong", "0099-01010 ff", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("format is wrong", "-022000015 ff", results.getString(1));
+		}
 	}
 
 	@Test
@@ -5018,26 +5285,27 @@ public class TestCsvDriver
 	@Test
 	public void testSavepoints() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-				+ filePath);
-
-		Savepoint savepoint1 = conn.setSavepoint();
-		savepoint1.getSavepointId();
-		conn.rollback(savepoint1);
-		Savepoint savepoint2 = conn.setSavepoint("name1");
-		String name = savepoint2.getSavepointName();
-		assertEquals("Incorrect Savepoint name", "name1", name);
-		conn.rollback(savepoint2);
-		conn.close();
-
-		try
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath))
 		{
-			conn.setSavepoint();
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertTrue(e.getMessage().contains(CsvResources.getString("closedConnection")));
+			Savepoint savepoint1 = conn.setSavepoint();
+			savepoint1.getSavepointId();
+			conn.rollback(savepoint1);
+			Savepoint savepoint2 = conn.setSavepoint("name1");
+			String name = savepoint2.getSavepointName();
+			assertEquals("Incorrect Savepoint name", "name1", name);
+			conn.rollback(savepoint2);
+			conn.close();
+
+			try
+			{
+				conn.setSavepoint();
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.getMessage().contains(CsvResources.getString("closedConnection")));
+			}
 		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestDbfDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestDbfDriver.java
@@ -47,7 +47,7 @@ import org.relique.jdbc.dbf.DbfClassNotFoundException;
 
 /**
  * This class is used to test the CsvJdbc driver.
- * 
+ *
  * @author Mario Frasca
  */
 public class TestDbfDriver
@@ -72,13 +72,13 @@ public class TestDbfDriver
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");  
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));  
+		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 
 	/**
 	 * This creates several sentences with where and tests they work
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
@@ -89,29 +89,31 @@ public class TestDbfDriver
 			Properties props = new Properties();
 			props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+			try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
-			Statement stmt = conn.createStatement();
+				Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt
-					.executeQuery("SELECT * FROM sample");
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Gianni", results
-					.getString("Name"));
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Reinout", results
-					.getString("Name"));
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Alex", results
-					.getString("Name"));
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Gianni", results
-					.getString("Name"));
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Mario", results
-					.getString("Name"));
-			assertFalse(results.next());
+				ResultSet results = stmt
+					.executeQuery("SELECT * FROM sample"))
+			{
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Gianni", results
+						.getString("Name"));
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Reinout", results
+						.getString("Name"));
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Alex", results
+						.getString("Name"));
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Gianni", results
+						.getString("Name"));
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Mario", results
+						.getString("Name"));
+				assertFalse(results.next());
+			}
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -130,29 +132,31 @@ public class TestDbfDriver
 			Properties props = new Properties();
 			props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+			try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
-			Statement stmt = conn.createStatement();
+				Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt
-					.executeQuery("SELECT * FROM sample WHERE key = 'op'");
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Gianni", results
-					.getString("Name"));
-			assertEquals("The name is wrong", "debian", results
-					.getString("value"));
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Reinout", results
-					.getString("Name"));
-			assertEquals("The name is wrong", "ubuntu", results
-					.getString("value"));
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Alex", results
-					.getString("Name"));
-			assertEquals("The name is wrong", "windows", results
-					.getString("value"));
-			assertFalse(results.next());
+				ResultSet results = stmt
+					.executeQuery("SELECT * FROM sample WHERE key = 'op'"))
+			{
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Gianni", results
+						.getString("Name"));
+				assertEquals("The name is wrong", "debian", results
+						.getString("value"));
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Reinout", results
+						.getString("Name"));
+				assertEquals("The name is wrong", "ubuntu", results
+						.getString("value"));
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Alex", results
+						.getString("Name"));
+				assertEquals("The name is wrong", "windows", results
+						.getString("value"));
+				assertFalse(results.next());
+			}
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -171,24 +175,26 @@ public class TestDbfDriver
 			Properties props = new Properties();
 			props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+			try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
-			Statement stmt = conn.createStatement();
+				Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt
-					.executeQuery("SELECT * FROM sample WHERE key = 'todo'");
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Gianni", results
-					.getString("Name"));
-			assertEquals("The name is wrong", "none", results
-					.getString("value"));
-			assertTrue(results.next());
-			assertEquals("The name is wrong", "Mario", results
-					.getString("Name"));
-			assertEquals("The name is wrong", "sleep", results
-					.getString("value"));
-			assertFalse(results.next());
+				ResultSet results = stmt
+					.executeQuery("SELECT * FROM sample WHERE key = 'todo'"))
+			{
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Gianni", results
+						.getString("Name"));
+				assertEquals("The name is wrong", "none", results
+						.getString("value"));
+				assertTrue(results.next());
+				assertEquals("The name is wrong", "Mario", results
+						.getString("Name"));
+				assertEquals("The name is wrong", "sleep", results
+						.getString("value"));
+				assertFalse(results.next());
+			}
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -202,18 +208,17 @@ public class TestDbfDriver
 	@Test
 	public void testWhereWithIsNull() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-					+ filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
 
 			Statement stmt = conn.createStatement();
 
 			ResultSet results = stmt
-					.executeQuery("SELECT * FROM fox_samp WHERE COWNNAME IS NULL");
+				.executeQuery("SELECT * FROM fox_samp WHERE COWNNAME IS NULL"))
+		{
 			assertFalse(results.next());
 		}
 		catch (DbfClassNotFoundException e)
@@ -228,18 +233,17 @@ public class TestDbfDriver
 	@Test
 	public void testTypedColumns() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
 			Statement stmt = conn.createStatement();
 
 			ResultSet results = stmt
-					.executeQuery("SELECT * FROM fox_samp");
+					.executeQuery("SELECT * FROM fox_samp"))
+		{
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
 
@@ -262,16 +266,15 @@ public class TestDbfDriver
 	@Test
 	public void testMemoColumn() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt.executeQuery("SELECT NOTE FROM xbase");
+			ResultSet results = stmt.executeQuery("SELECT NOTE FROM xbase"))
+		{
 			assertTrue(results.next());
 			assertEquals("The NOTE is wrong", "This is a memo fore record no one", results.getString(1));
 			assertTrue(results.next());
@@ -292,16 +295,15 @@ public class TestDbfDriver
 	@Test
 	public void testFloatColumn() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt.executeQuery("SELECT * FROM d");
+			ResultSet results = stmt.executeQuery("SELECT * FROM d"))
+		{
 			assertTrue(results.next());
 			long l = Math.round(7.63 * 1000);
 			assertEquals("The floatfield is wrong", l, Math.round(results.getDouble(1) * 1000));
@@ -319,18 +321,17 @@ public class TestDbfDriver
 	@Test
 	public void testColumnDisplaySizes() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
 
 			Statement stmt = conn.createStatement();
 
 			ResultSet results = stmt
-					.executeQuery("SELECT * FROM fox_samp");
+					.executeQuery("SELECT * FROM fox_samp"))
+		{
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
 
@@ -350,15 +351,13 @@ public class TestDbfDriver
 	@Test
 	public void testDatabaseMetadataTables() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
-			DatabaseMetaData metadata = conn.getMetaData();
-			ResultSet results = metadata.getTables(null, null, "%", null);
+			ResultSet results = conn.getMetaData().getTables(null, null, "%", null))
+		{
 			Set<String> target = new HashSet<String>();
 			target.add("sample");
 			target.add("fox_samp");
@@ -389,21 +388,18 @@ public class TestDbfDriver
 			return;
 		}
 	}
-	
+
 	@Test
 	public void testDatabaseMetadataTablesPattern() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
-			DatabaseMetaData metadata = conn.getMetaData();
 			// Get tables matching only this pattern
-			ResultSet results = metadata.getTables(null, null, "x%", new String[]{"TABLE"});
-
+			ResultSet results = conn.getMetaData().getTables(null, null, "x%", new String[]{"TABLE"}))
+		{
 			assertTrue(results.next());
 			assertEquals("Incorrect table name", "xbase", results.getString("TABLE_NAME"));
 			assertFalse(results.next());
@@ -420,15 +416,13 @@ public class TestDbfDriver
 	@Test
 	public void testDatabaseMetadataColumns() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 					+ filePath, props);
-			DatabaseMetaData metadata = conn.getMetaData();
-			ResultSet results = metadata.getColumns(null, null, "sample", "%");
+			ResultSet results = conn.getMetaData().getColumns(null, null, "sample", "%"))
+		{
 			assertTrue(results.next());
 			assertEquals("Incorrect table name", "sample", results.getString("TABLE_NAME"));
 			assertEquals("Incorrect column name", "NAME", results.getString("COLUMN_NAME"));
@@ -450,15 +444,13 @@ public class TestDbfDriver
 	@Test
 	public void testDatabaseMetadataColumnsPattern() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
-					+ filePath, props);
-			DatabaseMetaData metadata = conn.getMetaData();
-			ResultSet results = metadata.getColumns(null, null, "x%", "M%");
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			ResultSet results = conn.getMetaData().getColumns(null, null, "x%", "M%"))
+		{
 			assertTrue(results.next());
 			assertEquals("Incorrect table name", "xbase", results.getString("TABLE_NAME"));
 			assertEquals("Incorrect column name", "MSG", results.getString("COLUMN_NAME"));
@@ -479,23 +471,22 @@ public class TestDbfDriver
 	@Test
 	public void testGetNumeric() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt.executeQuery("SELECT * FROM fox_samp");
+			ResultSet results = stmt.executeQuery("SELECT * FROM fox_samp"))
+		{
 			assertTrue(results.next());
 			assertEquals("The NCOUNTYCOD is wrong", 33, results.getByte("NCOUNTYCOD"));
 			assertEquals("The NCOUNTYCOD is wrong", 33, results.getShort("NCOUNTYCOD"));
 			assertEquals("The NTAXYEAR is wrong", 2011, results.getInt("NTAXYEAR"));
 			assertEquals("The NNOTFCV is wrong", 0, results.getLong("NNOTFCV"));
 			assertEquals("The NASSASSRAT is wrong", 7250, Math.round(results.getFloat("NASSASSRAT") * 1000));
-			assertEquals("The NASSASSRAT is wrong", 7250, Math.round(results.getDouble("NASSASSRAT") * 1000));		
+			assertEquals("The NASSASSRAT is wrong", 7250, Math.round(results.getDouble("NASSASSRAT") * 1000));
 			assertFalse(results.next());
 		}
 		catch (DbfClassNotFoundException e)
@@ -506,20 +497,19 @@ public class TestDbfDriver
 			return;
 		}
 	}
-	
+
 	@Test
 	public void testGetDate() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt.executeQuery("SELECT DASSDATE FROM fox_samp");
+			ResultSet results = stmt.executeQuery("SELECT DASSDATE FROM fox_samp"))
+		{
 			assertTrue(results.next());
 			assertEquals("The DASSDATE is wrong", Date.valueOf("2012-12-25"), results.getDate(1));
 		}
@@ -531,20 +521,19 @@ public class TestDbfDriver
 			return;
 		}
 	}
-	
+
 	@Test
 	public void testGetTimestamp() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt.executeQuery("SELECT DASSDATE FROM fox_samp");
+			ResultSet results = stmt.executeQuery("SELECT DASSDATE FROM fox_samp"))
+		{
 			assertTrue(results.next());
 			assertEquals("The DASSDATE is wrong", Timestamp.valueOf("2012-12-25 00:00:00"),
 					results.getTimestamp(1));
@@ -557,21 +546,20 @@ public class TestDbfDriver
 			return;
 		}
 	}
-	
+
 	@Test
 	public void testCharset() throws SQLException
 	{
-		try
-		{
-			Properties props = new Properties();
-			props.put("fileExtension", ".dbf");
-			props.put("charset", "ISO-8859-1");
+		Properties props = new Properties();
+		props.put("fileExtension", ".dbf");
+		props.put("charset", "ISO-8859-1");
 
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
 
-			ResultSet results = stmt.executeQuery("SELECT HOTELNAME FROM hotel");
+			ResultSet results = stmt.executeQuery("SELECT HOTELNAME FROM hotel"))
+		{
 			assertTrue(results.next());
 			assertEquals("The HOTELNAME is wrong", "M\u00DCNCHEN HOTEL", results.getString(1));
 			assertTrue(results.next());

--- a/src/test/java/org/relique/jdbc/csv/TestDoubleQuoting.java
+++ b/src/test/java/org/relique/jdbc/csv/TestDoubleQuoting.java
@@ -49,7 +49,7 @@ public class TestDoubleQuoting
 		try
 		{
 			Class.forName("org.relique.jdbc.csv.CsvDriver");
-		} 
+		}
 		catch (ClassNotFoundException e)
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
@@ -61,65 +61,64 @@ public class TestDoubleQuoting
 	{
 		Properties props = new Properties();
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("SELECT * FROM \"C D\"");
-		assertTrue(rs1.next());
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("SELECT * FROM \"C D\""))
+		{
+			assertTrue(rs1.next());
+		}
 	}
-	
+
 	@Test
 	public void testQuotedColumnNames() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,Integer,Integer,Integer,Integer");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("SELECT \"A\", \"B\" + 100, \"[A]\", \"A-B\", \"A B\" FROM \"C D\"");
-		assertEquals("Column name A is wrong", "A", rs1.getMetaData().getColumnName(1));
+			ResultSet rs1 = stmt.executeQuery("SELECT \"A\", \"B\" + 100, \"[A]\", \"A-B\", \"A B\" FROM \"C D\""))
+		{
+			assertEquals("Column name A is wrong", "A", rs1.getMetaData().getColumnName(1));
 
-		assertEquals("Column name [A] is wrong", "[A]", rs1.getMetaData().getColumnName(3));
-		assertEquals("Column name A-B is wrong", "A-B", rs1.getMetaData().getColumnName(4));
-		assertEquals("Column name A B is wrong", "A B", rs1.getMetaData().getColumnName(5));
-		assertTrue(rs1.next());
-		assertEquals("The A is wrong", 1, rs1.getInt("A"));
-		assertEquals("The [A] is wrong", 3, rs1.getInt("[A]"));
-		assertEquals("The A-B is wrong", 4, rs1.getInt("A-B"));
-		assertEquals("The A-B is wrong", 5, rs1.getInt("A B"));
-		assertTrue(rs1.next());
-		assertEquals("The A is wrong", 6, rs1.getInt(1));
-		assertEquals("The B + 100 is wrong", 7 + 100, rs1.getInt(2));
-		assertEquals("The [A] is wrong", 8, rs1.getInt(3));
-		assertEquals("The A-B is wrong", 9, rs1.getInt(4));
-		assertEquals("The A-B is wrong", 10, rs1.getInt(5));
-		rs1.close();
-		stmt.close();
+			assertEquals("Column name [A] is wrong", "[A]", rs1.getMetaData().getColumnName(3));
+			assertEquals("Column name A-B is wrong", "A-B", rs1.getMetaData().getColumnName(4));
+			assertEquals("Column name A B is wrong", "A B", rs1.getMetaData().getColumnName(5));
+			assertTrue(rs1.next());
+			assertEquals("The A is wrong", 1, rs1.getInt("A"));
+			assertEquals("The [A] is wrong", 3, rs1.getInt("[A]"));
+			assertEquals("The A-B is wrong", 4, rs1.getInt("A-B"));
+			assertEquals("The A-B is wrong", 5, rs1.getInt("A B"));
+			assertTrue(rs1.next());
+			assertEquals("The A is wrong", 6, rs1.getInt(1));
+			assertEquals("The B + 100 is wrong", 7 + 100, rs1.getInt(2));
+			assertEquals("The [A] is wrong", 8, rs1.getInt(3));
+			assertEquals("The A-B is wrong", 9, rs1.getInt(4));
+			assertEquals("The A-B is wrong", 10, rs1.getInt(5));
+		}
 	}
-	
+
 	@Test
 	public void testQuotedTableAlias() throws SQLException
 	{
 		Properties props = new Properties();
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-		Statement stmt = conn.createStatement();
-
 		String alias = "\"http://www.google.com\"";
-		ResultSet rs1 = stmt.executeQuery("SELECT " + alias + ".ID, " + alias + ".\"EXTRA_FIELD\" " +
-				"FROM sample AS " + alias);
-		assertTrue(rs1.next());
-		assertEquals("The ID is wrong", "Q123", rs1.getString(1));
-		assertEquals("The EXTRA_FIELD is wrong", "F", rs1.getString(2));
 
-		rs1.close();
-		stmt.close();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+
+			Statement stmt = conn.createStatement();
+
+
+			ResultSet rs1 = stmt.executeQuery("SELECT " + alias + ".ID, " + alias + ".\"EXTRA_FIELD\" " +
+				"FROM sample AS " + alias))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The ID is wrong", "Q123", rs1.getString(1));
+			assertEquals("The EXTRA_FIELD is wrong", "F", rs1.getString(2));
+		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
@@ -62,19 +62,14 @@ public class TestFileSetInputStream
 	@Test
 	public void testGlueAsTrailing() throws IOException
 	{
-		BufferedReader inputRef = null;
-		BufferedReader inputTest = null;
-
-		try
-		{
-			inputRef = new BufferedReader(new InputStreamReader(
+		try (BufferedReader inputRef = new BufferedReader(new InputStreamReader(
 				new FileInputStream(filePath + "test-glued-trailing.txt")));
 
-			inputTest = new BufferedReader(new InputStreamReader(
+			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", false, false, null, 0, null)));
-
+								"location", "file_date" }, ",", false, false, null, 0, null))))
+		{
 			Set<String> refSet = new HashSet<String>();
 			Set<String> testSet = new HashSet<String>();
 			inputRef.readLine();
@@ -90,32 +85,20 @@ public class TestFileSetInputStream
 			while (lineRef != null && lineTest != null);
 			assertTrue("refSet contains testSet", refSet.containsAll(testSet));
 			assertTrue("testSet contains refSet", testSet.containsAll(refSet));
-		}
-		finally
-		{
-			if (inputRef != null)
-				inputRef.close();
-			if (inputTest != null)
-				inputTest.close();
 		}
 	}
 
 	@Test
 	public void testGlueAsLeading() throws IOException
 	{
-		BufferedReader inputRef = null;
-		BufferedReader inputTest = null;
-
-		try
-		{
-			inputRef = new BufferedReader(new InputStreamReader(
+		try (BufferedReader inputRef = new BufferedReader(new InputStreamReader(
 				new FileInputStream(filePath + "test-glued-leading.txt")));
 
-			inputTest = new BufferedReader(new InputStreamReader(
+			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", true, false, null, 0, null)));
-
+								"location", "file_date" }, ",", true, false, null, 0, null))))
+		{
 			Set<String> refSet = new HashSet<String>();
 			Set<String> testSet = new HashSet<String>();
 			inputRef.readLine();
@@ -132,31 +115,19 @@ public class TestFileSetInputStream
 			assertTrue("refSet contains testSet", refSet.containsAll(testSet));
 			assertTrue("testSet contains refSet", testSet.containsAll(refSet));
 		}
-		finally
-		{
-			if (inputRef != null)
-				inputRef.close();
-			if (inputTest != null)
-				inputTest.close();
-		}
 	}
 
 	@Test
 	public void testGlueAsLeadingHeaderless() throws IOException
 	{
-		BufferedReader inputRef = null;
-		BufferedReader inputTest = null;
-
-		try
-		{
-			inputRef = new BufferedReader(new InputStreamReader(
+		try (BufferedReader inputRef = new BufferedReader(new InputStreamReader(
 				new FileInputStream(filePath + "headerless-glued-leading.txt")));
 
-			inputTest = new BufferedReader(new InputStreamReader(
+			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"headerless-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", true, true, null, 0, null)));
-
+								"location", "file_date" }, ",", true, true, null, 0, null))))
+		{
 			Set<String> refSet = new HashSet<String>();
 			Set<String> testSet = new HashSet<String>();
 			String lineRef, lineTest;
@@ -170,32 +141,20 @@ public class TestFileSetInputStream
 			while (lineRef != null && lineTest != null);
 			assertTrue("refSet contains testSet", refSet.containsAll(testSet));
 			assertTrue("testSet contains refSet", testSet.containsAll(refSet));
-		}
-		finally
-		{
-			if (inputRef != null)
-				inputRef.close();
-			if (inputTest != null)
-				inputTest.close();
 		}
 	}
 
 	@Test
 	public void testGlueAsEmpty() throws IOException
 	{
-		BufferedReader inputRef = null;
-		BufferedReader inputTest = null;
-
-		try
-		{
-			inputRef = new BufferedReader(new InputStreamReader(
+		try (BufferedReader inputRef = new BufferedReader(new InputStreamReader(
 				new FileInputStream(filePath + "empty-glued.txt")));
 
-			inputTest = new BufferedReader(new InputStreamReader(
+			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"empty-([0-9]+).txt", new String[] {
-							"EMPTY_ID"}, ",", false, false, null, 0, null)));
-
+							"EMPTY_ID"}, ",", false, false, null, 0, null))))
+		{
 			Set<String> refSet = new HashSet<String>();
 			Set<String> testSet = new HashSet<String>();
 			String lineRef, lineTest;
@@ -210,30 +169,19 @@ public class TestFileSetInputStream
 			assertTrue("refSet contains testSet", refSet.containsAll(testSet));
 			assertTrue("testSet contains refSet", testSet.containsAll(refSet));
 		}
-		finally
-		{
-			if (inputRef != null)
-				inputRef.close();
-			if (inputTest != null)
-				inputTest.close();
-		}
 	}
 
 	@Test
 	public void testGlueAsLeadingLastLineNoNewline() throws IOException
 	{
-		BufferedReader inputTest = null;
+		String separator = ",";
 
-		try
-		{
-			String separator = ",";
-
-			// Test CSV files with no '\n' on last line
-			inputTest = new BufferedReader(new InputStreamReader(
+		// Test CSV files with no '\n' on last line
+		try (BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"petr-([0-9]{3})-([0-9]{3}).csv", new String[] {
-								"part1", "part2" }, separator, true, true, null, 0, null)));
-
+								"part1", "part2" }, separator, true, true, null, 0, null))))
+		{
 			String lineTest = inputTest.readLine();
 			while (lineTest != null)
 			{
@@ -245,58 +193,45 @@ public class TestFileSetInputStream
 				lineTest = inputTest.readLine();
 			}
 		}
-		finally
-		{
-			if (inputTest != null)
-				inputTest.close();
-		}
 	}
-	
+
 	@Test
 	public void testFileSetInputStreamClose() throws IOException
 	{
-		FileSetInputStream in = new FileSetInputStream(filePath,
+		try (FileSetInputStream in = new FileSetInputStream(filePath,
 					"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-					"location", "file_date"}, ",", false, false, null, 0, null);
-
-		in.read();
-		in.read();
-		in.close();
-		try
+					"location", "file_date"}, ",", false, false, null, 0, null))
 		{
 			in.read();
-			fail("expected exception java.io.IOException");
-		}
-		catch (IOException e)
-		{
-			assertTrue(("" + e).contains("IOException"));
+			in.read();
+			in.close();
+			try
+			{
+				in.read();
+				fail("expected exception java.io.IOException");
+			}
+			catch (IOException e)
+			{
+				assertTrue(("" + e).contains("IOException"));
+			}
 		}
 	}
 
 	@Test
 	public void testFileSetCharsetUtf16le() throws IOException
 	{
-		BufferedReader in = null;
-
-		try
-		{
-			String charset = "UTF-16LE";
-			in = new BufferedReader(new InputStreamReader(
+		String charset = "UTF-16LE";
+		try (BufferedReader in = new BufferedReader(new InputStreamReader(
 					new FileSetInputStream(filePath,
 						"utf16le_(\\d+).txt", new String[] {
-						"date"}, "|", false, false, null, 0, charset), charset));
-
+						"date"}, "|", false, false, null, 0, charset), charset)))
+		{
 			String line = in.readLine();
 			assertEquals("Col1|Col2|Some third|4th|date", line);
 			line = in.readLine();
 			assertEquals("1|01.10.2018|-4,4|1111|01102018", line);
 			line = in.readLine();
 			assertEquals("2|04.11.2020|-2,2|2222|04112020", line);
-		}
-		finally
-		{
-			if (in != null)
-				in.close();
 		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestFixedWidthFiles.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFixedWidthFiles.java
@@ -59,34 +59,36 @@ public class TestFixedWidthFiles
 
 	@Test
 	public void testFixedWidth() throws SQLException
-	{	
+	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("fixedWidths", "1-16,17-24,25-27,35-42,43-50,51-58");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		// GERMANY         Euro    EUR       0.7616450.7632460.002102
-		ResultSet rs1 = stmt.executeQuery("SELECT * FROM currency-exchange-rates-fixed");
-		assertTrue(rs1.next());
-		assertEquals("Country rate is wrong", "GERMANY", rs1.getString("Country"));
-		assertEquals("Currency rate is wrong", "Euro", rs1.getString("Currency"));
-		assertEquals("ISO rate is wrong", "EUR", rs1.getString("ISO"));
-		assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString("YESTERDY"));
-		assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString("TODAY_"));
-		assertEquals("% Change rate is wrong", "0.002102", rs1.getString("% Change"));
+			// GERMANY         Euro    EUR       0.7616450.7632460.002102
+			ResultSet rs1 = stmt.executeQuery("SELECT * FROM currency-exchange-rates-fixed"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("Country rate is wrong", "GERMANY", rs1.getString("Country"));
+			assertEquals("Currency rate is wrong", "Euro", rs1.getString("Currency"));
+			assertEquals("ISO rate is wrong", "EUR", rs1.getString("ISO"));
+			assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString("YESTERDY"));
+			assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString("TODAY_"));
+			assertEquals("% Change rate is wrong", "0.002102", rs1.getString("% Change"));
 
-		assertTrue(rs1.next());
-		assertEquals("Country rate is wrong", "GREECE", rs1.getString(1));
-		assertEquals("Currency rate is wrong", "Euro", rs1.getString(2));
-		assertEquals("ISO rate is wrong", "EUR", rs1.getString(3));
-		assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString(4));
-		assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString(5));
-		assertEquals("% Change rate is wrong", "0.002102", rs1.getString(6));
+			assertTrue(rs1.next());
+			assertEquals("Country rate is wrong", "GREECE", rs1.getString(1));
+			assertEquals("Currency rate is wrong", "Euro", rs1.getString(2));
+			assertEquals("ISO rate is wrong", "EUR", rs1.getString(3));
+			assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString(4));
+			assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString(5));
+			assertEquals("% Change rate is wrong", "0.002102", rs1.getString(6));
 
-		assertTrue(rs1.next());
+			assertTrue(rs1.next());
+		}
 	}
 
 	@Test
@@ -103,127 +105,141 @@ public class TestFixedWidthFiles
 		props.put("columnTypes", "String,String,String,Double,Double,Double");
 		props.put("fixedWidths", "1-16,17-24,25-27,35-42,43-50,51-58");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement())
+		{
+			// GERMANY         Euro    EUR       0.7616450.7632460.002102
+			try (ResultSet rs1 = stmt
+				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'GERMANY'"))
+			{
+				assertTrue(rs1.next());
+				assertEquals("ISO rate is wrong", "EUR", rs1.getString("ISO"));
+				assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString("PREV_DAY"));
+				assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString("TODAY"));
+				assertEquals("% Change rate is wrong", "0.002102", rs1.getString("PTChange"));
+			}
 
-		// GERMANY         Euro    EUR       0.7616450.7632460.002102
-		ResultSet rs1 = stmt
-				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'GERMANY'");
-		assertTrue(rs1.next());
-		assertEquals("ISO rate is wrong", "EUR", rs1.getString("ISO"));
-		assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString("PREV_DAY"));
-		assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString("TODAY"));
-		assertEquals("% Change rate is wrong", "0.002102", rs1.getString("PTChange"));
-		
-		// HUNGARY         Forint  HUF       226.1222226.67130.002429
-		ResultSet rs2 = stmt
-				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'HUNGARY'");
-		assertTrue(rs2.next());
-		assertEquals("ISO rate is wrong", "HUF", rs2.getString("ISO"));
-		assertEquals("YESTERDY rate is wrong", "226.1222", rs2.getString("PREV_DAY"));
-		assertEquals("TODAY_ rate is wrong", "226.6713", rs2.getString("TODAY"));
-		assertEquals("% Change rate is wrong", "0.002429", rs2.getString("PTChange"));
-		
-		// PERU            Sol     PEN       2.6618362.661836       0
-		ResultSet rs3 = stmt
-				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'PERU'");
-		assertTrue(rs3.next());
-		assertEquals("ISO rate is wrong", "PEN", rs3.getString("ISO"));
-		assertEquals("YESTERDY rate is wrong", "2.661836", rs3.getString("PREV_DAY"));
-		assertEquals("TODAY_ rate is wrong", "2.661836", rs3.getString("TODAY"));
-		assertEquals("% Change rate is wrong", "0.0", rs3.getString("PTChange"));
-		
-		//SAUDI ARABIA    Riyal   SAR       3.7504133.750361-1.4E-05
-		ResultSet rs4 = stmt
-				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'SAUDI ARABIA'");
-		assertTrue(rs4.next());
-		assertEquals("ISO rate is wrong", "SAR", rs4.getString("ISO"));
-		assertEquals("YESTERDY rate is wrong", "3.750413", rs4.getString("PREV_DAY"));
-		assertEquals("TODAY_ rate is wrong", "3.750361", rs4.getString("TODAY"));
-		assertEquals("% Change rate is wrong", "-1.4E-5", rs4.getString("PTChange"));
+			// HUNGARY         Forint  HUF       226.1222226.67130.002429
+			try (ResultSet rs2 = stmt
+				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'HUNGARY'"))
+			{
+				assertTrue(rs2.next());
+				assertEquals("ISO rate is wrong", "HUF", rs2.getString("ISO"));
+				assertEquals("YESTERDY rate is wrong", "226.1222", rs2.getString("PREV_DAY"));
+				assertEquals("TODAY_ rate is wrong", "226.6713", rs2.getString("TODAY"));
+				assertEquals("% Change rate is wrong", "0.002429", rs2.getString("PTChange"));
+			}
+
+			// PERU            Sol     PEN       2.6618362.661836       0
+			try (ResultSet rs3 = stmt
+				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'PERU'"))
+			{
+				assertTrue(rs3.next());
+				assertEquals("ISO rate is wrong", "PEN", rs3.getString("ISO"));
+				assertEquals("YESTERDY rate is wrong", "2.661836", rs3.getString("PREV_DAY"));
+				assertEquals("TODAY_ rate is wrong", "2.661836", rs3.getString("TODAY"));
+				assertEquals("% Change rate is wrong", "0.0", rs3.getString("PTChange"));
+			}
+
+			//SAUDI ARABIA    Riyal   SAR       3.7504133.750361-1.4E-05
+			try (ResultSet rs4 = stmt
+				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'SAUDI ARABIA'"))
+			{
+				assertTrue(rs4.next());
+				assertEquals("ISO rate is wrong", "SAR", rs4.getString("ISO"));
+				assertEquals("YESTERDY rate is wrong", "3.750413", rs4.getString("PREV_DAY"));
+				assertEquals("TODAY_ rate is wrong", "3.750361", rs4.getString("TODAY"));
+				assertEquals("% Change rate is wrong", "-1.4E-5", rs4.getString("PTChange"));
+			}
+		}
 	}
 
 	@Test
 	public void testNumericColumns() throws SQLException
-	{	
+	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("columnTypes", "String,String,String,Double,Double,Double");
 		props.put("fixedWidths", "1-16,17-24,25-27,35-42,43-50,51-58");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		//SWEDEN          Krona   SEK       6.76557 6.752711 -0.0019
-		//SWITZERLAND     Franc   CHF       0.9153470.9178320.002715
-		ResultSet rs1 = stmt.executeQuery("SELECT * FROM currency-exchange-rates-fixed " +
-			"WHERE Country='SWEDEN' OR Country='SWITZERLAND'");
-		int multiplier = 1000;
-		assertTrue(rs1.next());
-		assertEquals("TODAY_ is wrong", Math.round(6.76557 * multiplier), Math.round(rs1.getDouble("YESTERDY") * multiplier));
-		assertEquals("YESTERDY is wrong", Math.round(6.752711 * multiplier), Math.round(rs1.getDouble("TODAY_") * multiplier));
-		assertEquals("% Change is wrong", Math.round(-0.0019 * multiplier), Math.round(rs1.getDouble("% Change") * multiplier));
+			//SWEDEN          Krona   SEK       6.76557 6.752711 -0.0019
+			//SWITZERLAND     Franc   CHF       0.9153470.9178320.002715
+			ResultSet rs1 = stmt.executeQuery("SELECT * FROM currency-exchange-rates-fixed " +
+				"WHERE Country='SWEDEN' OR Country='SWITZERLAND'"))
+		{
+			int multiplier = 1000;
+			assertTrue(rs1.next());
+			assertEquals("TODAY_ is wrong", Math.round(6.76557 * multiplier), Math.round(rs1.getDouble("YESTERDY") * multiplier));
+			assertEquals("YESTERDY is wrong", Math.round(6.752711 * multiplier), Math.round(rs1.getDouble("TODAY_") * multiplier));
+			assertEquals("% Change is wrong", Math.round(-0.0019 * multiplier), Math.round(rs1.getDouble("% Change") * multiplier));
 
-		assertTrue(rs1.next());
-		assertEquals("TODAY_ is wrong", Math.round(0.915347 * multiplier), Math.round(rs1.getDouble("YESTERDY") * multiplier));
-		assertEquals("YESTERDY is wrong", Math.round(0.917832 * multiplier), Math.round(rs1.getDouble("TODAY_") * multiplier));
-		assertEquals("% Change is wrong", Math.round(0.002715 * multiplier), Math.round(rs1.getDouble("% Change") * multiplier));
+			assertTrue(rs1.next());
+			assertEquals("TODAY_ is wrong", Math.round(0.915347 * multiplier), Math.round(rs1.getDouble("YESTERDY") * multiplier));
+			assertEquals("YESTERDY is wrong", Math.round(0.917832 * multiplier), Math.round(rs1.getDouble("TODAY_") * multiplier));
+			assertEquals("% Change is wrong", Math.round(0.002715 * multiplier), Math.round(rs1.getDouble("% Change") * multiplier));
+		}
 	}
 
 	@Test
 	public void testColumnSizes() throws SQLException
-	{	
+	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("columnTypes", "String,String,String,Double,Double,Double");
 		props.put("fixedWidths", "1-16,17-24,25-27,35-42,43-50,51-58");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("SELECT Country,YESTERDY,ISO FROM currency-exchange-rates-fixed");
-
-		ResultSetMetaData meta = rs1.getMetaData();
-		assertEquals("Incorrect Column Size", 16, meta.getColumnDisplaySize(1));
-		assertEquals("Incorrect Column Size", 8, meta.getColumnDisplaySize(2));
-		assertEquals("Incorrect Column Size", 3, meta.getColumnDisplaySize(3));
+			ResultSet rs1 = stmt.executeQuery("SELECT Country,YESTERDY,ISO FROM currency-exchange-rates-fixed"))
+		{
+			ResultSetMetaData meta = rs1.getMetaData();
+			assertEquals("Incorrect Column Size", 16, meta.getColumnDisplaySize(1));
+			assertEquals("Incorrect Column Size", 8, meta.getColumnDisplaySize(2));
+			assertEquals("Incorrect Column Size", 3, meta.getColumnDisplaySize(3));
+		}
 	}
 
 	@Test
 	public void testWidthOrder() throws SQLException
-	{	
+	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("columnTypes", "String,Integer,String");
 		props.put("fixedWidths", "30-32,29,25-28");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("SELECT * FROM flights");
-		assertTrue(rs1.next());
-		assertEquals("Column 1 is wrong", "A18", rs1.getString(1));
-		assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
-		assertEquals("Column 3 is wrong", "", rs1.getString(3));
-		
-		assertTrue(rs1.next());
-		assertEquals("Column 1 is wrong", "B2", rs1.getString(1));
-		assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
-		assertEquals("Column 3 is wrong", "", rs1.getString(3));
+			ResultSet rs1 = stmt.executeQuery("SELECT * FROM flights"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("Column 1 is wrong", "A18", rs1.getString(1));
+			assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
+			assertEquals("Column 3 is wrong", "", rs1.getString(3));
 
-		assertTrue(rs1.next());
-		assertEquals("Column 1 is wrong", "D4", rs1.getString(1));
-		assertEquals("Column 2 is wrong", 2, rs1.getInt(2));
-		assertEquals("Column 3 is wrong", "", rs1.getString(3));
-		
-		assertTrue(rs1.next());
-		assertEquals("Column 1 is wrong", "A22", rs1.getString(1));
-		assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
-		assertEquals("Column 3 is wrong", "1320", rs1.getString(3));
+			assertTrue(rs1.next());
+			assertEquals("Column 1 is wrong", "B2", rs1.getString(1));
+			assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
+			assertEquals("Column 3 is wrong", "", rs1.getString(3));
+
+			assertTrue(rs1.next());
+			assertEquals("Column 1 is wrong", "D4", rs1.getString(1));
+			assertEquals("Column 2 is wrong", 2, rs1.getInt(2));
+			assertEquals("Column 3 is wrong", "", rs1.getString(3));
+
+			assertTrue(rs1.next());
+			assertEquals("Column 1 is wrong", "A22", rs1.getString(1));
+			assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
+			assertEquals("Column 3 is wrong", "1320", rs1.getString(3));
+		}
 	}
 
 	@Test
@@ -234,25 +250,27 @@ public class TestFixedWidthFiles
 		props.put("isHeaderFixedWidth", "false");
 		props.put("fixedWidths", "1-2,3-3,4-6,7-7");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		// GERMANY		   Euro	   EUR		 0.7616450.7632460.002102
-		ResultSet rs1 = stmt.executeQuery("SELECT * FROM single-char-cols-fixed");
-		assertTrue(rs1.next());
-		assertEquals("Column 1 value is wrong", "BB", rs1.getString("TwoChars"));
-		assertEquals("Column 2 value is wrong", "A", rs1.getString("OneChar"));
-		assertEquals("Column 3 value is wrong", "CCC",rs1.getString("ThreeChars"));
-		assertEquals("Column 4 value is wrong", "D", rs1.getString("YetAnotherOneChar"));
+			// GERMANY		   Euro	   EUR		 0.7616450.7632460.002102
+			ResultSet rs1 = stmt.executeQuery("SELECT * FROM single-char-cols-fixed"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("Column 1 value is wrong", "BB", rs1.getString("TwoChars"));
+			assertEquals("Column 2 value is wrong", "A", rs1.getString("OneChar"));
+			assertEquals("Column 3 value is wrong", "CCC",rs1.getString("ThreeChars"));
+			assertEquals("Column 4 value is wrong", "D", rs1.getString("YetAnotherOneChar"));
 
-		assertTrue(rs1.next());
-		assertEquals("Column 1 value is wrong", "22", rs1.getString(1));
-		assertEquals("Column 2 value is wrong", "1", rs1.getString(2));
-		assertEquals("Column 3 value is wrong", "333", rs1.getString(3));
-		assertEquals("Column 4 value is wrong", "4", rs1.getString(4));
+			assertTrue(rs1.next());
+			assertEquals("Column 1 value is wrong", "22", rs1.getString(1));
+			assertEquals("Column 2 value is wrong", "1", rs1.getString(2));
+			assertEquals("Column 3 value is wrong", "333", rs1.getString(3));
+			assertEquals("Column 4 value is wrong", "4", rs1.getString(4));
 
-		assertTrue(rs1.next());
+			assertTrue(rs1.next());
+		}
 	}
 
 	@Test
@@ -266,24 +284,26 @@ public class TestFixedWidthFiles
 		props.put("isHeaderFixedWidth", "false");
 		props.put("fixedWidths", "1-2,3-3,4-6,7-7");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		// GERMANY		   Euro	   EUR		 0.7616450.7632460.002102
-		ResultSet rs1 = stmt.executeQuery("SELECT * FROM single-char-cols-fixed");
-		assertTrue(rs1.next());
-		assertEquals("Column 1 value is wrong", "BB", rs1.getString("Column1"));
-		assertEquals("Column 2 value is wrong", "A", rs1.getString("Column2"));
-		assertEquals("Column 3 value is wrong", "CCC",rs1.getString("Column3"));
-		assertEquals("Column 4 value is wrong", "D", rs1.getString("Column4"));
+			// GERMANY		   Euro	   EUR		 0.7616450.7632460.002102
+			ResultSet rs1 = stmt.executeQuery("SELECT * FROM single-char-cols-fixed"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("Column 1 value is wrong", "BB", rs1.getString("Column1"));
+			assertEquals("Column 2 value is wrong", "A", rs1.getString("Column2"));
+			assertEquals("Column 3 value is wrong", "CCC",rs1.getString("Column3"));
+			assertEquals("Column 4 value is wrong", "D", rs1.getString("Column4"));
 
-		assertTrue(rs1.next());
-		assertEquals("Column 1 value is wrong", "22", rs1.getString(1));
-		assertEquals("Column 2 value is wrong", "1", rs1.getString(2));
-		assertEquals("Column 3 value is wrong", "333", rs1.getString(3));
-		assertEquals("Column 4 value is wrong", "4", rs1.getString(4));
+			assertTrue(rs1.next());
+			assertEquals("Column 1 value is wrong", "22", rs1.getString(1));
+			assertEquals("Column 2 value is wrong", "1", rs1.getString(2));
+			assertEquals("Column 3 value is wrong", "333", rs1.getString(3));
+			assertEquals("Column 4 value is wrong", "4", rs1.getString(4));
 
-		assertTrue(rs1.next());
+			assertTrue(rs1.next());
+		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestGroupBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestGroupBy.java
@@ -63,8 +63,8 @@ public class TestGroupBy
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");  
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));  
+		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 
 	@Test
@@ -76,21 +76,24 @@ public class TestGroupBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select TO_BLZ from transactions group by TO_BLZ");
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select TO_BLZ from transactions group by TO_BLZ"))
+		{
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -103,34 +106,37 @@ public class TestGroupBy
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
 		props.put("dateFormat", "dd-mm-yyyy");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select TRANS_DATE, TO_BLZ from transactions group by TRANS_DATE, TO_BLZ");
-		assertTrue(results.next());
-		assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-19"), results.getDate("TRANS_DATE"));
-		assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-21"), results.getDate("TRANS_DATE"));
-		assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-21"), results.getDate("TRANS_DATE"));
-		assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-24"), results.getDate("TRANS_DATE"));
-		assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-27"), results.getDate("TRANS_DATE"));
-		assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-28"), results.getDate("TRANS_DATE"));
-		assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-31"), results.getDate("TRANS_DATE"));
-		assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select TRANS_DATE, TO_BLZ from transactions group by TRANS_DATE, TO_BLZ"))
+		{
+			assertTrue(results.next());
+			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-19"), results.getDate("TRANS_DATE"));
+			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-21"), results.getDate("TRANS_DATE"));
+			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-21"), results.getDate("TRANS_DATE"));
+			assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-24"), results.getDate("TRANS_DATE"));
+			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-27"), results.getDate("TRANS_DATE"));
+			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-28"), results.getDate("TRANS_DATE"));
+			assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-31"), results.getDate("TRANS_DATE"));
+			assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -138,32 +144,38 @@ public class TestGroupBy
 	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select ID from empty-2 GROUP BY ID");
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select ID from empty-2 GROUP BY ID"))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGroupByAllDifferent() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select ID from sample4 GROUP BY ID");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "01", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "02", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "03", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "04", results.getString("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select ID from sample4 GROUP BY ID"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "03", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -171,34 +183,40 @@ public class TestGroupBy
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select Job from sample5 WHERE ID >= 5 GROUP BY Job");
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Piloto", results.getString("Job"));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Office Manager", results.getString("Job"));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Office Employee", results.getString("Job"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select Job from sample5 WHERE ID >= 5 GROUP BY Job"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Piloto", results.getString("Job"));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Office Manager", results.getString("Job"));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Office Employee", results.getString("Job"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGroupByOrderBy() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select Job from sample4 GROUP BY Job ORDER BY Job");
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select Job from sample4 GROUP BY Job ORDER BY Job"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -210,25 +228,28 @@ public class TestGroupBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select TO_BLZ, COUNT(TO_BLZ) AS N from transactions group by TO_BLZ");
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-		assertEquals("The COUNT is wrong", 5, results.getInt("N"));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
-		assertEquals("The COUNT is wrong", 2, results.getInt("N"));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
-		assertEquals("The COUNT is wrong", 1, results.getInt("N"));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
-		assertEquals("The COUNT is wrong", 1, results.getInt("N"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select TO_BLZ, COUNT(TO_BLZ) AS N from transactions group by TO_BLZ"))
+		{
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertEquals("The COUNT is wrong", 5, results.getInt("N"));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
+			assertEquals("The COUNT is wrong", 2, results.getInt("N"));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
+			assertEquals("The COUNT is wrong", 1, results.getInt("N"));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
+			assertEquals("The COUNT is wrong", 1, results.getInt("N"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -236,41 +257,47 @@ public class TestGroupBy
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "String,Integer");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select NAME, count(*) from scores group by NAME");
-		assertTrue(results.next());
-		assertEquals("The NAME is wrong", "Daniel", results.getString(1));
-		assertEquals("The COUNT is wrong", 3, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("The NAME is wrong", "Mark", results.getString(1));
-		assertEquals("The COUNT is wrong", 3, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("The NAME is wrong", "Maria", results.getString(1));
-		assertEquals("The COUNT is wrong", 3, results.getInt(2));
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select NAME, count(*) from scores group by NAME"))
+		{
+			assertTrue(results.next());
+			assertEquals("The NAME is wrong", "Daniel", results.getString(1));
+			assertEquals("The COUNT is wrong", 3, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("The NAME is wrong", "Mark", results.getString(1));
+			assertEquals("The COUNT is wrong", 3, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("The NAME is wrong", "Maria", results.getString(1));
+			assertEquals("The COUNT is wrong", 3, results.getInt(2));
+		}
 	}
 
 	@Test
 	public void testGroupByCountNull() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select NAME, COUNT(NULLIF(SCORE, 'NA')) FROM scores GROUP BY NAME");
-		assertTrue(results.next());
-		assertEquals("The NAME is wrong", "Daniel", results.getString(1));
-		assertEquals("The COUNT is wrong", 2, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("The NAME is wrong", "Mark", results.getString(1));
-		assertEquals("The COUNT is wrong", 3, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("The NAME is wrong", "Maria", results.getString(1));
-		assertEquals("The COUNT is wrong", 1, results.getInt(2));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select NAME, COUNT(NULLIF(SCORE, 'NA')) FROM scores GROUP BY NAME"))
+		{
+			assertTrue(results.next());
+			assertEquals("The NAME is wrong", "Daniel", results.getString(1));
+			assertEquals("The COUNT is wrong", 2, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("The NAME is wrong", "Mark", results.getString(1));
+			assertEquals("The COUNT is wrong", 3, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("The NAME is wrong", "Maria", results.getString(1));
+			assertEquals("The COUNT is wrong", 1, results.getInt(2));
+			assertFalse(results.next());
+		}
 	}
 
 	/**
@@ -290,96 +317,110 @@ public class TestGroupBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select TO_BLZ, MIN(AMOUNT) AS MIN_AMOUNT, MAX(AMOUNT) AS MAX_AMOUNT from transactions group by TO_BLZ");
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-		assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(21.23, results.getDouble("MIN_AMOUNT")));
-		assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(250.00, results.getDouble("MAX_AMOUNT")));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
-		assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(460.00, results.getDouble("MIN_AMOUNT")));
-		assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(999.00, results.getDouble("MAX_AMOUNT")));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
-		assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(1012.74, results.getDouble("MIN_AMOUNT")));
-		assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(1012.74, results.getDouble("MAX_AMOUNT")));
-		assertTrue(results.next());
-		assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
-		assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(7.23, results.getDouble("MIN_AMOUNT")));
-		assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(7.23, results.getDouble("MAX_AMOUNT")));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select TO_BLZ, MIN(AMOUNT) AS MIN_AMOUNT, MAX(AMOUNT) AS MAX_AMOUNT from transactions group by TO_BLZ"))
+		{
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(21.23, results.getDouble("MIN_AMOUNT")));
+			assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(250.00, results.getDouble("MAX_AMOUNT")));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
+			assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(460.00, results.getDouble("MIN_AMOUNT")));
+			assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(999.00, results.getDouble("MAX_AMOUNT")));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
+			assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(1012.74, results.getDouble("MIN_AMOUNT")));
+			assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(1012.74, results.getDouble("MAX_AMOUNT")));
+			assertTrue(results.next());
+			assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
+			assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(7.23, results.getDouble("MIN_AMOUNT")));
+			assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(7.23, results.getDouble("MAX_AMOUNT")));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGroupByStringAgg() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet results = stmt.executeQuery("select Job, string_agg(Name, ';') from sample4 GROUP BY Job");
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Project Manager", results.getString(1));
-		assertEquals("The string_agg is wrong", "Juan Pablo Morales;Mauricio Hernandez;Felipe Grajales", results.getString(2));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Finance Manager", results.getString(1));
-		assertEquals("The string_agg is wrong", "Maria Cristina Lucero", results.getString(2));
-		assertFalse(results.next());
+			ResultSet results = stmt.executeQuery("select Job, string_agg(Name, ';') from sample4 GROUP BY Job"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Project Manager", results.getString(1));
+			assertEquals("The string_agg is wrong", "Juan Pablo Morales;Mauricio Hernandez;Felipe Grajales", results.getString(2));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Finance Manager", results.getString(1));
+			assertEquals("The string_agg is wrong", "Maria Cristina Lucero", results.getString(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGroupByOrderByCount() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select Job, COUNT(Job) C from sample4 GROUP BY Job ORDER BY C DESC");
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
-		assertEquals("The COUNT is wrong", 3, results.getInt("C"));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
-		assertEquals("The COUNT is wrong", 1, results.getInt("C"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select Job, COUNT(Job) C from sample4 GROUP BY Job ORDER BY C DESC"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
+			assertEquals("The COUNT is wrong", 3, results.getInt("C"));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertEquals("The COUNT is wrong", 1, results.getInt("C"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGroupByColumnNumber() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select Job from sample4 GROUP BY 1");
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select Job from sample4 GROUP BY 1"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGroupByTableAlias() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select Job from sample4 T GROUP BY T.Job");
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select Job from sample4 T GROUP BY T.Job"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -392,52 +433,57 @@ public class TestGroupBy
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
 		props.put("dateFormat", "dd-mm-yyyy");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select FROM_ACCT + '/' + FROM_BLZ as KEY from transactions group by KEY");
-		assertTrue(results.next());
-		assertEquals("The KEY is wrong", "3670345/10010010", results.getString("KEY"));
-		assertTrue(results.next());
-		assertEquals("The KEY is wrong", "97540210/10020500", results.getString("KEY"));
-		assertTrue(results.next());
-		assertEquals("The KEY is wrong", "58340576/10010010", results.getString("KEY"));
-		assertTrue(results.next());
-		assertEquals("The KEY is wrong", "2340529/10020200", results.getString("KEY"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select FROM_ACCT + '/' + FROM_BLZ as KEY from transactions group by KEY"))
+		{
+			assertTrue(results.next());
+			assertEquals("The KEY is wrong", "3670345/10010010", results.getString("KEY"));
+			assertTrue(results.next());
+			assertEquals("The KEY is wrong", "97540210/10020500", results.getString("KEY"));
+			assertTrue(results.next());
+			assertEquals("The KEY is wrong", "58340576/10010010", results.getString("KEY"));
+			assertTrue(results.next());
+			assertEquals("The KEY is wrong", "2340529/10020200", results.getString("KEY"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGroupByWithLiteral() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select Job + '/' C1, 7 C2 from sample4 GROUP BY Job");
-		assertTrue(results.next());
-		assertEquals("The C1 is wrong", "Project Manager/", results.getString("C1"));
-		assertEquals("The C2 is wrong", "7", results.getString("C2"));
-		assertTrue(results.next());
-		assertEquals("The C1 is wrong", "Finance Manager/", results.getString("C1"));
-		assertEquals("The C2 is wrong", "7", results.getString("C2"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt.executeQuery("select Job + '/' C1, 7 C2 from sample4 GROUP BY Job"))
+		{
+			assertTrue(results.next());
+			assertEquals("The C1 is wrong", "Project Manager/", results.getString("C1"));
+			assertEquals("The C2 is wrong", "7", results.getString("C2"));
+			assertTrue(results.next());
+			assertEquals("The C1 is wrong", "Finance Manager/", results.getString("C1"));
+			assertEquals("The C2 is wrong", "7", results.getString("C2"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testGroupByWithBadColumnName() throws SQLException
-	{		
-		try
-		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
-
-			stmt.executeQuery("SELECT Id FROM sample group by XXXX");
+			ResultSet results = stmt.executeQuery("SELECT Id FROM sample group by XXXX"))
+		{
 			fail("Should raise a java.sqlSQLException");
 		}
 		catch (SQLException e)
@@ -448,15 +494,14 @@ public class TestGroupBy
 
 	@Test
 	public void testSelectUngroupedColumn() throws SQLException
-	{		
-		try
-		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
-
-			stmt.executeQuery("SELECT Id FROM sample4 group by Job");
+			ResultSet results = stmt.executeQuery("SELECT Id FROM sample4 group by Job"))
+		{
 			fail("Should raise a java.sqlSQLException");
 		}
 		catch (SQLException e)
@@ -467,15 +512,14 @@ public class TestGroupBy
 
 	@Test
 	public void testOrderByUngroupedColumn() throws SQLException
-	{		
-		try
-		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
-
-			stmt.executeQuery("SELECT Job FROM sample4 group by Job order by Id");
+			ResultSet results = stmt.executeQuery("SELECT Job FROM sample4 group by Job order by Id"))
+		{
 			fail("Should raise a java.sqlSQLException");
 		}
 		catch (SQLException e)
@@ -493,68 +537,76 @@ public class TestGroupBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select FROM_BLZ from transactions group by FROM_BLZ having FROM_BLZ > 10020000");
-		assertTrue(results.next());
-		assertEquals("The FROM_BLZ is wrong", 10020500, results.getInt("FROM_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The FROM_BLZ is wrong", 10020200, results.getInt("FROM_BLZ"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select FROM_BLZ from transactions group by FROM_BLZ having FROM_BLZ > 10020000"))
+		{
+			assertTrue(results.next());
+			assertEquals("The FROM_BLZ is wrong", 10020500, results.getInt("FROM_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The FROM_BLZ is wrong", 10020200, results.getInt("FROM_BLZ"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testHavingCount() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select Job from sample5 group by Job having COUNT(Job) = 1");
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Piloto", results.getString("Job"));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Office Manager", results.getString("Job"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select Job from sample5 group by Job having COUNT(Job) = 1"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Piloto", results.getString("Job"));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Office Manager", results.getString("Job"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testSelectAndHavingCount() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select Job, COUNT(Job) from sample5 group by Job having COUNT(Job) > 1");
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
-		assertEquals("The COUNT(Job) is wrong", 3, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("The Job is wrong", "Office Employee", results.getString("Job"));
-		assertEquals("The COUNT(Job) is wrong", 4, results.getInt(2));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select Job, COUNT(Job) from sample5 group by Job having COUNT(Job) > 1"))
+		{
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
+			assertEquals("The COUNT(Job) is wrong", 3, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("The Job is wrong", "Office Employee", results.getString("Job"));
+			assertEquals("The COUNT(Job) is wrong", 4, results.getInt(2));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testHavingWithBadColumnName() throws SQLException
-	{		
-		try
-		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
-
-			stmt.executeQuery("SELECT Id FROM sample group by Id HAVING XXXX = 1");
+			ResultSet results = stmt.executeQuery("SELECT Id FROM sample group by Id HAVING XXXX = 1"))
+		{
 			fail("Should raise a java.sqlSQLException");
 		}
 		catch (SQLException e)
@@ -565,15 +617,15 @@ public class TestGroupBy
 
 	@Test
 	public void testHavingUngroupedColumn() throws SQLException
-	{		
-		try
-		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
 			Statement stmt = conn.createStatement();
 
-			stmt.executeQuery("SELECT Id FROM sample group by Id HAVING Name = 'foo'");
+			ResultSet results = stmt.executeQuery("SELECT Id FROM sample group by Id HAVING Name = 'foo'"))
+		{
 			fail("Should raise a java.sqlSQLException");
 		}
 		catch (SQLException e)
@@ -591,54 +643,52 @@ public class TestGroupBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select FROM_BLZ, count(distinct FROM_ACCT) from transactions group by FROM_BLZ order by FROM_BLZ");
-		assertTrue(results.next());
-		assertEquals("Incorrect FROM_BLZ", "10010010", results.getString(1));
-		assertEquals("Incorrect count FROM_ACCT", 2, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("Incorrect FROM_BLZ", "10020200", results.getString(1));
-		assertEquals("Incorrect count FROM_ACCT", 1, results.getInt(2));
-		assertTrue(results.next());
-		assertEquals("Incorrect FROM_BLZ", "10020500", results.getString(1));
-		assertEquals("Incorrect count FROM_ACCT", 1, results.getInt(2));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
 
-		results.close();
-		stmt.close();
-		conn.close();
+			ResultSet results = stmt.executeQuery("select FROM_BLZ, count(distinct FROM_ACCT) from transactions group by FROM_BLZ order by FROM_BLZ"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect FROM_BLZ", "10010010", results.getString(1));
+			assertEquals("Incorrect count FROM_ACCT", 2, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("Incorrect FROM_BLZ", "10020200", results.getString(1));
+			assertEquals("Incorrect count FROM_ACCT", 1, results.getInt(2));
+			assertTrue(results.next());
+			assertEquals("Incorrect FROM_BLZ", "10020500", results.getString(1));
+			assertEquals("Incorrect count FROM_ACCT", 1, results.getInt(2));
+			assertFalse(results.next());
+		}
 	}
-	
+
 	@Test
 	public void testGroupBySumAvgDistinct() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,Int,Int,Date,Time");
 		props.put("dateFormat", "M/D/YYYY");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt.executeQuery("select CampaignNo, sum(distinct PurchaseCt), round(avg(distinct PurchaseCt)*10) from Purchase group by CampaignNo order by CampaignNo");
-		assertTrue(results.next());
-		assertEquals("Incorrect CampaignNo", 1, results.getInt(1));
-		assertEquals("Incorrect sum PurchaseCt", 4 + 1 + 11, results.getInt(2));
-		assertEquals("Incorrect avg PurchaseCt", Math.round((4 + 1 + 11) / 3.0 * 10), results.getInt(3));
-		assertTrue(results.next());
-		assertEquals("Incorrect CampaignNo", 21, results.getInt(1));
-		assertEquals("Incorrect sum PurchaseCt", 1 + 3, results.getInt(2));
-		assertEquals("Incorrect avg PurchaseCt", Math.round((1 + 3) / 2.0 * 10), results.getInt(3));
-		assertTrue(results.next());
-		assertEquals("Incorrect CampaignNo", 61, results.getInt(1));
-		assertEquals("Incorrect sum PurchaseCt", 4, results.getInt(2));
-		assertEquals("Incorrect avg PurchaseCt", 4 * 10, results.getInt(3));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
 
-		results.close();
-		stmt.close();
-		conn.close();
+			ResultSet results = stmt.executeQuery("select CampaignNo, sum(distinct PurchaseCt), round(avg(distinct PurchaseCt)*10) from Purchase group by CampaignNo order by CampaignNo"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect CampaignNo", 1, results.getInt(1));
+			assertEquals("Incorrect sum PurchaseCt", 4 + 1 + 11, results.getInt(2));
+			assertEquals("Incorrect avg PurchaseCt", Math.round((4 + 1 + 11) / 3.0 * 10), results.getInt(3));
+			assertTrue(results.next());
+			assertEquals("Incorrect CampaignNo", 21, results.getInt(1));
+			assertEquals("Incorrect sum PurchaseCt", 1 + 3, results.getInt(2));
+			assertEquals("Incorrect avg PurchaseCt", Math.round((1 + 3) / 2.0 * 10), results.getInt(3));
+			assertTrue(results.next());
+			assertEquals("Incorrect CampaignNo", 61, results.getInt(1));
+			assertEquals("Incorrect sum PurchaseCt", 4, results.getInt(2));
+			assertEquals("Incorrect avg PurchaseCt", 4 * 10, results.getInt(3));
+			assertFalse(results.next());
+		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestJoinedTables.java
+++ b/src/test/java/org/relique/jdbc/csv/TestJoinedTables.java
@@ -67,173 +67,173 @@ public class TestJoinedTables
 
 		// setting both transposedLines and skipTransposedFields informs the
 		// driver we are receiving a compacted join
-		
-		// L,P,K,U,W, leaving D,T as regular fields, V as matrix of joined values 
+
+		// L,P,K,U,W, leaving D,T as regular fields, V as matrix of joined values
 		props.put("transposedLines", "5"); 
-		
+
 		// the first column in the transposed table holds the (ignored) header.
 		props.put("transposedFieldsToSkip", "1");
 		// the driver must be told that there is no header.
 		props.put("suppressHeaders", "true");
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		results = stmt.executeQuery("SELECT * FROM twojoinedtables01");
-		assertTrue("there should be results", results.next());
-		assertEquals("l1", results.getObject("L"));
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("k1", results.getObject("K"));
-		assertEquals("u1", results.getObject("U"));
-		assertEquals("w1", results.getObject("W"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v11", results.getObject("V"));
+			ResultSet results = stmt.executeQuery("SELECT * FROM twojoinedtables01"))
+		{
+			assertTrue("there should be results", results.next());
+			assertEquals("l1", results.getObject("L"));
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("k1", results.getObject("K"));
+			assertEquals("u1", results.getObject("U"));
+			assertEquals("w1", results.getObject("W"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v11", results.getObject("V"));
 
-		assertTrue("there should be results", results.next());
-		assertEquals("l2", results.getObject("L"));
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("k2", results.getObject("K"));
-		assertEquals("u2", results.getObject("U"));
-		assertEquals("w2", results.getObject("W"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v12", results.getObject("V"));
+			assertTrue("there should be results", results.next());
+			assertEquals("l2", results.getObject("L"));
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("k2", results.getObject("K"));
+			assertEquals("u2", results.getObject("U"));
+			assertEquals("w2", results.getObject("W"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v12", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l3", results.getObject("L"));
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("k3", results.getObject("K"));
-		assertEquals("u3", results.getObject("U"));
-		assertEquals("w3", results.getObject("W"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v13", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l3", results.getObject("L"));
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("k3", results.getObject("K"));
+			assertEquals("u3", results.getObject("U"));
+			assertEquals("w3", results.getObject("W"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v13", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l1", results.getObject("L"));
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("k1", results.getObject("K"));
-		assertEquals("u1", results.getObject("U"));
-		assertEquals("w1", results.getObject("W"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v21", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l1", results.getObject("L"));
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("k1", results.getObject("K"));
+			assertEquals("u1", results.getObject("U"));
+			assertEquals("w1", results.getObject("W"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v21", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l2", results.getObject("L"));
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("k2", results.getObject("K"));
-		assertEquals("u2", results.getObject("U"));
-		assertEquals("w2", results.getObject("W"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v22", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l2", results.getObject("L"));
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("k2", results.getObject("K"));
+			assertEquals("u2", results.getObject("U"));
+			assertEquals("w2", results.getObject("W"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v22", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l3", results.getObject("L"));
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("k3", results.getObject("K"));
-		assertEquals("u3", results.getObject("U"));
-		assertEquals("w3", results.getObject("W"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v23", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l3", results.getObject("L"));
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("k3", results.getObject("K"));
+			assertEquals("u3", results.getObject("U"));
+			assertEquals("w3", results.getObject("W"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v23", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l1", results.getObject("L"));
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("k1", results.getObject("K"));
-		assertEquals("u1", results.getObject("U"));
-		assertEquals("w1", results.getObject("W"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v31", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l1", results.getObject("L"));
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("k1", results.getObject("K"));
+			assertEquals("u1", results.getObject("U"));
+			assertEquals("w1", results.getObject("W"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v31", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l2", results.getObject("L"));
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("k2", results.getObject("K"));
-		assertEquals("u2", results.getObject("U"));
-		assertEquals("w2", results.getObject("W"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v32", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l2", results.getObject("L"));
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("k2", results.getObject("K"));
+			assertEquals("u2", results.getObject("U"));
+			assertEquals("w2", results.getObject("W"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v32", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l3", results.getObject("L"));
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("k3", results.getObject("K"));
-		assertEquals("u3", results.getObject("U"));
-		assertEquals("w3", results.getObject("W"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v33", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l3", results.getObject("L"));
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("k3", results.getObject("K"));
+			assertEquals("u3", results.getObject("U"));
+			assertEquals("w3", results.getObject("W"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v33", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l1", results.getObject("L"));
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("k1", results.getObject("K"));
-		assertEquals("u1", results.getObject("U"));
-		assertEquals("w1", results.getObject("W"));
-		assertEquals("d4", results.getObject("D"));
-		assertEquals("t4", results.getObject("T"));
-		assertEquals("v41", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l1", results.getObject("L"));
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("k1", results.getObject("K"));
+			assertEquals("u1", results.getObject("U"));
+			assertEquals("w1", results.getObject("W"));
+			assertEquals("d4", results.getObject("D"));
+			assertEquals("t4", results.getObject("T"));
+			assertEquals("v41", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l2", results.getObject("L"));
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("k2", results.getObject("K"));
-		assertEquals("u2", results.getObject("U"));
-		assertEquals("w2", results.getObject("W"));
-		assertEquals("d4", results.getObject("D"));
-		assertEquals("t4", results.getObject("T"));
-		assertEquals("v42", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l2", results.getObject("L"));
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("k2", results.getObject("K"));
+			assertEquals("u2", results.getObject("U"));
+			assertEquals("w2", results.getObject("W"));
+			assertEquals("d4", results.getObject("D"));
+			assertEquals("t4", results.getObject("T"));
+			assertEquals("v42", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l3", results.getObject("L"));
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("k3", results.getObject("K"));
-		assertEquals("u3", results.getObject("U"));
-		assertEquals("w3", results.getObject("W"));
-		assertEquals("d4", results.getObject("D"));
-		assertEquals("t4", results.getObject("T"));
-		assertEquals("v43", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l3", results.getObject("L"));
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("k3", results.getObject("K"));
+			assertEquals("u3", results.getObject("U"));
+			assertEquals("w3", results.getObject("W"));
+			assertEquals("d4", results.getObject("D"));
+			assertEquals("t4", results.getObject("T"));
+			assertEquals("v43", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l1", results.getObject("L"));
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("k1", results.getObject("K"));
-		assertEquals("u1", results.getObject("U"));
-		assertEquals("w1", results.getObject("W"));
-		assertEquals("d5", results.getObject("D"));
-		assertEquals("t5", results.getObject("T"));
-		assertEquals("v51", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l1", results.getObject("L"));
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("k1", results.getObject("K"));
+			assertEquals("u1", results.getObject("U"));
+			assertEquals("w1", results.getObject("W"));
+			assertEquals("d5", results.getObject("D"));
+			assertEquals("t5", results.getObject("T"));
+			assertEquals("v51", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l2", results.getObject("L"));
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("k2", results.getObject("K"));
-		assertEquals("u2", results.getObject("U"));
-		assertEquals("w2", results.getObject("W"));
-		assertEquals("d5", results.getObject("D"));
-		assertEquals("t5", results.getObject("T"));
-		assertEquals("v52", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l2", results.getObject("L"));
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("k2", results.getObject("K"));
+			assertEquals("u2", results.getObject("U"));
+			assertEquals("w2", results.getObject("W"));
+			assertEquals("d5", results.getObject("D"));
+			assertEquals("t5", results.getObject("T"));
+			assertEquals("v52", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("l3", results.getObject("L"));
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("k3", results.getObject("K"));
-		assertEquals("u3", results.getObject("U"));
-		assertEquals("w3", results.getObject("W"));
-		assertEquals("d5", results.getObject("D"));
-		assertEquals("t5", results.getObject("T"));
-		assertEquals("v53", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("l3", results.getObject("L"));
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("k3", results.getObject("K"));
+			assertEquals("u3", results.getObject("U"));
+			assertEquals("w3", results.getObject("W"));
+			assertEquals("d5", results.getObject("D"));
+			assertEquals("t5", results.getObject("T"));
+			assertEquals("v53", results.getObject("V"));
 
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -242,118 +242,118 @@ public class TestJoinedTables
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("headerline", "P,D,T,V");
-		
+
 		// setting both transposedLines and skipTransposedFields informs the
 		// driver we are receiving a compacted join
-		
+
 		// transposedLines <- 1; leaving D,T as regular fields, V as matrix of
 		// joined values
 		props.put("transposedLines", "1");
-		
+
 		// transposedFieldsToSkip <- 2; the file looks like a regular CSV (with
 		// variable header)
 		props.put("transposedFieldsToSkip", "2");
 		// the driver must be told that there is no header.
 		props.put("suppressHeaders", "true");
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		results = stmt.executeQuery("SELECT * FROM twojoinedtables02");
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v11", results.getObject("V"));
+			ResultSet results = stmt.executeQuery("SELECT * FROM twojoinedtables02"))
+		{
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v11", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v12", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v12", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v13", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v13", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p4", results.getObject("P"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v14", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p4", results.getObject("P"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v14", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p5", results.getObject("P"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v15", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p5", results.getObject("P"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v15", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v21", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v21", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v22", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v22", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v23", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v23", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p4", results.getObject("P"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v24", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p4", results.getObject("P"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v24", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p5", results.getObject("P"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v25", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p5", results.getObject("P"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v25", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v31", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v31", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v32", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v32", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v33", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v33", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p4", results.getObject("P"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v34", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p4", results.getObject("P"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v34", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p5", results.getObject("P"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v35", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p5", results.getObject("P"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v35", results.getObject("V"));
 
-		assertFalse(results.next());
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -362,159 +362,159 @@ public class TestJoinedTables
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("headerline", "P,J,D,T,V");
-		
+
 		// setting both transposedLines and skipTransposedFields informs the
 		// driver we are receiving a compacted join
-		
+
 		// transposedLines <- 1; leaving D,T as regular fields, V as matrix of
 		// joined values
 		props.put("transposedLines", "1");
-		
+
 		// transposedFieldsToSkip <- 2; the file looks like a regular CSV (with
 		// variable header)
 		props.put("transposedFieldsToSkip", "3");
 		// the driver must be told that there is no header.
 		props.put("suppressHeaders", "true");
-		
+
 		props.put("indexedFiles", "True");
 		props.put("fileTailPattern", "_(.*)");
 		props.put("fileTailParts", "junk");
 		props.put("fileTailPrepend", "true");
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		results = stmt.executeQuery("SELECT * FROM twojoinedtablesindex");
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("1", results.getObject("J"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v11", results.getObject("V"));
+			ResultSet results = stmt.executeQuery("SELECT * FROM twojoinedtablesindex"))
+		{
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("1", results.getObject("J"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v11", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("1", results.getObject("J"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v12", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("1", results.getObject("J"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v12", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("1", results.getObject("J"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v13", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("1", results.getObject("J"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v13", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("1", results.getObject("J"));
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v21", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("1", results.getObject("J"));
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v21", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("1", results.getObject("J"));
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v22", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("1", results.getObject("J"));
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v22", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("1", results.getObject("J"));
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("d2", results.getObject("D"));
-		assertEquals("t2", results.getObject("T"));
-		assertEquals("v23", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("1", results.getObject("J"));
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("d2", results.getObject("D"));
+			assertEquals("t2", results.getObject("T"));
+			assertEquals("v23", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("1", results.getObject("J"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v31", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("1", results.getObject("J"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v31", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("1", results.getObject("J"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v32", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("1", results.getObject("J"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v32", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("1", results.getObject("J"));
-		assertEquals("d3", results.getObject("D"));
-		assertEquals("t3", results.getObject("T"));
-		assertEquals("v33", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("1", results.getObject("J"));
+			assertEquals("d3", results.getObject("D"));
+			assertEquals("t3", results.getObject("T"));
+			assertEquals("v33", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("2", results.getObject("J"));
-		assertEquals("d7", results.getObject("D"));
-		assertEquals("t7", results.getObject("T"));
-		assertEquals("v71", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("2", results.getObject("J"));
+			assertEquals("d7", results.getObject("D"));
+			assertEquals("t7", results.getObject("T"));
+			assertEquals("v71", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("2", results.getObject("J"));
-		assertEquals("d7", results.getObject("D"));
-		assertEquals("t7", results.getObject("T"));
-		assertEquals("v72", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("2", results.getObject("J"));
+			assertEquals("d7", results.getObject("D"));
+			assertEquals("t7", results.getObject("T"));
+			assertEquals("v72", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("2", results.getObject("J"));
-		assertEquals("d7", results.getObject("D"));
-		assertEquals("t7", results.getObject("T"));
-		assertEquals("v73", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("2", results.getObject("J"));
+			assertEquals("d7", results.getObject("D"));
+			assertEquals("t7", results.getObject("T"));
+			assertEquals("v73", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("2", results.getObject("J"));
-		assertEquals("d8", results.getObject("D"));
-		assertEquals("t8", results.getObject("T"));
-		assertEquals("v81", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("2", results.getObject("J"));
+			assertEquals("d8", results.getObject("D"));
+			assertEquals("t8", results.getObject("T"));
+			assertEquals("v81", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("2", results.getObject("J"));
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("d8", results.getObject("D"));
-		assertEquals("t8", results.getObject("T"));
-		assertEquals("v82", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("2", results.getObject("J"));
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("d8", results.getObject("D"));
+			assertEquals("t8", results.getObject("T"));
+			assertEquals("v82", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("2", results.getObject("J"));
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("d8", results.getObject("D"));
-		assertEquals("t8", results.getObject("T"));
-		assertEquals("v83", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("2", results.getObject("J"));
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("d8", results.getObject("D"));
+			assertEquals("t8", results.getObject("T"));
+			assertEquals("v83", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("2", results.getObject("J"));
-		assertEquals("d9", results.getObject("D"));
-		assertEquals("t9", results.getObject("T"));
-		assertEquals("v91", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("2", results.getObject("J"));
+			assertEquals("d9", results.getObject("D"));
+			assertEquals("t9", results.getObject("T"));
+			assertEquals("v91", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("2", results.getObject("J"));
-		assertEquals("d9", results.getObject("D"));
-		assertEquals("t9", results.getObject("T"));
-		assertEquals("v92", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("2", results.getObject("J"));
+			assertEquals("d9", results.getObject("D"));
+			assertEquals("t9", results.getObject("T"));
+			assertEquals("v92", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p3", results.getObject("P"));
-		assertEquals("2", results.getObject("J"));
-		assertEquals("d9", results.getObject("D"));
-		assertEquals("t9", results.getObject("T"));
-		assertEquals("v93", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p3", results.getObject("P"));
+			assertEquals("2", results.getObject("J"));
+			assertEquals("d9", results.getObject("D"));
+			assertEquals("t9", results.getObject("T"));
+			assertEquals("v93", results.getObject("V"));
 
-		// assertFalse(results.next()); don't test this: I've added a third file for an other test.
+			// assertFalse(results.next()); don't test this: I've added a third file for an other test.
+		}
 	}
 
 	@Test
@@ -524,70 +524,70 @@ public class TestJoinedTables
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
 		props.put("headerline", "P,J,D,T,V");
-		
+
 		// setting both transposedLines and skipTransposedFields informs the
 		// driver we are receiving a compacted join
-		
+
 		// transposedLines <- 1; leaving D,T as regular fields, V as matrix of
 		// joined values
 		props.put("transposedLines", "1");
-		
+
 		// transposedFieldsToSkip <- 2; the file looks like a regular CSV (with
 		// variable header)
 		props.put("transposedFieldsToSkip", "3");
 		// the driver must be told that there is no header.
 		props.put("suppressHeaders", "true");
-		
+
 		props.put("indexedFiles", "True");
 		props.put("fileTailPattern", "_(.*)");
 		props.put("fileTailParts", "junk");
 		props.put("fileTailPrepend", "true");
 
-		ResultSet results = null;
-
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath, props);
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		results = stmt.executeQuery("SELECT * FROM twojoinedtablesindex");
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
-		assertTrue(results.next());
+			ResultSet results = stmt.executeQuery("SELECT * FROM twojoinedtablesindex"))
+		{
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertTrue(results.next());
 
-		assertTrue(results.next());
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("3", results.getObject("J"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v11", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("3", results.getObject("J"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v11", results.getObject("V"));
 
-		assertTrue(results.next());
-		assertEquals("p2", results.getObject("P"));
-		assertEquals("3", results.getObject("J"));
-		assertEquals("d1", results.getObject("D"));
-		assertEquals("t1", results.getObject("T"));
-		assertEquals("v12", results.getObject("V"));
+			assertTrue(results.next());
+			assertEquals("p2", results.getObject("P"));
+			assertEquals("3", results.getObject("J"));
+			assertEquals("d1", results.getObject("D"));
+			assertEquals("t1", results.getObject("T"));
+			assertEquals("v12", results.getObject("V"));
 
-		assertTrue(results.next()); // TODO: here it crashes
-		assertEquals("p1", results.getObject("P"));
-		assertEquals("3", results.getObject("J"));
-		assertEquals("d9", results.getObject("D"));
-		assertEquals("t9", results.getObject("T"));
-		assertEquals("v93", results.getObject("V"));
+			assertTrue(results.next()); // TODO: here it crashes
+			assertEquals("p1", results.getObject("P"));
+			assertEquals("3", results.getObject("J"));
+			assertEquals("d9", results.getObject("D"));
+			assertEquals("t9", results.getObject("T"));
+			assertEquals("v93", results.getObject("V"));
+		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestLimitOffset.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLimitOffset.java
@@ -71,21 +71,24 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select id from sample5 limit 4");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 41, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 1, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select id from sample5 limit 4"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 1, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -93,21 +96,24 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select id from sample4 limit 999");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 1, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 4, results.getInt("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select id from sample4 limit 999"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 1, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 4, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -115,19 +121,22 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select id from sample5 where id > 6 limit 3");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 41, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 7, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 8, results.getInt("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select id from sample5 where id > 6 limit 3"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 7, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -135,17 +144,20 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select id, name from sample5 order by id desc limit 2");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 41, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 9, results.getInt("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select id, name from sample5 order by id desc limit 2"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 9, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -153,17 +165,20 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select id from sample5 limit 9 offset 8");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 8, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 9, results.getInt("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select id from sample5 limit 9 offset 8"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 9, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -171,13 +186,16 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select id from sample5 limit 99 offset 99");
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select id from sample5 limit 99 offset 99"))
+		{
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -185,19 +203,22 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select id from sample5 where id > 2 limit 3 offset 4");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 6, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 7, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 8, results.getInt("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select id from sample5 where id > 2 limit 3 offset 4"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 6, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 7, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -205,23 +226,26 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select * from sample5 order by id limit 99 offset 5");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 6, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 7, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 8, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 9, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 41, results.getInt("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select * from sample5 order by id limit 99 offset 5"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 6, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 7, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 9, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -229,18 +253,20 @@ public class TestLimitOffset
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,String,Date,Time");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		try
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("select * from sample5 limit 5 offset -1");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertTrue(e.toString().startsWith("java.sql.SQLException: " + CsvResources.getString("syntaxError")));
+			try
+			{
+				stmt.executeQuery("select * from sample5 limit 5 offset -1");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.toString().startsWith("java.sql.SQLException: " + CsvResources.getString("syntaxError")));
+			}
 		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
@@ -62,8 +62,8 @@ public class TestOrderBy
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");  
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));  
+		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 
 	@Test
@@ -76,43 +76,46 @@ public class TestOrderBy
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Integer,String");
 		props.put("charset", "UTF-8");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM banks ORDER BY BANK_NAME");
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010424, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "Aareal Bank (Berlin)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10020200, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "BHF-BANK (Berlin)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10020500, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10020000, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "Berliner Bank -alt- (Berlin)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10000000, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "Bundesbank (Berlin)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10020400, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "Citadele Bank Zndl Deutschland (M\u00FCnchen)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10019610, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "Dexia Kommunalbank Deutschland (Berlin)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010010, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "Postbank (Berlin)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010111, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "SEB (Berlin)", results.getString("BANK_NAME"));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010222, results.getInt("BLZ"));
-		assertEquals("The BLZ_NAME is wrong", "The Royal Bank of Scotland, Niederlassung Deutschland (Berlin)", results.getString("BANK_NAME"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM banks ORDER BY BANK_NAME"))
+		{
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10010424, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "Aareal Bank (Berlin)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10020200, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "BHF-BANK (Berlin)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10020500, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10020000, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "Berliner Bank -alt- (Berlin)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10000000, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "Bundesbank (Berlin)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10020400, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "Citadele Bank Zndl Deutschland (M\u00FCnchen)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10019610, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "Dexia Kommunalbank Deutschland (Berlin)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10010010, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "Postbank (Berlin)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10010111, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "SEB (Berlin)", results.getString("BANK_NAME"));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10010222, results.getInt("BLZ"));
+			assertEquals("The BLZ_NAME is wrong", "The Royal Bank of Scotland, Niederlassung Deutschland (Berlin)", results.getString("BANK_NAME"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -120,33 +123,36 @@ public class TestOrderBy
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT * FROM sample5 ORDER BY 1");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 1, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 4, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 5, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 6, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 7, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 8, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 9, results.getInt("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 41, results.getInt("ID"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM sample5 ORDER BY 1"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 1, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 4, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 5, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 6, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 7, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 9, results.getInt("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -154,17 +160,20 @@ public class TestOrderBy
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ID+10 AS ID10 FROM sample5 ORDER BY 1");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 11, results.getInt("ID10"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 12, results.getInt("ID10"));
-		assertTrue(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT ID+10 AS ID10 FROM sample5 ORDER BY 1"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 11, results.getInt("ID10"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 12, results.getInt("ID10"));
+			assertTrue(results.next());
+		}
 	}
 
 	@Test
@@ -176,33 +185,36 @@ public class TestOrderBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Integer,String");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT BLZ FROM banks ORDER BY BLZ DESC");
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10020500, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10020400, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10020200, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10020000, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10019610, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010424, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010222, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010111, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10010010, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The BLZ is wrong", 10000000, results.getInt(1));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT BLZ FROM banks ORDER BY BLZ DESC"))
+		{
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10020500, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10020400, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10020200, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10020000, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10019610, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10010424, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10010222, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10010111, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10010010, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The BLZ is wrong", 10000000, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -214,40 +226,43 @@ public class TestOrderBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select * from transactions order by from_blz, from_acct");
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 58340576, results.getInt("from_acct"));
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10020200, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 2340529, results.getInt("from_acct"));
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
-		assertTrue(results.next());
-		assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
-		assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select * from transactions order by from_blz, from_acct"))
+		{
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 58340576, results.getInt("from_acct"));
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10020200, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 2340529, results.getInt("from_acct"));
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
+			assertTrue(results.next());
+			assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
+			assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
@@ -259,22 +274,25 @@ public class TestOrderBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT FROM_ACCT, FROM_BLZ from transactions where AMOUNT < 50 ORDER BY AMOUNT");
-		assertTrue(results.next());
-		assertEquals("The FROM_ACCT is wrong", 97540210, results.getInt("FROM_ACCT"));
-		assertEquals("The FROM_BLZ is wrong", 10020500, results.getInt("FROM_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt("FROM_ACCT"));
-		assertEquals("The FROM_BLZ is wrong", 10010010, results.getInt("FROM_BLZ"));
-		assertTrue(results.next());
-		assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt("FROM_ACCT"));
-		assertEquals("The FROM_BLZ is wrong", 10010010, results.getInt("FROM_BLZ"));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT FROM_ACCT, FROM_BLZ from transactions where AMOUNT < 50 ORDER BY AMOUNT"))
+		{
+			assertTrue(results.next());
+			assertEquals("The FROM_ACCT is wrong", 97540210, results.getInt("FROM_ACCT"));
+			assertEquals("The FROM_BLZ is wrong", 10020500, results.getInt("FROM_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt("FROM_ACCT"));
+			assertEquals("The FROM_BLZ is wrong", 10010010, results.getInt("FROM_BLZ"));
+			assertTrue(results.next());
+			assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt("FROM_ACCT"));
+			assertEquals("The FROM_BLZ is wrong", 10010010, results.getInt("FROM_BLZ"));
+			assertFalse(results.next());
+		}
 	}
 
 	/**
@@ -294,20 +312,23 @@ public class TestOrderBy
 		props.put("fileExtension", ".txt");
 		props.put("commentChar", "#");
 		props.put("columnTypes", "Date,Integer,Integer,Integer,Integer,Double");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT FROM_ACCT, AMOUNT * 0.01 as FEE from transactions ORDER BY FEE");
-		assertTrue(results.next());
-		assertEquals("The FROM_ACCT is wrong", 97540210, results.getInt(1));
-		double fee = results.getDouble(2);
-		assertTrue("The FEE is wrong", fuzzyEquals(7.23 * 0.01, fee));
-		assertTrue(results.next());
-		assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt(1));
-		fee = results.getDouble(2);
-		assertTrue("The FEE is wrong", fuzzyEquals(21.23 * 0.01, fee));
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT FROM_ACCT, AMOUNT * 0.01 as FEE from transactions ORDER BY FEE"))
+		{
+			assertTrue(results.next());
+			assertEquals("The FROM_ACCT is wrong", 97540210, results.getInt(1));
+			double fee = results.getDouble(2);
+			assertTrue("The FEE is wrong", fuzzyEquals(7.23 * 0.01, fee));
+			assertTrue(results.next());
+			assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt(1));
+			fee = results.getDouble(2);
+			assertTrue("The FEE is wrong", fuzzyEquals(21.23 * 0.01, fee));
+		}
 	}
 
 	@Test
@@ -319,20 +340,23 @@ public class TestOrderBy
 		props.put("fileTailParts", "location,file_date");
 		props.put("indexedFiles", "True");
 		props.put("columnTypes", "Date,Time,String,Float,Float,String,String");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT AI007.000, AI007.001 FROM test ORDER BY AI007.000 + AI007.001 DESC");
-		assertTrue(results.next());
-		double a0 = results.getFloat("AI007.000");
-		double a1 = results.getFloat("AI007.001");
-		assertTrue("The sort order is wrong", fuzzyEquals(26.54, a0 + a1));
-		assertTrue(results.next());
-		a0 = results.getFloat("AI007.000");
-		a1 = results.getFloat("AI007.001");
-		assertTrue("The sort order is wrong", fuzzyEquals(26.54, a0 + a1));
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT AI007.000, AI007.001 FROM test ORDER BY AI007.000 + AI007.001 DESC"))
+		{
+			assertTrue(results.next());
+			double a0 = results.getFloat("AI007.000");
+			double a1 = results.getFloat("AI007.001");
+			assertTrue("The sort order is wrong", fuzzyEquals(26.54, a0 + a1));
+			assertTrue(results.next());
+			a0 = results.getFloat("AI007.000");
+			a1 = results.getFloat("AI007.001");
+			assertTrue("The sort order is wrong", fuzzyEquals(26.54, a0 + a1));
+		}
 	}
 
 	@Test
@@ -342,45 +366,47 @@ public class TestOrderBy
 		props.put("columnTypes", "Int,String,String,Date,Time");
 		props.put("timeFormat", "HHmm");
 		props.put("dateFormat", "yyyy-MM-dd");
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		ResultSet results = stmt
-				.executeQuery("select * from sample5 order by start+timeoffset asc");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 1, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 41, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 2, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 3, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 7, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 8, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 4, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 5, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 6, results.getInt(1));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", 9, results.getInt(1));
-		assertFalse(results.next());
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("select * from sample5 order by start+timeoffset asc"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 1, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 41, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 2, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 3, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 7, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 8, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 4, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 5, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 6, results.getInt(1));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", 9, results.getInt(1));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testOrderByWithBadColumnName() throws SQLException
-	{		
-		try
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+
+			Statement stmt = conn.createStatement())
 		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-			Statement stmt = conn.createStatement();
-
 			stmt.executeQuery("SELECT Id FROM sample order by XXXX");
 			fail("Should raise a java.sqlSQLException");
 		}
@@ -392,14 +418,13 @@ public class TestOrderBy
 
 	@Test
 	public void testOrderByWithBadColumnNumber() throws SQLException
-	{		
-		try
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+
+			Statement stmt = conn.createStatement())
 		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-			Statement stmt = conn.createStatement();
-
 			stmt.executeQuery("SELECT * FROM sample ORDER BY 99");
 			fail("Should raise a java.sqlSQLException");
 		}
@@ -411,14 +436,13 @@ public class TestOrderBy
 
 	@Test
 	public void testOrderByWithFloatColumnNumber() throws SQLException
-	{		
-		try
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+
+			Statement stmt = conn.createStatement())
 		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-			Statement stmt = conn.createStatement();
-
 			stmt.executeQuery("SELECT * FROM sample ORDER BY 3.14");
 			fail("Should raise a java.sqlSQLException");
 		}
@@ -430,14 +454,13 @@ public class TestOrderBy
 
 	@Test
 	public void testOrderByWithBadValue() throws SQLException
-	{		
-		try
+	{
+		Properties props = new Properties();
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+
+			Statement stmt = conn.createStatement())
 		{
-			Properties props = new Properties();
-			Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
-
-			Statement stmt = conn.createStatement();
-
 			stmt.executeQuery("SELECT * FROM sample ORDER BY 'X'");
 			fail("Should raise a java.sqlSQLException");
 		}
@@ -450,10 +473,12 @@ public class TestOrderBy
 	@Test
 	public void testOrderByNoResults() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
-		Statement stmt = conn.createStatement();
-		ResultSet results = stmt
-				.executeQuery("SELECT Name, Job FROM sample4 WHERE ID='05' order by Name");
-		assertFalse(results.next());
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt
+				.executeQuery("SELECT Name, Job FROM sample4 WHERE ID='05' order by Name"))
+		{
+			assertFalse(results.next());
+		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestScrollableDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestScrollableDriver.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 
 /**
  * This class is used to test the CsvJdbc Scrollable driver.
- * 
+ *
  * @author Chetan Gupta
  */
 public class TestScrollableDriver
@@ -67,247 +67,242 @@ public class TestScrollableDriver
 	{
 		// create a connection. The first command line parameter is assumed to
 		// be the directory in which the .csv files are held
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		// create a Statement object to execute the query with
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
-			ResultSet.CONCUR_READ_ONLY);
+			// create a Statement object to execute the query with
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+				ResultSet.CONCUR_READ_ONLY);
 
-		// Select the ID and NAME columns from sample.csv
-		ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample");
-
-		// dump out the results
-		results.next();
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "\"S,\"", results
-				.getString("NAME"));
-		assertEquals("incorrect row #", 1, results.getRow());
-
-		results.next();
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
-				.getString("NAME"));
-		assertEquals("incorrect row #", 2, results.getRow());
-
-		results.previous();
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "\"S,\"", results
-				.getString("NAME"));
-
-		results.first();
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "\"S,\"", results
-				.getString("NAME"));
-		assertEquals("incorrect row #", 1, results.getRow());
-
-		assertFalse(results.previous());
-		assertEquals("incorrect row #", 0, results.getRow());
-		try
+			// Select the ID and NAME columns from sample.csv
+			ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample"))
 		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
+			// dump out the results
+			results.next();
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "\"S,\"", results
+					.getString("NAME"));
+			assertEquals("incorrect row #", 1, results.getRow());
+
+			results.next();
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
+					.getString("NAME"));
+			assertEquals("incorrect row #", 2, results.getRow());
+
+			results.previous();
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "\"S,\"", results
+					.getString("NAME"));
+
+			results.first();
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "\"S,\"", results
+					.getString("NAME"));
+			assertEquals("incorrect row #", 1, results.getRow());
+
+			assertFalse(results.previous());
+			assertEquals("incorrect row #", 0, results.getRow());
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			results.next();
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "\"S,\"", results
+					.getString("NAME"));
+
+			results.next();
+			assertEquals("incorrect row #", 2, results.getRow());
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
+					.getString("NAME"));
+
+			results.absolute(1);
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "\"S,\"", results
+					.getString("NAME"));
+
+			results.absolute(2);
+			assertEquals("incorrect row #", 2, results.getRow());
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
+					.getString("NAME"));
+
+			results.relative(2);
+			assertEquals("incorrect row #", 4, results.getRow());
+			assertEquals("Incorrect ID Value", "C456", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Susan, Peter and Dave", results
+					.getString("NAME"));
+
+			results.relative(-3);
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "\"S,\"", results
+					.getString("NAME"));
+
+			results.relative(0);
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", results.getString("NAME"),
+					"\"S,\"");
+
+			results.last();
+			assertEquals("incorrect row #", 6, results.getRow());
+			assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
+			assertEquals("Incorrect NAME Value",
+					"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
+							.getString("NAME"));
+
+			results.absolute(-1);
+			assertEquals("incorrect row #", 6, results.getRow());
+			assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
+			assertEquals("Incorrect NAME Value",
+					"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
+							.getString("NAME"));
+
+			results.absolute(-2);
+			assertEquals("incorrect row #", 5, results.getRow());
+			assertEquals("Incorrect ID Value", "D789", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Amelia \"meals\" Maurice",
+					results.getString("NAME"));
+
+			results.last();
+			results.next();
+			assertNull(results.getString("ID"));
+			assertNull(results.getString("NAME"));
+
+			results.previous();
+			assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
+			assertEquals("Incorrect NAME Value",
+					"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
+							.getString("NAME"));
+
+			assertFalse(results.relative(100));
+			assertEquals("incorrect row #", 7, results.getRow());
+			assertNull(results.getString("ID"));
+			assertNull(results.getString("NAME"));
+
+			assertFalse(results.relative(-100));
+			assertEquals("incorrect row #", 0, results.getRow());
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			results.relative(2);
+			assertEquals("incorrect row #", 2, results.getRow());
+			assertEquals("Incorrect ID Value", results.getString("ID"), "A123");
+			assertEquals("Incorrect NAME Value", results.getString("NAME"),
+					"Jonathan Ackerman");
+
+			results.absolute(7);
+			assertEquals("incorrect row #", 7, results.getRow());
+			assertNull(results.getString("ID"));
+			assertNull(results.getString("NAME"));
+
+			assertFalse(results.absolute(-10));
+			assertEquals("incorrect row #", 0, results.getRow());
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			results.absolute(2);
+			assertEquals("Incorrect ID Value", results.getString("ID"), "A123");
+			assertEquals("Incorrect NAME Value", results.getString("NAME"),
+					"Jonathan Ackerman");
+
+			assertFalse(results.absolute(0));
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			assertFalse(results.relative(0));
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		results.next();
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "\"S,\"", results
-				.getString("NAME"));
-
-		results.next();
-		assertEquals("incorrect row #", 2, results.getRow());
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
-				.getString("NAME"));
-
-		results.absolute(1);
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "\"S,\"", results
-				.getString("NAME"));
-
-		results.absolute(2);
-		assertEquals("incorrect row #", 2, results.getRow());
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
-				.getString("NAME"));
-
-		results.relative(2);
-		assertEquals("incorrect row #", 4, results.getRow());
-		assertEquals("Incorrect ID Value", "C456", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Susan, Peter and Dave", results
-				.getString("NAME"));
-
-		results.relative(-3);
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "\"S,\"", results
-				.getString("NAME"));
-
-		results.relative(0);
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", results.getString("NAME"),
-				"\"S,\"");
-
-		results.last();
-		assertEquals("incorrect row #", 6, results.getRow());
-		assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
-		assertEquals("Incorrect NAME Value",
-				"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
-						.getString("NAME"));
-
-		results.absolute(-1);
-		assertEquals("incorrect row #", 6, results.getRow());
-		assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
-		assertEquals("Incorrect NAME Value",
-				"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
-						.getString("NAME"));
-
-		results.absolute(-2);
-		assertEquals("incorrect row #", 5, results.getRow());
-		assertEquals("Incorrect ID Value", "D789", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Amelia \"meals\" Maurice",
-				results.getString("NAME"));
-
-		results.last();
-		results.next();
-		assertNull(results.getString("ID"));
-		assertNull(results.getString("NAME"));
-
-		results.previous();
-		assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
-		assertEquals("Incorrect NAME Value",
-				"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
-						.getString("NAME"));
-
-		assertFalse(results.relative(100));
-		assertEquals("incorrect row #", 7, results.getRow());
-		assertNull(results.getString("ID"));
-		assertNull(results.getString("NAME"));
-
-		assertFalse(results.relative(-100));
-		assertEquals("incorrect row #", 0, results.getRow());
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		results.relative(2);
-		assertEquals("incorrect row #", 2, results.getRow());
-		assertEquals("Incorrect ID Value", results.getString("ID"), "A123");
-		assertEquals("Incorrect NAME Value", results.getString("NAME"),
-				"Jonathan Ackerman");
-
-		results.absolute(7);
-		assertEquals("incorrect row #", 7, results.getRow());
-		assertNull(results.getString("ID"));
-		assertNull(results.getString("NAME"));
-
-		assertFalse(results.absolute(-10));
-		assertEquals("incorrect row #", 0, results.getRow());
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		results.absolute(2);
-		assertEquals("Incorrect ID Value", results.getString("ID"), "A123");
-		assertEquals("Incorrect NAME Value", results.getString("NAME"),
-				"Jonathan Ackerman");
-
-		assertFalse(results.absolute(0));
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		assertFalse(results.relative(0));
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		// clean up
-		results.close();
-		stmt.close();
-		conn.close();
-
 	}
 
 	@Test
@@ -315,74 +310,70 @@ public class TestScrollableDriver
 	{
 		// create a connection. The first command line parameter is assumed to
 		// be the directory in which the .csv files are held
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		// create a Statement object to execute the query with
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
-			ResultSet.CONCUR_READ_ONLY);
+			// create a Statement object to execute the query with
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+				ResultSet.CONCUR_READ_ONLY);
 
-		// Select the ID and NAME columns from sample.csv
-		ResultSet results = stmt.executeQuery("SELECT ID, NAME FROM sample");
+			// Select the ID and NAME columns from sample.csv
+			ResultSet results = stmt.executeQuery("SELECT ID, NAME FROM sample"))
+		{
+			// dump out the results
+			results.next();
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertTrue(results.isFirst());
+			assertFalse(results.isLast());
+			assertFalse(results.isBeforeFirst());
+			assertFalse(results.isAfterLast());
 
-		// dump out the results
-		results.next();
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertTrue(results.isFirst());
-		assertFalse(results.isLast());
-		assertFalse(results.isBeforeFirst());
-		assertFalse(results.isAfterLast());
+			results.next();
+			assertEquals("incorrect row #", 2, results.getRow());
+			assertFalse(results.isFirst());
+			assertFalse(results.isLast());
 
-		results.next();
-		assertEquals("incorrect row #", 2, results.getRow());
-		assertFalse(results.isFirst());
-		assertFalse(results.isLast());
+			results.previous();
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertTrue(results.isFirst());
+			assertFalse(results.isLast());
 
-		results.previous();
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertTrue(results.isFirst());
-		assertFalse(results.isLast());
+			results.first();
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertTrue(results.isFirst());
+			assertFalse(results.isLast());
 
-		results.first();
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertTrue(results.isFirst());
-		assertFalse(results.isLast());
+			results.previous();
+			assertEquals("incorrect row #", 0, results.getRow());
+			assertTrue(results.isBeforeFirst());
+			assertFalse(results.isAfterLast());
+			assertFalse(results.isFirst());
+			assertFalse(results.isLast());
 
-		results.previous();
-		assertEquals("incorrect row #", 0, results.getRow());
-		assertTrue(results.isBeforeFirst());
-		assertFalse(results.isAfterLast());
-		assertFalse(results.isFirst());
-		assertFalse(results.isLast());
+			results.next();
+			assertEquals("incorrect row #", 1, results.getRow());
+			assertTrue(results.isFirst());
+			assertFalse(results.isLast());
 
-		results.next();
-		assertEquals("incorrect row #", 1, results.getRow());
-		assertTrue(results.isFirst());
-		assertFalse(results.isLast());
+			results.last();
+			assertEquals("incorrect row #", 6, results.getRow());
+			assertFalse(results.isFirst());
+			assertTrue(results.isLast());
 
-		results.last();
-		assertEquals("incorrect row #", 6, results.getRow());
-		assertFalse(results.isFirst());
-		assertTrue(results.isLast());
+			results.absolute(-1);
+			assertEquals("incorrect row #", 6, results.getRow());
+			assertFalse(results.isBeforeFirst());
+			assertFalse(results.isAfterLast());
+			assertFalse(results.isFirst());
+			assertTrue(results.isLast());
 
-		results.absolute(-1);
-		assertEquals("incorrect row #", 6, results.getRow());
-		assertFalse(results.isBeforeFirst());
-		assertFalse(results.isAfterLast());
-		assertFalse(results.isFirst());
-		assertTrue(results.isLast());
-
-		results.afterLast();
-		assertEquals("incorrect row #", 7, results.getRow());
-		assertFalse(results.isBeforeFirst());
-		assertTrue(results.isAfterLast());
-		assertFalse("is seen as first", results.isFirst());
-		assertFalse("is seen as last", results.isLast());
-
-		// clean up
-		results.close();
-		stmt.close();
-		conn.close();
+			results.afterLast();
+			assertEquals("incorrect row #", 7, results.getRow());
+			assertFalse(results.isBeforeFirst());
+			assertTrue(results.isAfterLast());
+			assertFalse("is seen as first", results.isFirst());
+			assertFalse("is seen as last", results.isLast());
+		}
 	}
 
 	@Test
@@ -394,665 +385,646 @@ public class TestScrollableDriver
 
 		// create a connection. The first command line parameter is assumed to
 		// be the directory in which the .csv files are held
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		// create a Statement object to execute the query with
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
-			ResultSet.CONCUR_READ_ONLY);
+			// create a Statement object to execute the query with
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+				ResultSet.CONCUR_READ_ONLY);
 
-		// Select the ID and NAME columns from sample.csv
-		ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample2");
-
-		// dump out the results
-		results.next();
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
-
-		results.next();
-		assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
-
-		results.first();
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
-
-		assertFalse(results.previous());
-		try
+			// Select the ID and NAME columns from sample.csv
+			ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample2"))
 		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
+			// dump out the results
+			results.next();
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
 
-		results.next();
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
+			results.next();
+			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
 
-		results.next();
-		assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+			results.first();
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
 
-		results.relative(2);
-		assertEquals("Incorrect ID Value", "D456", results.getString("ID"));
-		assertEquals("Incorrect NAME Value",
-				"Dilip \"meals\" Maurice\n ~In New  LIne~ \nDone", results
-						.getString("NAME"));
+			assertFalse(results.previous());
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
 
-		results.relative(-3);
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
+			results.next();
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
 
-		results.relative(0);
-		assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
+			results.next();
+			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
 
-		results.absolute(2);
-		assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+			results.relative(2);
+			assertEquals("Incorrect ID Value", "D456", results.getString("ID"));
+			assertEquals("Incorrect NAME Value",
+					"Dilip \"meals\" Maurice\n ~In New  LIne~ \nDone", results
+							.getString("NAME"));
 
-		results.absolute(-2);
-		assertEquals("Incorrect ID Value", "E589", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "\"Elephant\"", results
-				.getString("NAME"));
+			results.relative(-3);
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
 
-		results.last();
-		assertEquals("Incorrect ID Value", "F634", results.getString("ID"));
-		assertEquals(
-				"Incorrect NAME Value",
-				"Fandu \"\"peg leg\"\", Jimmy & Samantha \n~In Another New  LIne~ \n\"\"Sam\"\"",
-				results.getString("NAME"));
+			results.relative(0);
+			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
 
-		results.next();
-		assertNull(results.getString("ID"));
-		assertNull(results.getString("NAME"));
+			results.absolute(2);
+			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
 
-		results.previous();
-		assertEquals("Incorrect ID Value", "F634", results.getString("ID"));
-		assertEquals(
-				"Incorrect NAME Value",
-				"Fandu \"\"peg leg\"\", Jimmy & Samantha \n~In Another New  LIne~ \n\"\"Sam\"\"",
-				results.getString("NAME"));
+			results.absolute(-2);
+			assertEquals("Incorrect ID Value", "E589", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "\"Elephant\"", results
+					.getString("NAME"));
 
-		results.relative(100);
-		assertNull(results.getString("ID"));
-		assertNull(results.getString("NAME"));
+			results.last();
+			assertEquals("Incorrect ID Value", "F634", results.getString("ID"));
+			assertEquals(
+					"Incorrect NAME Value",
+					"Fandu \"\"peg leg\"\", Jimmy & Samantha \n~In Another New  LIne~ \n\"\"Sam\"\"",
+					results.getString("NAME"));
 
-		assertFalse(results.relative(-100));
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
+			results.next();
+			assertNull(results.getString("ID"));
+			assertNull(results.getString("NAME"));
+
+			results.previous();
+			assertEquals("Incorrect ID Value", "F634", results.getString("ID"));
+			assertEquals(
+					"Incorrect NAME Value",
+					"Fandu \"\"peg leg\"\", Jimmy & Samantha \n~In Another New  LIne~ \n\"\"Sam\"\"",
+					results.getString("NAME"));
+
+			results.relative(100);
+			assertNull(results.getString("ID"));
+			assertNull(results.getString("NAME"));
+
+			assertFalse(results.relative(-100));
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			results.relative(2);
+			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+
+			results.absolute(7);
+			assertNull(results.getString("ID"));
+			assertNull(results.getString("NAME"));
+
+			assertFalse(results.absolute(-10));
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			results.absolute(2);
+			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
+			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+
+			assertFalse(results.absolute(0));
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+
+			assertFalse(results.relative(0));
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		results.relative(2);
-		assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
-
-		results.absolute(7);
-		assertNull(results.getString("ID"));
-		assertNull(results.getString("NAME"));
-
-		assertFalse(results.absolute(-10));
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		results.absolute(2);
-		assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-		assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
-
-		assertFalse(results.absolute(0));
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		assertFalse(results.relative(0));
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-
-		// clean up
-		results.close();
-		stmt.close();
-		conn.close();
 	}
 
 	/**
 	 * This checks for the scenario when due to where clause no rows are
 	 * returned.
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
 	public void testWhereNoResults() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		// create a Statement object to execute the query with
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
-			ResultSet.CONCUR_READ_ONLY);
+			// create a Statement object to execute the query with
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+				ResultSet.CONCUR_READ_ONLY);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ID,Name FROM sample4 WHERE ID='05'");
-		assertFalse("There are some junk records found", results.next());
-		assertFalse(results.last());
-		try
+			ResultSet results = stmt
+				.executeQuery("SELECT ID,Name FROM sample4 WHERE ID='05'"))
 		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
+			assertFalse("There are some junk records found", results.next());
+			assertFalse(results.last());
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			assertTrue("Is not last", results.isLast());
+			assertFalse(results.absolute(0));
+			try
+			{
+				results.getString("ID");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			try
+			{
+				results.getString("NAME");
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
+			}
+			assertTrue("Is not last", results.isLast());
+			assertFalse(results.absolute(0));
+			assertTrue("Is not before first", results.isBeforeFirst());
+			results.previous();
+			assertTrue("Is not before first", results.isBeforeFirst());
+			assertTrue("Is not last", results.isLast());
+			// Following throws exception
+			// assertTrue("Is not before first", results.isAfterLast());
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		assertTrue("Is not last", results.isLast());
-		assertFalse(results.absolute(0));
-		try
-		{
-			results.getString("ID");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		try
-		{
-			results.getString("NAME");
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
-		}
-		assertTrue("Is not last", results.isLast());
-		assertFalse(results.absolute(0));
-		assertTrue("Is not before first", results.isBeforeFirst());
-		results.previous();
-		assertTrue("Is not before first", results.isBeforeFirst());
-		assertTrue("Is not last", results.isLast());
-		// Following throws exception
-		// assertTrue("Is not before first", results.isAfterLast());
-
 	}
 
 	/**
 	 * This checks for the scenario when we have single record
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
 	public void testWhereSingleRecord() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
-		// create a Statement object to execute the query with
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
-			ResultSet.CONCUR_READ_ONLY);
+			// create a Statement object to execute the query with
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+				ResultSet.CONCUR_READ_ONLY);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ID,Name FROM singlerecord");
-		assertTrue(results.last());
-		assertEquals("Invalid Id", "A123", results.getString("ID"));
-		assertEquals("Invalid Name", "Jonathan Ackerman", results
-				.getString("NAME"));
-		results.absolute(1);
-		assertEquals("Invalid Id", "A123", results.getString("ID"));
-		assertEquals("Invalid Name", "Jonathan Ackerman", results
-				.getString("NAME"));
-		assertTrue("Is not last", results.isLast());
-		assertTrue("Is not first", results.isFirst());
-		results.absolute(0);
-		assertTrue("Is not before first", results.isBeforeFirst());
-		results.previous();
-		assertTrue("Is not before first", results.isBeforeFirst());
-		assertTrue(results.next());
-		assertEquals("Invalid Id", "A123", results.getString("ID"));
-		assertEquals("Invalid Name", "Jonathan Ackerman", results
-				.getString("NAME"));
-		results.relative(1);
-		assertTrue("Is not after last", results.isAfterLast());
-		results.previous();
-		assertEquals("Invalid Id", "A123", results.getString("ID"));
-		assertEquals("Invalid Name", "Jonathan Ackerman", results
-				.getString("NAME"));
+			ResultSet results = stmt
+				.executeQuery("SELECT ID,Name FROM singlerecord"))
+		{
+			assertTrue(results.last());
+			assertEquals("Invalid Id", "A123", results.getString("ID"));
+			assertEquals("Invalid Name", "Jonathan Ackerman", results
+					.getString("NAME"));
+			results.absolute(1);
+			assertEquals("Invalid Id", "A123", results.getString("ID"));
+			assertEquals("Invalid Name", "Jonathan Ackerman", results
+					.getString("NAME"));
+			assertTrue("Is not last", results.isLast());
+			assertTrue("Is not first", results.isFirst());
+			results.absolute(0);
+			assertTrue("Is not before first", results.isBeforeFirst());
+			results.previous();
+			assertTrue("Is not before first", results.isBeforeFirst());
+			assertTrue(results.next());
+			assertEquals("Invalid Id", "A123", results.getString("ID"));
+			assertEquals("Invalid Name", "Jonathan Ackerman", results
+					.getString("NAME"));
+			results.relative(1);
+			assertTrue("Is not after last", results.isAfterLast());
+			results.previous();
+			assertEquals("Invalid Id", "A123", results.getString("ID"));
+			assertEquals("Invalid Name", "Jonathan Ackerman", results
+					.getString("NAME"));
+		}
 	}
 
 	/**
 	 * This tests for the scenario with where clause.
-	 * 
+	 *
 	 * @throws SQLException
 	 */
 	@Test
 	public void testWhereMultipleResult() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
-			ResultSet.CONCUR_READ_ONLY);
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+				ResultSet.CONCUR_READ_ONLY);
 
-		ResultSet results = stmt
-				.executeQuery("SELECT ID, Name, Job FROM sample4 WHERE Job = 'Project Manager'");
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "01", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "02", results.getString("ID"));
-		assertTrue(results.next());
-		assertEquals("The ID is wrong", "04", results.getString("ID"));
-		assertTrue(results.first());
-		assertEquals("The ID is wrong when using first", "01", results
-				.getString("ID"));
+			ResultSet results = stmt
+				.executeQuery("SELECT ID, Name, Job FROM sample4 WHERE Job = 'Project Manager'"))
+		{
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertTrue(results.next());
+			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertTrue(results.first());
+			assertEquals("The ID is wrong when using first", "01", results
+					.getString("ID"));
 
-		assertTrue(results.absolute(3));
-		assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertTrue(results.absolute(3));
+			assertEquals("The ID is wrong", "04", results.getString("ID"));
 
-		assertTrue(results.last());
-		assertEquals("The ID is wrong", "04", results.getString("ID"));
-		assertFalse("It has records after last", results.next());
-		assertTrue("Is not after Last", results.isAfterLast());
-		assertTrue(results.previous());
-		assertTrue(results.previous());
-		assertEquals("The ID is wrong", "02", results.getString("ID"));
-		assertTrue(results.relative(0));
-		assertEquals("The ID is wrong", "02", results.getString("ID"));
-		assertTrue(results.relative(1));
-		assertEquals("The ID is wrong", "04", results.getString("ID"));
-		assertTrue("Is not last", results.isLast());
-		assertTrue(results.relative(-2));
-		assertEquals("The ID is wrong", "01", results.getString("ID"));
-		assertTrue("Is not first", results.isFirst());
-		results.previous();
-		assertTrue("Is not before first", results.isBeforeFirst());
-
+			assertTrue(results.last());
+			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertFalse("It has records after last", results.next());
+			assertTrue("Is not after Last", results.isAfterLast());
+			assertTrue(results.previous());
+			assertTrue(results.previous());
+			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertTrue(results.relative(0));
+			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertTrue(results.relative(1));
+			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertTrue("Is not last", results.isLast());
+			assertTrue(results.relative(-2));
+			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertTrue("Is not first", results.isFirst());
+			results.previous();
+			assertTrue("Is not before first", results.isBeforeFirst());
+		}
 	}
 
 	@Test
 	public void testMaxRows() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		stmt.setMaxRows(4);
-		assertEquals("getMaxRows() incorrect", 4, stmt.getMaxRows());
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY))
+		{
+			stmt.setMaxRows(4);
+			assertEquals("getMaxRows() incorrect", 4, stmt.getMaxRows());
 
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
-
-		assertTrue("Moving to last record failed", results.last());
-		assertEquals("Last record wrong", 4, results.getRow());
-		assertEquals("The ID is wrong", "03", results.getString("ID"));
-		assertTrue("Moving to first record failed", results.first());
-		assertEquals("The ID is wrong", "41", results.getString("ID"));
-		assertTrue("Reading row 2 failed", results.next());
-		assertTrue("Reading row 3 failed", results.next());
-		assertTrue("Reading row 4 failed", results.next());
-		assertFalse("Stopping after row 4 failed", results.next());
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample5"))
+			{
+				assertTrue("Moving to last record failed", results.last());
+				assertEquals("Last record wrong", 4, results.getRow());
+				assertEquals("The ID is wrong", "03", results.getString("ID"));
+				assertTrue("Moving to first record failed", results.first());
+				assertEquals("The ID is wrong", "41", results.getString("ID"));
+				assertTrue("Reading row 2 failed", results.next());
+				assertTrue("Reading row 3 failed", results.next());
+				assertTrue("Reading row 4 failed", results.next());
+				assertFalse("Stopping after row 4 failed", results.next());
+			}
+		}
 	}
 
 	@Test
 	public void testResultSetFirstClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.first();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.first();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetLastClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.last();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.last();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetPreviousClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.previous();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.previous();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetAbsoluteClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.absolute(2);
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.absolute(2);
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetRelativeClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.relative(-1);
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.relative(-1);
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetAfterLastClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.afterLast();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.afterLast();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetBeforeFirstClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.beforeFirst();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.beforeFirst();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetIsAfterLastClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.isAfterLast();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.isAfterLast();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetIsBeforeFirstClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.isBeforeFirst();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.isBeforeFirst();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetIsFirstClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.isFirst();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.isFirst();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 
 	@Test
 	public void testResultSetIsLastClosed() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
 				+ filePath);
 
-		Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
-		ResultSet results = stmt.executeQuery("SELECT * FROM sample");
-		results.next();
-		results.next();
-		results.close();
-		try
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY);
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			results.isLast();
-			fail("Closed result set should throw SQLException");
+			results.next();
+			results.next();
+			results.close();
+			try
+			{
+				results.isLast();
+				fail("Closed result set should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("closedResultSet"), "" + e);
-		}
-
-		// clean up
-		stmt.close();
-		conn.close();
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestSubQuery.java
+++ b/src/test/java/org/relique/jdbc/csv/TestSubQuery.java
@@ -51,7 +51,7 @@ public class TestSubQuery
 		try
 		{
 			Class.forName("org.relique.jdbc.csv.CsvDriver");
-		} 
+		}
 		catch (ClassNotFoundException e)
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
@@ -79,27 +79,26 @@ public class TestSubQuery
         props.put("commentChar", "#");
         props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME FROM banks WHERE BLZ=FROM_BLZ), AMOUNT FROM transactions");
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-		assertTrue("The AMOUNT is wrong", fuzzyEquals(250.0, rs1.getDouble(2)));
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME FROM banks WHERE BLZ=FROM_BLZ), AMOUNT FROM transactions"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+			assertTrue("The AMOUNT is wrong", fuzzyEquals(250.0, rs1.getDouble(2)));
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+		}
 	}
-	
+
 	@Test
 	public void testInvalidTable() throws SQLException
 	{
@@ -111,22 +110,23 @@ public class TestSubQuery
         props.put("commentChar", "#");
         props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME FROM XXXX), AMOUNT FROM transactions");
-			if (rs1.next())
-				rs1.getString(1);
-			fail("Should raise a java.sqlSQLException");
+			try
+			{
+				ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME FROM XXXX), AMOUNT FROM transactions");
+				if (rs1.next())
+					rs1.getString(1);
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.getMessage().contains(CsvResources.getString("fileNotFound")));
+				assertTrue(e.getMessage().contains("XXXX"));
+			}
 		}
-		catch (SQLException e)
-		{
-			assertTrue(e.getMessage().contains(CsvResources.getString("fileNotFound")));
-			assertTrue(e.getMessage().contains("XXXX"));
-		}		
 	}
 
 	@Test
@@ -140,22 +140,23 @@ public class TestSubQuery
         props.put("commentChar", "#");
         props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			ResultSet rs1 = stmt.executeQuery("SELECT (SELECT XXXX FROM banks WHERE BLZ=FROM_BLZ), AMOUNT FROM transactions");
-			if (rs1.next())
-				rs1.getString(1);
-			fail("Should raise a java.sqlSQLException");
+			try
+			{
+				ResultSet rs1 = stmt.executeQuery("SELECT (SELECT XXXX FROM banks WHERE BLZ=FROM_BLZ), AMOUNT FROM transactions");
+				if (rs1.next())
+					rs1.getString(1);
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.getMessage().contains(CsvResources.getString("invalidColumnName")));
+				assertTrue(e.getMessage().contains("XXXX"));
+			}
 		}
-		catch (SQLException e)
-		{
-			assertTrue(e.getMessage().contains(CsvResources.getString("invalidColumnName")));
-			assertTrue(e.getMessage().contains("XXXX"));
-		}		
 	}
 
 	@Test
@@ -169,23 +170,24 @@ public class TestSubQuery
         props.put("commentChar", "#");
         props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME, BANK_NAME B2 FROM banks WHERE BLZ=FROM_BLZ), AMOUNT FROM transactions");
-			if (rs1.next())
-				rs1.getString(1);
-			fail("Should raise a java.sqlSQLException");
+			try
+			{
+				ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME, BANK_NAME B2 FROM banks WHERE BLZ=FROM_BLZ), AMOUNT FROM transactions");
+				if (rs1.next())
+					rs1.getString(1);
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("subqueryOneColumn"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("subqueryOneColumn"), "" + e);
-		}		
 	}
-	
+
 	@Test
 	public void testMoreThanOneRow() throws SQLException
 	{
@@ -198,50 +200,50 @@ public class TestSubQuery
         props.put("commentChar", "#");
         props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME FROM banks), AMOUNT FROM transactions");
-			if (rs1.next())
-				rs1.getString(1);
-			fail("Should raise a java.sqlSQLException");
+			try
+			{
+				ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME FROM banks), AMOUNT FROM transactions");
+				if (rs1.next())
+					rs1.getString(1);
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("subqueryOneRow"), "" + e);
+			}
 		}
-		catch (SQLException e)
-		{
-			assertEquals("java.sql.SQLException: " + CsvResources.getString("subqueryOneRow"), "" + e);
-		}		
 	}
-	
+
 	@Test
 	public void testNoMatch() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("SELECT ID, NAME, (SELECT NAME FROM sample2 s2 WHERE s2.ID=s1.ID) FROM sample s1");
-		assertTrue(rs1.next());
-		assertEquals("The ID is wrong", "Q123", rs1.getString(1));
-		assertEquals("The Name is wrong", "\"S,\"", rs1.getString(2));
-		// No match so subquery returns null for this row.
-		assertNull("The Subquery is wrong", rs1.getString(3));
-		assertTrue(rs1.next());
-		assertEquals("The ID is wrong", "A123", rs1.getString(1));
-		assertEquals("The Name is wrong", "Jonathan Ackerman", rs1.getString(2));
-		assertEquals("The Subquery is wrong", "Aman", rs1.getString(3));	
-		assertTrue(rs1.next());
-		assertEquals("The ID is wrong", "B234", rs1.getString(1));
-		assertEquals("The Name is wrong", "Grady O'Neil", rs1.getString(2));
-		// No match so subquery returns null for this row.
-		assertNull("The Subquery is wrong", rs1.getString(3));
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("SELECT ID, NAME, (SELECT NAME FROM sample2 s2 WHERE s2.ID=s1.ID) FROM sample s1"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The ID is wrong", "Q123", rs1.getString(1));
+			assertEquals("The Name is wrong", "\"S,\"", rs1.getString(2));
+			// No match so subquery returns null for this row.
+			assertNull("The Subquery is wrong", rs1.getString(3));
+			assertTrue(rs1.next());
+			assertEquals("The ID is wrong", "A123", rs1.getString(1));
+			assertEquals("The Name is wrong", "Jonathan Ackerman", rs1.getString(2));
+			assertEquals("The Subquery is wrong", "Aman", rs1.getString(3));
+			assertTrue(rs1.next());
+			assertEquals("The ID is wrong", "B234", rs1.getString(1));
+			assertEquals("The Name is wrong", "Grady O'Neil", rs1.getString(2));
+			// No match so subquery returns null for this row.
+			assertNull("The Subquery is wrong", rs1.getString(3));
+		}
 	}
-	
+
 	@Test
 	public void testAggregateFunction() throws SQLException
 	{
@@ -253,25 +255,24 @@ public class TestSubQuery
         props.put("commentChar", "#");
         props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("SELECT BANK_NAME, (SELECT COUNT(*) FROM transactions WHERE BLZ=FROM_BLZ) COUNT_ FROM banks");
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Bundesbank (Berlin)", rs1.getString(1));
-		assertEquals("The Subquery is wrong", 0, rs1.getInt(2));
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-		assertEquals("The Subquery is wrong", 5, rs1.getInt(2));
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "SEB (Berlin)", rs1.getString(1));
-		assertEquals("The Subquery is wrong", 0, rs1.getInt(2));
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("SELECT BANK_NAME, (SELECT COUNT(*) FROM transactions WHERE BLZ=FROM_BLZ) COUNT_ FROM banks"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Bundesbank (Berlin)", rs1.getString(1));
+			assertEquals("The Subquery is wrong", 0, rs1.getInt(2));
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+			assertEquals("The Subquery is wrong", 5, rs1.getInt(2));
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "SEB (Berlin)", rs1.getString(1));
+			assertEquals("The Subquery is wrong", 0, rs1.getInt(2));
+		}
 	}
-	
+
 	@Test
 	public void testOrderBy() throws SQLException
 	{
@@ -283,23 +284,22 @@ public class TestSubQuery
         props.put("commentChar", "#");
         props.put("charset", "UTF-8");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("SELECT BANK_NAME, (SELECT COUNT(*) FROM transactions WHERE BLZ=FROM_BLZ) COUNT_ FROM banks ORDER BY COUNT_ DESC");
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-		assertEquals("The Subquery is wrong", 5, rs1.getInt(2));
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", rs1.getString(1));
-		assertEquals("The Subquery is wrong", 3, rs1.getInt(2));
-		assertTrue(rs1.next());
-		assertEquals("The BANK_NAME is wrong", "BHF-BANK (Berlin)", rs1.getString(1));
-		assertEquals("The Subquery is wrong", 1, rs1.getInt(2));
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("SELECT BANK_NAME, (SELECT COUNT(*) FROM transactions WHERE BLZ=FROM_BLZ) COUNT_ FROM banks ORDER BY COUNT_ DESC"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+			assertEquals("The Subquery is wrong", 5, rs1.getInt(2));
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", rs1.getString(1));
+			assertEquals("The Subquery is wrong", 3, rs1.getInt(2));
+			assertTrue(rs1.next());
+			assertEquals("The BANK_NAME is wrong", "BHF-BANK (Berlin)", rs1.getString(1));
+			assertEquals("The Subquery is wrong", 1, rs1.getInt(2));
+		}
 	}
 
 	@Test
@@ -308,117 +308,113 @@ public class TestSubQuery
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,Integer,Integer,Date,Time");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("select AccountNo from Purchase where CampaignNo=(select max(CampaignNo) from Purchase)");
-		assertTrue(rs1.next());
-		assertEquals("The AccountNo is wrong", 22021, rs1.getInt(1));
-		assertFalse(rs1.next());
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("select AccountNo from Purchase where CampaignNo=(select max(CampaignNo) from Purchase)"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The AccountNo is wrong", 22021, rs1.getInt(1));
+			assertFalse(rs1.next());
+		}
 	}
 
 	@Test
 	public void testInSubQuery() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("select NAME from sample5 where ID in (select ID from sample4)");
-		assertTrue(rs1.next());
-		assertEquals("The NAME is wrong", "Juan Pablo Morales", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The NAME is wrong", "Mauricio Hernandez", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The NAME is wrong", "Maria Cristina Lucero", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The NAME is wrong", "Felipe Grajales", rs1.getString(1));
-		assertFalse(rs1.next());
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("select NAME from sample5 where ID in (select ID from sample4)"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The NAME is wrong", "Juan Pablo Morales", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The NAME is wrong", "Mauricio Hernandez", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The NAME is wrong", "Maria Cristina Lucero", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The NAME is wrong", "Felipe Grajales", rs1.getString(1));
+			assertFalse(rs1.next());
+		}
 	}
 
 	@Test
 	public void testInSubQueryNoMatch() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("select NAME from sample5 where ID in (select AccountNo from Purchase where CampaignNo='XXXX')");
-		assertFalse(rs1.next());
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("select NAME from sample5 where ID in (select AccountNo from Purchase where CampaignNo='XXXX')"))
+		{
+			assertFalse(rs1.next());
+		}
 	}
 
 	@Test
 	public void testExistsSubQuery() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("select EXTRA_FIELD from sample where exists (select 1 from sample2 where sample2.id=sample.id)");
-		assertTrue(rs1.next());
-		assertEquals("The EXTRA_FIELD is wrong", "A", rs1.getString(1));
-		assertFalse(rs1.next());
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("select EXTRA_FIELD from sample where exists (select 1 from sample2 where sample2.id=sample.id)"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The EXTRA_FIELD is wrong", "A", rs1.getString(1));
+			assertFalse(rs1.next());
+		}
 	}
 
 	@Test
 	public void testNotExistsSubQuery() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
+			Statement stmt = conn.createStatement();
 
-		ResultSet rs1 = stmt.executeQuery("select EXTRA_FIELD from sample where not exists (select 1 from sample2 where sample2.id=sample.id)");
-		assertTrue(rs1.next());
-		assertEquals("The EXTRA_FIELD is wrong", "F", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The EXTRA_FIELD is wrong", "B", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The EXTRA_FIELD is wrong", "C", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The EXTRA_FIELD is wrong", "E", rs1.getString(1));
-		assertTrue(rs1.next());
-		assertEquals("The EXTRA_FIELD is wrong", "G", rs1.getString(1));
-		assertFalse(rs1.next());
-
-		rs1.close();
-		stmt.close();
+			ResultSet rs1 = stmt.executeQuery("select EXTRA_FIELD from sample where not exists (select 1 from sample2 where sample2.id=sample.id)"))
+		{
+			assertTrue(rs1.next());
+			assertEquals("The EXTRA_FIELD is wrong", "F", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The EXTRA_FIELD is wrong", "B", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The EXTRA_FIELD is wrong", "C", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The EXTRA_FIELD is wrong", "E", rs1.getString(1));
+			assertTrue(rs1.next());
+			assertEquals("The EXTRA_FIELD is wrong", "G", rs1.getString(1));
+			assertFalse(rs1.next());
+		}
 	}
 
 	@Test
 	public void testDerivedTable() throws SQLException
 	{
 		Properties props = new Properties();
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			ResultSet rs1 = stmt.executeQuery("SELECT ID FROM (SELECT ID FROM sample) AS X");
-			if (rs1.next())
-				rs1.getString(1);
-			fail("Should raise a java.sqlSQLException");
-		}
-		catch (SQLException e)
-		{
-			assertTrue(e.getMessage().contains(CsvResources.getString("derivedTableNotSupported")));
+			try
+			{
+				ResultSet rs1 = stmt.executeQuery("SELECT ID FROM (SELECT ID FROM sample) AS X");
+				if (rs1.next())
+					rs1.getString(1);
+				fail("Should raise a java.sqlSQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.getMessage().contains(CsvResources.getString("derivedTableNotSupported")));
+			}
 		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
+++ b/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
@@ -71,11 +71,13 @@ public class TestZipFiles
 	@Test
 	public void testConnectionName() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
-			+ filePath + File.separator + TEST_ZIP_FILENAME_1);
-		String url = conn.getMetaData().getURL();
-		assertTrue(url.startsWith("jdbc:relique:csv:zip:"));
-		assertTrue(url.endsWith(TEST_ZIP_FILENAME_1));
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
+			+ filePath + File.separator + TEST_ZIP_FILENAME_1))
+		{
+			String url = conn.getMetaData().getURL();
+			assertTrue(url.startsWith("jdbc:relique:csv:zip:"));
+			assertTrue(url.endsWith(TEST_ZIP_FILENAME_1));
+		}
 	}
 
 	@Test
@@ -84,55 +86,56 @@ public class TestZipFiles
 		Properties props = new Properties();
 		props.put("columnTypes", "Short,String,String,Short,Short,Short");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
 			+ filePath + File.separator + TEST_ZIP_FILENAME_1, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT * FROM medals2004");
-		assertTrue(results.next());
-		assertEquals("The YEAR is wrong", 2004, results.getShort(1));
-		assertEquals("The COUNTRY is wrong", "United States", results.getString(2));
-		assertEquals("The CODE is wrong", "USA", results.getString(3));
-		assertEquals("The GOLD is wrong", 36, results.getShort(4));
-		assertTrue(results.next());
-		assertEquals("The YEAR is wrong", 2004, results.getShort(1));
-		assertEquals("The COUNTRY is wrong", "China", results.getString(2));
-		assertEquals("The CODE is wrong", "CHN", results.getString(3));
-		assertEquals("The GOLD is wrong", 32, results.getShort(4));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM medals2004"))
+		{
+			assertTrue(results.next());
+			assertEquals("The YEAR is wrong", 2004, results.getShort(1));
+			assertEquals("The COUNTRY is wrong", "United States", results.getString(2));
+			assertEquals("The CODE is wrong", "USA", results.getString(3));
+			assertEquals("The GOLD is wrong", 36, results.getShort(4));
+			assertTrue(results.next());
+			assertEquals("The YEAR is wrong", 2004, results.getShort(1));
+			assertEquals("The COUNTRY is wrong", "China", results.getString(2));
+			assertEquals("The CODE is wrong", "CHN", results.getString(3));
+			assertEquals("The GOLD is wrong", 32, results.getShort(4));
+		}
 	}
 	
 	@Test
 	public void testListTables() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
 			+ filePath + File.separator + TEST_ZIP_FILENAME_1);
-
-		ResultSet results = conn.getMetaData().getTables(null, null, "%", null);
-		assertTrue(results.next());
-		assertEquals("The TABLE_NAME is wrong", "medals2004", results.getString("TABLE_NAME"));
-		assertTrue(results.next());
-		assertEquals("The TABLE_NAME is wrong", "medals2008", results.getString("TABLE_NAME"));
-		assertFalse(results.next());
+			ResultSet results = conn.getMetaData().getTables(null, null, "%", null))
+		{
+			assertTrue(results.next());
+			assertEquals("The TABLE_NAME is wrong", "medals2004", results.getString("TABLE_NAME"));
+			assertTrue(results.next());
+			assertEquals("The TABLE_NAME is wrong", "medals2008", results.getString("TABLE_NAME"));
+			assertFalse(results.next());
+		}
 	}
 
 	@Test
 	public void testBadTableNameFails() throws SQLException
 	{
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
 			+ filePath + File.separator + TEST_ZIP_FILENAME_1);
-
-		Statement stmt = conn.createStatement();
-
-		try
+			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM abc");
-			fail("Query should fail");
-		}
-		catch (SQLException e)
-		{
-			String message = "" + e;
-			assertTrue(message.startsWith("java.sql.SQLException: " + CsvResources.getString("tableNotFound") + ":"));
+			try
+			{
+				stmt.executeQuery("SELECT * FROM abc");
+				fail("Query should fail");
+			}
+			catch (SQLException e)
+			{
+				String message = "" + e;
+				assertTrue(message.startsWith("java.sql.SQLException: " + CsvResources.getString("tableNotFound") + ":"));
+			}
 		}
 	}
 
@@ -160,18 +163,18 @@ public class TestZipFiles
 		props.put("charset", "ISO-8859-1");
 		props.put("fileExtension", ".txt");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
 			+ filePath + File.separator + TEST_ZIP_FILENAME_2, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT * FROM iso8859-1");
-		assertTrue(results.next());
-		assertEquals("ISO8859-1 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("ISO8859-1 encoding is wrong", "100\u00B0", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("ISO8859-1 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM iso8859-1"))
+		{
+			assertTrue(results.next());
+			assertEquals("ISO8859-1 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("ISO8859-1 encoding is wrong", "100\u00B0", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("ISO8859-1 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+		}
 	}
 
 	@Test
@@ -182,18 +185,18 @@ public class TestZipFiles
 		props.put("charset", "UTF-8");
 		props.put("fileExtension", ".txt");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
 			+ filePath + File.separator + TEST_ZIP_FILENAME_2, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT * FROM utf-8");
-		assertTrue(results.next());
-		assertEquals("UTF-8 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("UTF-8 encoding is wrong", "100\u00B0", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("UTF-8 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM utf-8"))
+		{
+			assertTrue(results.next());
+			assertEquals("UTF-8 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("UTF-8 encoding is wrong", "100\u00B0", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("UTF-8 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+		}
 	}
 
 	@Test
@@ -204,17 +207,17 @@ public class TestZipFiles
 		props.put("charset", "UTF-16");
 		props.put("fileExtension", ".txt");
 
-		Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
 			+ filePath + File.separator + TEST_ZIP_FILENAME_2, props);
-
-		Statement stmt = conn.createStatement();
-
-		ResultSet results = stmt.executeQuery("SELECT * FROM utf-16");
-		assertTrue(results.next());
-		assertEquals("UTF-16 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("UTF-16 encoding is wrong", "100\u00B0", results.getString(1));
-		assertTrue(results.next());
-		assertEquals("UTF-16 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM utf-16"))
+		{
+			assertTrue(results.next());
+			assertEquals("UTF-16 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("UTF-16 encoding is wrong", "100\u00B0", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("UTF-16 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
+++ b/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
@@ -142,10 +142,9 @@ public class TestZipFiles
 	@Test
 	public void testBadZipFileFails() throws SQLException
 	{
-		try
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
+				+ filePath + File.separator + "abc" + TEST_ZIP_FILENAME_1))
 		{
-			DriverManager.getConnection("jdbc:relique:csv:zip:"
-				+ filePath + File.separator + "abc" + TEST_ZIP_FILENAME_1);
 			fail("Connection should fail");
 		}
 		catch (SQLException e)


### PR DESCRIPTION
Changed unit tests to use try-with-resources when creating `java.sql.Connection`, `java.sql.Statement` and `java.sql.ResultSet` objects, so that these objects are always closed at the end of the unit test.

This is probably how these classes are used in modern applications, so it is better to test these classes this way too.

Fixes #19 