### PR TITLE
Fix EncryptedFileInputStream.read(byte[] b) override

### DIFF
--- a/src/main/java/org/relique/io/EncryptedFileInputStream.java
+++ b/src/main/java/org/relique/io/EncryptedFileInputStream.java
@@ -49,7 +49,7 @@ public class EncryptedFileInputStream extends InputStream
 			return in.read(b, off, len);
 	}
 
-	public int read(InputStream in, byte[] b) throws IOException
+	public int read(byte[] b) throws IOException
 	{
 		if (filter != null)
 			return filter.read(in, b);


### PR DESCRIPTION
Method should be  `EncryptedFileInputStream.read(byte[] b)`, not `EncryptedFileInputStream.read(InputStream in, byte[] b)` to correctly override a `java.io.InputStream` method.

Fixes #24