### PR TITLE
Remove unnecessary Class.forname calls from example programs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,6 @@ The CsvJdbc driver is used just like any other JDBC driver:
 
 
 1. download `csvjdbc.jar` and add it to the Java CLASSPATH.
-1. load the driver class, (its full name is `org.relique.jdbc.csv.CsvDriver`)
 1. use `DriverManager` to connect to the database (the directory or ZIP file)
 1. create a statement object
 1. use the statement object to execute an SQL SELECT query

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,9 +37,6 @@ public class DemoDriver
 {
   public static void main(String[] args) throws Exception
   {
-    // Load the driver.
-    Class.forName("org.relique.jdbc.csv.CsvDriver");
-
     // Create a connection to directory given as first command line
     // parameter. Driver properties are passed in URL format
     // (or alternatively in a java.utils.Properties object).

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -106,7 +106,6 @@ public class DemoDriver2
 {
   public static void main(String[] args) throws Exception
   {
-    Class.forName("org.relique.jdbc.csv.CsvDriver");
     try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + args[0]);
 
       // create a scrollable Statement so we can move forwards and backwards
@@ -144,7 +143,6 @@ public class DemoDriver3
 {
   public static void main(String[] args) throws Exception
   {
-    Class.forName("org.relique.jdbc.csv.CsvDriver");
     Properties props = new Properties();
     props.put("fileExtension", ".txt");
     props.put("indexedFiles", "true");
@@ -187,7 +185,6 @@ public class DemoDriver4
 {
   public static void main(String[] args) throws Exception
   {
-    Class.forName("org.relique.jdbc.csv.CsvDriver");
     Properties props = new Properties();
     // Define column names and column data types here.
     props.put("suppressHeaders", "true");
@@ -223,7 +220,6 @@ public class DemoDriver5
 {
   public static void main(String[] args) throws Exception
   {
-    Class.forName("org.relique.jdbc.csv.CsvDriver");
     String zipFilename = args[0];
     try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:" +
         zipFilename);
@@ -289,7 +285,6 @@ public class DemoDriver6
 {
   public static void main(String []args) throws Exception
   {
-    Class.forName("org.relique.jdbc.csv.CsvDriver");
     String sql = "SELECT * FROM sample";
     // Give name of Java class that provides database tables.
     try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" +


### PR DESCRIPTION
Fixes #27 