### PR TITLE
Rename duplicate column names when defectiveHeaders=true

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -359,7 +359,8 @@ decryption class set in property `cryptoFilterClassName`.
 ### defectiveHeaders
 + type: Boolean
 + default: `False`
-+ in case a column name is the emtpy string, replace it with COLUMNx,
++ When true, column names that are an emtpy string or a case insensitive
+duplicate of a previous column name are renamed to COLUMNx,
 where x is the ordinal identifying the column.
 
 ### fileExtension

--- a/src/main/java/org/relique/jdbc/csv/CsvRawReader.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvRawReader.java
@@ -139,9 +139,10 @@ public class CsvRawReader
 				fixDefectiveHeaders();
 			Set<String> uniqueNames = new HashSet<String>();
 			for (int i = 0; i < this.columnNames.length; i++)
-				uniqueNames.add(this.columnNames[i]);
-			if (uniqueNames.size() != this.columnNames.length)
-				throw new SQLException(CsvResources.getString("duplicateColumns"));
+			{
+				if (!uniqueNames.add(this.columnNames[i].toUpperCase()))
+					throw new SQLException(CsvResources.getString("duplicateColumns") + ": " + this.columnNames[i]);
+			}
 		}
 
 		for (int i=0; i<skipLeadingDataLines; i++)

--- a/src/main/java/org/relique/jdbc/csv/CsvRawReader.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvRawReader.java
@@ -153,10 +153,23 @@ public class CsvRawReader
 
 	private void fixDefectiveHeaders()
 	{
+		Set<String> uniqueNames = new HashSet<String>();
 		for (int i = 0; i < this.columnNames.length; i++)
 		{
+			boolean isDefective = false;
 			if (this.columnNames[i].length() == 0)
+			{
+				isDefective = true;
+			}
+			else if (!uniqueNames.add(this.columnNames[i].toUpperCase()))
+			{
+				isDefective = true;
+			}
+
+			if (isDefective)
+			{
 				this.columnNames[i] = "COLUMN" + String.valueOf(i + 1);
+			}
 		}
 	}
 

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -3330,6 +3330,32 @@ public class TestCsvDriver
 	}
 
 	@Test
+	public void testFixDuplicatedColumnNames() throws SQLException
+	{
+		Properties props = new Properties();
+		props.put("defectiveHeaders", "True");
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT * FROM duplicate_headers"))
+		{
+			ResultSetMetaData metadata = results.getMetaData();
+			assertEquals("ID", metadata.getColumnName(1));
+			assertEquals("COLUMN2", metadata.getColumnName(2));
+			assertEquals("Name", metadata.getColumnName(3));
+			assertEquals("COLUMN4", metadata.getColumnName(4));
+			assertTrue(results.next());
+			assertEquals("1:ID is wrong", "1", results.getString("ID"));
+			assertEquals("2:COLUMN2 is wrong", "2", results.getString("COLUMN2"));
+			assertEquals("3:Name is wrong", "george", results.getString("Name"));
+			assertEquals("4:COLUMN4 is wrong", "joe", results.getString("COLUMN4"));
+		}
+	}
+
+	@Test
 	public void testDuplicatedColumnNamesSuppressHeader() throws SQLException
 	{
 		// no bug report, check discussion thread

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -3323,9 +3323,8 @@ public class TestCsvDriver
 			}
 			catch (SQLException e)
 			{
-				assertEquals("wrong exception and/or exception text!",
-					"java.sql.SQLException: " + CsvResources.getString("duplicateColumns"),
-					"" + e);
+				assertTrue("wrong exception and/or exception text!",
+					e.toString().contains(CsvResources.getString("duplicateColumns")));
 			}
 		}
 	}


### PR DESCRIPTION
Extend database connection property `defectiveHeaders` to rename duplicate column names to COLUMNx, in addition to renaming column names that are an empty string.

Fixes #37