### PR TITLE
Prevent duplicate builds for PRs from base repo branches

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -1,6 +1,13 @@
 name: Java CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
It will help to avoid such cases:
<img width="979" alt="Screen Shot 2021-06-03 at 1 12 40 AM" src="https://user-images.githubusercontent.com/5081226/120558955-dfe45e00-c408-11eb-8bfe-00ae5f6c58ea.png">
