### PR TITLE
Add maxDataLines property to stop reading CSV file after N lines

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -516,6 +516,13 @@ as a single quote character.
 words such as `December` which vary depending on the locale. Call method
 `java.util.Locale.toString()` to convert a locale to a string.
 
+### maxDataLines
++ type: Integer
++ default: `0`
++ when non-zero, defines the maximum number of lines of data to read from the
+file.  Using this property together with `skipLeadingDataLines` enables a
+limited number of lines to be read from the middle of a very large file.
+
 ### separator
 + type: String
 + default: `,`

--- a/src/main/java/org/relique/jdbc/csv/CsvConnection.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvConnection.java
@@ -122,6 +122,8 @@ public class CsvConnection implements Connection
 
 	private int skipLeadingLines = 0;
 
+	private int maxDataLines = 0;
+
 	private boolean ignoreUnparseableLines;
 
 	private String missingValue;
@@ -491,6 +493,8 @@ public class CsvConnection implements Connection
 			CsvDriver.DEFAULT_SKIP_LEADING_DATA_LINES));
 		setSkipLeadingLines(info.getProperty(CsvDriver.SKIP_LEADING_LINES,
 			CsvDriver.DEFAULT_SKIP_LEADING_LINES));
+		setMaxDataLines(info.getProperty(CsvDriver.MAX_DATA_LINES,
+				CsvDriver.DEFAULT_MAX_DATA_LINES));
 		setQuoteStyle(info.getProperty(CsvDriver.QUOTE_STYLE,
 			CsvDriver.DEFAULT_QUOTE_STYLE));
 		setIgnoreUnparseableLines(Boolean.parseBoolean(info.getProperty(
@@ -1263,6 +1267,26 @@ public class CsvConnection implements Connection
 	public void setSkipLeadingLines(int skipLeadingLines)
 	{
 		this.skipLeadingLines = skipLeadingLines;
+	}
+
+	private void setMaxDataLines(String property)
+	{
+		try
+		{
+			maxDataLines = Integer.parseInt(property);
+		}
+		catch (NumberFormatException e)
+		{
+			maxDataLines = 0;
+		}
+	}
+
+	/**
+	 * @return the maxDataLines
+	 */
+	public int getMaxDataLines()
+	{
+		return maxDataLines;
 	}
 
 	public boolean isIgnoreUnparseableLines()

--- a/src/main/java/org/relique/jdbc/csv/CsvDatabaseMetaData.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvDatabaseMetaData.java
@@ -596,7 +596,7 @@ public class CsvDatabaseMetaData implements DatabaseMetaData
 				internalStatement = (CsvStatement) createdByConnection.createStatement();
 			retval = new CsvResultSet(internalStatement, reader, "",
 				queryEnvironment, false, ResultSet.TYPE_FORWARD_ONLY, null, null, null, null, -1, 0,
-				columnTypes, 0, new HashMap<>());
+				columnTypes, 0, 0, new HashMap<>());
 		}
 		catch (ClassNotFoundException e)
 		{

--- a/src/main/java/org/relique/jdbc/csv/CsvDriver.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvDriver.java
@@ -63,6 +63,7 @@ public class CsvDriver implements Driver
 	public static final boolean DEFAULT_USE_DATE_TIME_FORMATTER = false;
 	public static final String DEFAULT_COMMENT_CHAR = null;
 	public static final String DEFAULT_SKIP_LEADING_LINES = null;
+	public static final String DEFAULT_MAX_DATA_LINES = "0";
 	public static final String DEFAULT_IGNORE_UNPARSEABLE_LINES = "False";
 	public static final String DEFAULT_MISSING_VALUE = null;
 	public static final String DEFAULT_FILE_TAIL_PREPEND = "False";
@@ -86,6 +87,7 @@ public class CsvDriver implements Driver
 	public static final String USE_DATE_TIME_FORMATTER = "useDateTimeFormatter";
 	public static final String COMMENT_CHAR = "commentChar";
 	public static final String SKIP_LEADING_LINES = "skipLeadingLines";
+	public static final String MAX_DATA_LINES = "maxDataLines";
 	public static final String IGNORE_UNPARSEABLE_LINES = "ignoreNonParseableLines";
 	public static final String MISSING_VALUE = "missingValue";
 	public static final String FILE_TAIL_PREPEND = "fileTailPrepend";

--- a/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
@@ -122,6 +122,8 @@ public class CsvResultSet implements ResultSet
 
 	private int limit;
 
+	private int maxDataLines;
+
 	private boolean isClosed = false;
 
 	/**
@@ -226,6 +228,7 @@ public class CsvResultSet implements ResultSet
 			int sqlOffset,
 			String columnTypes,
 			int skipLeadingLines,
+			int maxDataLines,
 			Map<String, Object> parentObjectEnvironment) throws ClassNotFoundException, SQLException
 	{
 		this.statement = statement;
@@ -250,6 +253,7 @@ public class CsvResultSet implements ResultSet
 			this.orderByColumns = null;
 		if (isDistinct)
 			this.distinctValues = new HashSet<>();
+		this.maxDataLines = maxDataLines;
 		this.parentObjectEnvironment = parentObjectEnvironment;
 
 		String timeFormat = ((CsvConnection)statement.getConnection()).getTimeFormat();
@@ -905,6 +909,11 @@ public class CsvResultSet implements ResultSet
 			if(maxRows != 0 && currentRow >= maxRows)
 			{
 				// Do not fetch any more rows, we have reached the row limit set by caller.
+				thereWasAnAnswer = false;
+			}
+			else if (maxDataLines != 0 && currentRow >= maxDataLines)
+			{
+				// We have already read the maximum number of rows from CSV file. Stop now.
 				thereWasAnAnswer = false;
 			}
 			else if(limit >= 0 && currentRow >= limit)

--- a/src/main/java/org/relique/jdbc/csv/CsvStatement.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvStatement.java
@@ -510,6 +510,7 @@ public class CsvStatement implements Statement
 				parser.getOffset(),
 				connection.getColumnTypes(tableName),
 				connection.getSkipLeadingLines(),
+				connection.getMaxDataLines(),
 				parentobjectEnvironment);
 			lastResultSet = resultSet;
 		}

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -4007,6 +4007,49 @@ public class TestCsvDriver
 	}
 
 	@Test
+	public void testMaxDataLines() throws SQLException
+	{
+		Properties props = new Properties();
+		props.put("skipLeadingDataLines", "2");
+		props.put("maxDataLines", "3");
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect ID Value", "B234", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect ID Value", "C456", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect ID Value", "D789", results.getString(1));
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
+	public void testMaxDataLinesWithOrderBy() throws SQLException
+	{
+		Properties props = new Properties();
+		props.put("maxDataLines", "3");
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT * FROM sample ORDER BY ID"))
+		{
+			assertTrue(results.next());
+			assertEquals("Incorrect ID Value", "A123", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect ID Value", "B234", results.getString(1));
+			assertTrue(results.next());
+			assertEquals("Incorrect ID Value", "Q123", results.getString(1));
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
 	public void testIgnoreUnparseableInIndexedFile() throws SQLException
 	{
 		Properties props = new Properties();


### PR DESCRIPTION
Added database connection property `maxDataLines`.

If this property is set, CsvJdbc will stop reading a CSV file after this number of data lines.

This property enables part of a very large CSV file to be read, and when this property used together with property `skipLeadingDataLines`, enables a limited number of lines to be read from the middle of a very large file.

Added unit tests `TestCsvDriver.testMaxDataLines()` and `TestCsvDriver.testMaxDataLinesWithOrderBy()`.

Unit test `TestCsvDriver.testMaxDataLines()` tests that with `skipLeadingDataLines` set to `2` and
`maxDataLines` set to `3`, only the third, fourth and fifth lines of data are read from the CSV file.

Fixed #48 