### PR TITLE
Remove exceptions that are never thrown

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/CsvRawReader.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvRawReader.java
@@ -398,7 +398,6 @@ public class CsvRawReader
 
 
 	private String [] parseFixedLine(String line, boolean trimValues)
-		throws SQLException
 	{
 		String []values = new String[fixedWidthColumns.size()];
 		if (line == null)

--- a/src/main/java/org/relique/jdbc/csv/CsvReader.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvReader.java
@@ -205,7 +205,7 @@ public class CsvReader extends DataReader
 		return this.aliasedColumnNames;
 	}
 
-	private Object getField(int i) throws SQLException
+	private Object getField(int i)
 	{
 		if (isPlainReader())
 			return rawReader.getField(i);
@@ -303,55 +303,49 @@ public class CsvReader extends DataReader
 		columnTypes = new String[fieldValues.length];
 		for (int i = 0; i < fieldValues.length; i++)
 		{
-			try
+			String typeName = "String";
+			String value = getField(i).toString();
+			if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false"))
 			{
-				String typeName = "String";
-				String value = getField(i).toString();
-				if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false"))
-				{
-					typeName = "Boolean";
-				}
-				else if (value.equals(("" + converter.parseInt(value))))
-				{
-					typeName = "Int";
-				}
-				else if (value.equals(("" + converter.parseLong(value))))
-				{
-					typeName = "Long";
-				}
-				else if (value.equals(("" + converter.parseDouble(value))))
-				{
-					typeName = "Double";
-				}
-				else if (value.equals(("" + converter.parseBytes(value))))
-				{
-					typeName = "Bytes";
-				}
-				else if (value.equals(("" + converter.parseBigDecimal(value))))
-				{
-					typeName = "BigDecimal";
-				}
-				else if (converter.parseTimestamp(value) != null)
-				{
-					typeName = "Timestamp";
-				}
-				else if (converter.parseDate(value) != null)
-				{
-					typeName = "Date";
-				}
-				else if (converter.parseTime(value) != null)
-				{
-					typeName = "Time";
-				}
-				else if (value.equals(("" + converter.parseAsciiStream(value))))
-				{
-					typeName = "AsciiStream";
-				}
-				columnTypes[i] = typeName;
+				typeName = "Boolean";
 			}
-			catch (SQLException e)
+			else if (value.equals(("" + converter.parseInt(value))))
 			{
+				typeName = "Int";
 			}
+			else if (value.equals(("" + converter.parseLong(value))))
+			{
+				typeName = "Long";
+			}
+			else if (value.equals(("" + converter.parseDouble(value))))
+			{
+				typeName = "Double";
+			}
+			else if (value.equals(("" + converter.parseBytes(value))))
+			{
+				typeName = "Bytes";
+			}
+			else if (value.equals(("" + converter.parseBigDecimal(value))))
+			{
+				typeName = "BigDecimal";
+			}
+			else if (converter.parseTimestamp(value) != null)
+			{
+				typeName = "Timestamp";
+			}
+			else if (converter.parseDate(value) != null)
+			{
+				typeName = "Date";
+			}
+			else if (converter.parseTime(value) != null)
+			{
+				typeName = "Time";
+			}
+			else if (value.equals(("" + converter.parseAsciiStream(value))))
+			{
+				typeName = "AsciiStream";
+			}
+			columnTypes[i] = typeName;
 		}
 	}
 

--- a/src/main/java/org/relique/jdbc/csv/CsvStatement.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvStatement.java
@@ -545,7 +545,7 @@ public class CsvStatement implements Statement
 		}
 	}
 
-	public boolean isCancelled() throws SQLException
+	public boolean isCancelled()
 	{
 		return cancelled;
 	}

--- a/src/main/java/org/relique/jdbc/csv/Expression.java
+++ b/src/main/java/org/relique/jdbc/csv/Expression.java
@@ -24,6 +24,9 @@ import java.util.Set;
 
 public abstract class Expression
 {
+	/**
+	 * @throws SQLException if error evaluating expression.
+	 */
 	public Object eval(Map<String, Object> env) throws SQLException
 	{
 		return null;

--- a/src/main/java/org/relique/jdbc/csv/LogicalExpression.java
+++ b/src/main/java/org/relique/jdbc/csv/LogicalExpression.java
@@ -27,6 +27,7 @@ abstract class LogicalExpression extends Expression
 	 * Returns evaluation of expression using given environment.
 	 * @param env key, value pairs of environment.
 	 * @return TRUE or FALSE or null if evaluation contains SQL NULL.
+	 * @throws SQLException if error evaluating logical expression.
 	 */
 	public Boolean isTrue(Map<String, Object> env) throws SQLException
 	{

--- a/src/main/java/org/relique/jdbc/csv/SQLSubstringFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLSubstringFunction.java
@@ -64,7 +64,7 @@ class SQLSubstringFunction extends Expression
 		return retval;
 	}
 
-	private Object substring(Object str, Object startIndex, Object len) throws SQLException
+	private Object substring(Object str, Object startIndex, Object len)
 	{
 		int start = 0;
 		long nChars = 0;

--- a/src/test/java/org/relique/jdbc/csv/TestCryptoFilter.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCryptoFilter.java
@@ -358,7 +358,7 @@ public class TestCryptoFilter
 	}
 
 	@Test
-	public void testOpenManyCryptoFiles() throws SQLException, IOException
+	public void testOpenManyCryptoFiles() throws SQLException
 	{
 		// the properties for the connection:
 		Properties props = new Properties();

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -650,8 +650,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testColumnTypesUserSpecified() throws SQLException,
-			ParseException
+	public void testColumnTypesUserSpecified() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Date");
@@ -677,8 +676,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testColumnTypesUserSpecifiedShuffled() throws SQLException,
-			ParseException
+	public void testColumnTypesUserSpecifiedShuffled() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Date");
@@ -762,8 +760,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testColumnTypesInferDateTimeFromData() throws SQLException,
-			ParseException
+	public void testColumnTypesInferDateTimeFromData() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "");
@@ -795,8 +792,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testColumnTypesInferBeforeNext() throws SQLException,
-			ParseException
+	public void testColumnTypesInferBeforeNext() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "");
@@ -855,8 +851,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testColumnTypesDefaultBehaviour() throws SQLException,
-			ParseException
+	public void testColumnTypesDefaultBehaviour() throws SQLException
 	{
 		Properties props = new Properties();
 
@@ -876,7 +871,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testBadColumnTypesFails() throws SQLException
+	public void testBadColumnTypesFails()
 	{
 		try
 		{
@@ -898,7 +893,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testBadColumnNameFails() throws SQLException
+	public void testBadColumnNameFails()
 	{
 		try
 		{
@@ -919,7 +914,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testEmptyColumnTypesFails() throws SQLException
+	public void testEmptyColumnTypesFails()
 	{
 		try
 		{
@@ -942,8 +937,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testColumnTypesWithSelectStar() throws SQLException,
-			ParseException
+	public void testColumnTypesWithSelectStar() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Int,String,String,Timestamp");
@@ -965,8 +959,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testColumnTypesWithMultipleTables() throws SQLException,
-			ParseException
+	public void testColumnTypesWithMultipleTables() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes.sample5", "Int,String,String,Timestamp");
@@ -1553,7 +1546,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testWhereWithBadColumnName() throws SQLException
+	public void testWhereWithBadColumnName()
 	{
 		try
 		{
@@ -2918,7 +2911,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testSkippingUtf8ByteOrderMark() throws SQLException, ParseException
+	public void testSkippingUtf8ByteOrderMark() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("charset", "UTF-8");
@@ -3542,7 +3535,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testBadQuotechar() throws SQLException
+	public void testBadQuotechar()
 	{
 		Properties props = new Properties();
 		props.put("quotechar", "()");
@@ -3894,7 +3887,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testWithDefectiveHeaders() throws SQLException, ParseException
+	public void testWithDefectiveHeaders() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
@@ -3926,7 +3919,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testWithHeaderMissingColumns() throws SQLException, ParseException
+	public void testWithHeaderMissingColumns() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("defectiveHeaders", "True");
@@ -3954,7 +3947,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testSkipLeadingDataLines() throws SQLException, ParseException
+	public void testSkipLeadingDataLines() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("fileExtension", ".txt");
@@ -4139,8 +4132,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testTimestampFormat() throws SQLException,
-			ParseException
+	public void testTimestampFormat() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("timeZoneName", "UTC");
@@ -4169,7 +4161,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testTimestampFormatGermany() throws SQLException, ParseException
+	public void testTimestampFormatGermany() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("timeZoneName", "UTC");
@@ -4197,8 +4189,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testTimestampInTimeZoneRome() throws SQLException,
-			ParseException
+	public void testTimestampInTimeZoneRome() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("timeZoneName", "Europe/Rome");
@@ -4227,8 +4218,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testTimestampInTimeZoneSantiago() throws SQLException,
-			ParseException
+	public void testTimestampInTimeZoneSantiago() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("timeZoneName", "America/Santiago");
@@ -4257,8 +4247,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testTimestampInTimeZoneGMTPlus0400() throws SQLException,
-			ParseException
+	public void testTimestampInTimeZoneGMTPlus0400() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("timeZoneName", "GMT+04:00");
@@ -4287,8 +4276,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testTimestampInTimeZoneGMTMinus0400() throws SQLException,
-			ParseException
+	public void testTimestampInTimeZoneGMTMinus0400() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("timeZoneName", "GMT-04:00");
@@ -4317,8 +4305,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testAddingDateToTimeInTimeZoneAthens() throws SQLException,
-			ParseException
+	public void testAddingDateToTimeInTimeZoneAthens() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("timeZoneName", "Europe/Athens");
@@ -4361,8 +4348,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testAddingDateToTimeInTimeZoneGMTMinus0500() throws SQLException,
-			ParseException
+	public void testAddingDateToTimeInTimeZoneGMTMinus0500() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("timeZoneName", "GMT-05:00");
@@ -4792,7 +4778,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testTableReaderWithBadReader() throws SQLException
+	public void testTableReaderWithBadReader()
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:class:" + TestCsvDriver.class.getName()))
 		{
@@ -4971,7 +4957,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testNoTable() throws SQLException, ParseException
+	public void testNoTable() throws SQLException
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 			Statement stmt = conn.createStatement();
@@ -5204,8 +5190,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testBooleanConversion() throws SQLException,
-			ParseException
+	public void testBooleanConversion() throws SQLException
 	{
 		Properties props = new Properties();
 		props.put("columnTypes", "Integer,String,Boolean");
@@ -5356,7 +5341,7 @@ public class TestCsvDriver
 	}
 
 	@Test
-	public void testBadUserSqlFunction() throws SQLException
+	public void testBadUserSqlFunction()
 	{
 		Properties props = new Properties();
 		props.put("function.BAD", "java.lang.Math.bad(double)");

--- a/src/test/java/org/relique/jdbc/csv/TestGroupBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestGroupBy.java
@@ -475,7 +475,7 @@ public class TestGroupBy
 	}
 
 	@Test
-	public void testGroupByWithBadColumnName() throws SQLException
+	public void testGroupByWithBadColumnName()
 	{
 		Properties props = new Properties();
 
@@ -493,7 +493,7 @@ public class TestGroupBy
 	}
 
 	@Test
-	public void testSelectUngroupedColumn() throws SQLException
+	public void testSelectUngroupedColumn()
 	{
 		Properties props = new Properties();
 
@@ -511,7 +511,7 @@ public class TestGroupBy
 	}
 
 	@Test
-	public void testOrderByUngroupedColumn() throws SQLException
+	public void testOrderByUngroupedColumn()
 	{
 		Properties props = new Properties();
 
@@ -598,7 +598,7 @@ public class TestGroupBy
 	}
 
 	@Test
-	public void testHavingWithBadColumnName() throws SQLException
+	public void testHavingWithBadColumnName()
 	{
 		Properties props = new Properties();
 
@@ -616,7 +616,7 @@ public class TestGroupBy
 	}
 
 	@Test
-	public void testHavingUngroupedColumn() throws SQLException
+	public void testHavingUngroupedColumn()
 	{
 		Properties props = new Properties();
 

--- a/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
@@ -399,7 +399,7 @@ public class TestOrderBy
 	}
 
 	@Test
-	public void testOrderByWithBadColumnName() throws SQLException
+	public void testOrderByWithBadColumnName()
 	{
 		Properties props = new Properties();
 
@@ -417,7 +417,7 @@ public class TestOrderBy
 	}
 
 	@Test
-	public void testOrderByWithBadColumnNumber() throws SQLException
+	public void testOrderByWithBadColumnNumber()
 	{
 		Properties props = new Properties();
 
@@ -435,7 +435,7 @@ public class TestOrderBy
 	}
 
 	@Test
-	public void testOrderByWithFloatColumnNumber() throws SQLException
+	public void testOrderByWithFloatColumnNumber()
 	{
 		Properties props = new Properties();
 
@@ -453,7 +453,7 @@ public class TestOrderBy
 	}
 
 	@Test
-	public void testOrderByWithBadValue() throws SQLException
+	public void testOrderByWithBadValue()
 	{
 		Properties props = new Properties();
 

--- a/src/test/java/org/relique/jdbc/csv/TestSqlParser.java
+++ b/src/test/java/org/relique/jdbc/csv/TestSqlParser.java
@@ -472,7 +472,7 @@ public class TestSqlParser
 	}
 
 	@Test
-	public void testParsingQueryEnvironmentEntries() throws ParseException, SQLException
+	public void testParsingQueryEnvironmentEntries() throws ParseException
 	{
 		ExpressionParser cs;
 		cs = new ExpressionParser(new StringReader("*"));

--- a/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
+++ b/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
@@ -140,7 +140,7 @@ public class TestZipFiles
 	}
 
 	@Test
-	public void testBadZipFileFails() throws SQLException
+	public void testBadZipFileFails()
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:zip:"
 				+ filePath + File.separator + "abc" + TEST_ZIP_FILENAME_1))


### PR DESCRIPTION
Removed unused `throws SQLException` and other unused exception types to avoid `The declared exception is not actually thrown` info messages in eclipse.