### PR TITLE
fix evaluation of Long column plus Date column in SQL expression

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/BinaryOperation.java
+++ b/src/main/java/org/relique/jdbc/csv/BinaryOperation.java
@@ -181,7 +181,7 @@ class BinaryOperation extends Expression
 					if (leftEval instanceof Short)
 						leftLong = Long.valueOf(((Short)leftEval).intValue());
 					else if (leftEval instanceof Long)
-						leftLong = (Long)rightEval;
+						leftLong = (Long)leftEval;
 					else
 						leftLong = Long.valueOf(((Integer)leftEval).intValue());
 					return incrementDate(rightD, leftLong.longValue());

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -2792,6 +2792,30 @@ public class TestCsvDriver
 	}
 
 	@Test
+	public void testLongPlusDate() throws SQLException
+	{
+		Properties props = new Properties();
+		props.put("columnTypes", "Date,Long,String");
+		props.put("dateFormat", "yyyy-MM-dd");
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+
+			Statement stmt = conn.createStatement();
+
+            ResultSet results = stmt.executeQuery("select start_date + duration, duration + start_date from events"))
+		{
+			assertTrue(results.next());
+			java.sql.Date expect = java.sql.Date.valueOf("2024-01-01");
+			assertEquals("start_date plus duration is wrong", expect, results.getDate(1));
+			assertEquals("duration plus start_date is wrong", expect, results.getDate(2));
+			assertTrue(results.next());
+			expect = java.sql.Date.valueOf("2023-04-01");
+			assertEquals("start_date plus duration is wrong", expect, results.getDate(1));
+			assertEquals("duration plus start_date is wrong", expect, results.getDate(2));
+		}
+	}
+
+	@Test
 	public void testNullIfFunction() throws SQLException
 	{
 		Properties props = new Properties();

--- a/src/testdata/events.csv
+++ b/src/testdata/events.csv
@@ -1,0 +1,3 @@
+start_date,duration,description
+2023-01-01,365,"centenary year"
+2023-03-01,31,"book month"


### PR DESCRIPTION
Fixed adding a column of type Long and a column of type Date in an expression in an SQL statement.

Added unit test `TestCsvDriver.testLongPlusDate` to test adding a Long column and a Date column from test CSV file `events.csv`.

Fixes #56.