### PR TITLE
Interpret empty headerline string as unset

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/CsvRawReader.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvRawReader.java
@@ -111,7 +111,7 @@ public class CsvRawReader
 		if (this.suppressHeaders)
 		{
 			// column names specified by property are available. Read and use.
-			if (this.headerLine != null)
+			if (this.headerLine != null && !this.headerLine.isEmpty())
 			{
 				this.columnNames = parseHeaderLine(this.headerLine, trimHeaders);
 			}

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -4721,6 +4721,27 @@ public class TestCsvDriver
 	}
 
 	@Test
+	public void testEmptyHeaderline() throws SQLException
+	{
+		Properties props = new Properties();
+		props.put("headerline", "");
+		props.put("suppressHeaders", "true");
+		props.put("fileExtension", ".txt");
+		props.put("commentChar", "#");
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"
+				+ filePath, props);
+			Statement stmt = conn.createStatement();
+			ResultSet results = stmt.executeQuery("SELECT COLUMN1, COLUMN2 FROM banks"))
+		{
+			assertTrue(results.next());
+			// Check that default column names are used.
+			assertEquals("COLUMN1 wrong", "10000000", results.getString("COLUMN1"));
+			assertEquals("COLUMN2 wrong", "Bundesbank (Berlin)", results.getString("COLUMN2"));
+		}
+	}
+
+	@Test
 	public void testWarnings() throws SQLException
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:"


### PR DESCRIPTION
If database connection property `headerline` is an empty string, then interpret this property as not set, which is the default for this property.

Added unit test `TestCsvDriver.testEmptyHeaderline` to test this.

Fixes #52.