### PR TITLE
Throw IOException for bad dir name in FileSetInputStream

### DIFF
--- a/src/main/java/org/relique/io/FileSetInputStream.java
+++ b/src/main/java/org/relique/io/FileSetInputStream.java
@@ -129,6 +129,11 @@ public class FileSetInputStream extends InputStream
 		File root = new File(dirName);
 		File[] candidates = root.listFiles();
 
+		if (candidates == null)
+		{
+			throw new IOException(CsvResources.getString("dirNotFound") + ": " + dirName);
+		}
+
 		fileNameRE = Pattern.compile(fileNamePattern);
 
 		for (int i = 0; i < candidates.length; i++)

--- a/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
@@ -234,4 +234,22 @@ public class TestFileSetInputStream
 			assertEquals("2|04.11.2020|-2,2|2222|04112020", line);
 		}
 	}
+
+	@Test
+	public void testFileSetInputStreamBadDirName()
+	{
+		try
+		{
+		    try (FileSetInputStream in = new FileSetInputStream("????",
+			"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
+			"location", "file_date"}, ",", false, false, null, 0, null))
+		    {
+			fail("expected exception java.io.IOException");
+		    }
+		}
+		catch (IOException e)
+		{
+			assertTrue(("" + e).contains("IOException"));
+		}
+	}
 }


### PR DESCRIPTION
This situation should not occur, because directory was checked previously in method `CsvDriver.connect()`.

However, [SpotBugs](https://spotbugs.github.io/) identified this as a potential `NullPointerException`.

Added unit test `TestFileSetInputStream.testFileSetInputStreamBadDirName` to test this situation.