### PR TITLE
Throw SQLException for bad dir name in CsvConnection

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/CsvConnection.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvConnection.java
@@ -1437,6 +1437,11 @@ public class CsvConnection implements Connection
 				}
 			});
 
+			if (matchingFiles == null)
+			{
+				throw new SQLException(CsvResources.getString("dirNotFound") + ": " + path);
+			}
+
 			Pattern fileNameRE = null;
 			if (indexedFiles)
 			{


### PR DESCRIPTION
Throw exception if directory being queried disappears whilst CsvJdbc is connected to it.