### PR TITLE
Avoid static DateFormat members

### DIFF
--- a/src/test/java/org/relique/jdbc/csv/TestAggregateFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestAggregateFunctions.java
@@ -29,10 +29,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Properties;
-import java.util.TimeZone;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,7 +40,6 @@ import org.junit.Test;
 public class TestAggregateFunctions
 {
 	public static String filePath;
-	public static DateFormat toUTC;
 
 	@BeforeClass
 	public static void setUp()
@@ -62,9 +58,6 @@ public class TestAggregateFunctions
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");  
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));  
-
 	}
 
 	@Test

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -69,7 +69,6 @@ import org.junit.Test;
 public class TestCsvDriver
 {
 	private static String filePath;
-	private static DateFormat toUTC;
 	private static DateTimeFormatter toUTCDateTimeFormatter;
 
 	@BeforeClass
@@ -89,9 +88,16 @@ public class TestCsvDriver
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
+
 		toUTCDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.of("UTC"));
+	}
+
+	private DateFormat getUTCDateFormat()
+	{
+		// java.text.DateFormat is not thread-safe, so create new object every time we need one.
+		DateFormat toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
+		return toUTC;
 	}
 
 	@Test
@@ -950,6 +956,7 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			String target = "2001-01-02 12:30:00";
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("the start time is wrong", target, toUTC.format(results
 					.getObject("start")));
 			assertEquals("The ID is wrong", Integer.valueOf(1), results.getObject("id"));
@@ -2232,6 +2239,7 @@ public class TestCsvDriver
 			expect = java.sql.Timestamp.valueOf("2001-04-02 12:30:00");
 			assertEquals("adding Date to Time", expect.getClass(), results
 					.getObject("ts").getClass());
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
 					.format(results.getObject("ts")) + ".0");
 
@@ -2276,6 +2284,7 @@ public class TestCsvDriver
 			Object expect = java.sql.Timestamp.valueOf("2001-04-02 12:31:01");
 			assertEquals("adding Date + Time + Int", expect.getClass(), results
 					.getObject("ts").getClass());
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
 					.format(results.getObject("ts")) + ".0");
 			expect = java.sql.Timestamp.valueOf("2001-04-02 12:28:59");
@@ -3985,6 +3994,7 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM twoheaders"))
 		{
 			assertTrue(results.next());
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
 					.getObject(1)));
 			assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
@@ -4177,6 +4187,7 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			Timestamp got = results.getTimestamp(1);
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("2013-11-25 13:29:07", toUTC.format(got));
 			assertTrue(results.next());
 			got = results.getTimestamp(1);
@@ -4229,6 +4240,7 @@ public class TestCsvDriver
 			// TODO: getString miserably fails!
 			//assertEquals("2001-01-02 12:30:00.0", results.getString("start"));
 			Timestamp got = (Timestamp) results.getObject("start");
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("2001-01-02 11:30:00", toUTC.format(got));
 			got = results.getTimestamp("start");
 			assertEquals("2001-01-02 11:30:00", toUTC.format(got));
@@ -4258,6 +4270,7 @@ public class TestCsvDriver
 			// TODO: getString miserably fails!
 			//assertEquals("2001-01-02 12:30:00", results.getString("start"));
 			Timestamp got = (Timestamp) results.getObject("start");
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("2001-01-02 15:30:00", toUTC.format(got));
 			got = results.getTimestamp("start");
 			assertEquals("2001-01-02 15:30:00", toUTC.format(got));
@@ -4287,6 +4300,7 @@ public class TestCsvDriver
 			// TODO: getString miserably fails!
 			// assertEquals("2001-01-02 12:30:00", results.getString("start"));
 			Timestamp got = (Timestamp) results.getObject("start");
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("2001-01-02 08:30:00", toUTC.format(got));
 			got = results.getTimestamp("start");
 			assertEquals("2001-01-02 08:30:00", toUTC.format(got));
@@ -4316,6 +4330,7 @@ public class TestCsvDriver
 			// TODO: getString miserably fails!
 			// assertEquals("2001-01-02 12:30:00", results.getString("start"));
 			Timestamp got = (Timestamp) results.getObject("start");
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("2001-01-02 16:30:00", toUTC.format(got));
 			got = results.getTimestamp("start");
 			assertEquals("2001-01-02 16:30:00", toUTC.format(got));
@@ -4345,6 +4360,7 @@ public class TestCsvDriver
 			// TODO: getString miserably fails!
 			//assertEquals("2001-01-02 12:30:00", results.getString("start"));
 			Timestamp got = (Timestamp) results.getObject("DT");
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("2010-01-01 23:30:00", toUTC.format(got));
 
 			assertTrue(results.next());
@@ -4388,6 +4404,7 @@ public class TestCsvDriver
 			// TODO: getString miserably fails!
 			//assertEquals("2001-01-02 12:30:00", results.getString("start"));
 			Timestamp got = (Timestamp) results.getObject("DT");
+			DateFormat toUTC = getUTCDateFormat();
 			assertEquals("2010-01-02 06:30:00", toUTC.format(got));
 
 			assertTrue(results.next());

--- a/src/test/java/org/relique/jdbc/csv/TestDbfDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestDbfDriver.java
@@ -33,12 +33,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TimeZone;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -52,7 +49,6 @@ import org.relique.jdbc.dbf.DbfClassNotFoundException;
 public class TestDbfDriver
 {
 	private static String filePath;
-	private static DateFormat toUTC;
 
 	@BeforeClass
 	public static void setUp()
@@ -71,8 +67,6 @@ public class TestDbfDriver
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 
 	/**

--- a/src/test/java/org/relique/jdbc/csv/TestGroupBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestGroupBy.java
@@ -30,10 +30,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Properties;
-import java.util.TimeZone;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,7 +41,6 @@ import org.junit.Test;
 public class TestGroupBy
 {
 	private static String filePath;
-	private static DateFormat toUTC;
 
 	@BeforeClass
 	public static void setUp()
@@ -63,8 +59,6 @@ public class TestGroupBy
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 
 	@Test

--- a/src/test/java/org/relique/jdbc/csv/TestLimitOffset.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLimitOffset.java
@@ -29,10 +29,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Properties;
-import java.util.TimeZone;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,7 +40,6 @@ import org.junit.Test;
 public class TestLimitOffset
 {
 	private static String filePath;
-	private static DateFormat toUTC;
 
 	@BeforeClass
 	public static void setUp()
@@ -62,8 +58,6 @@ public class TestLimitOffset
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");  
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));  
 	}
 
 	@Test

--- a/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
@@ -29,10 +29,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Properties;
-import java.util.TimeZone;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,7 +40,6 @@ import org.junit.Test;
 public class TestOrderBy
 {
 	private static String filePath;
-	private static DateFormat toUTC;
 
 	@BeforeClass
 	public static void setUp()
@@ -62,8 +58,6 @@ public class TestOrderBy
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 
 	@Test

--- a/src/test/java/org/relique/jdbc/csv/TestStringConverter.java
+++ b/src/test/java/org/relique/jdbc/csv/TestStringConverter.java
@@ -38,14 +38,13 @@ import org.junit.Test;
  * @author Mario Frasca
  */
 public class TestStringConverter
-{	
-	private static DateFormat toUTC;
-
-	@BeforeClass
-	public static void setUp()
+{
+	private DateFormat getUTCDateFormat()
 	{
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");  
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));  
+		// java.text.DateFormat is not thread-safe, so create new object every time we need one.
+		DateFormat toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
+		return toUTC;
 	}
 
 	@Test
@@ -165,6 +164,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "yyyy-MM-dd HH:mm:ss", "America/Guadeloupe", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("2010-01-01 12:00:00");
 		assertEquals("2010-01-01 16:00:00", toUTC.format(got));
 
@@ -179,6 +179,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "yyyy-MM-dd HH:mm:ss", "Asia/Yakutsk", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("2010-01-01 12:00:00");
 		assertEquals("2010-01-01 03:00:00", toUTC.format(got));
 
@@ -194,6 +195,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "yyyy-MM-dd HH:mm:ss", "America/Santiago", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("2010-01-01 12:00:00");
 		assertEquals("2010-01-01 15:00:00", toUTC.format(got));
 
@@ -209,6 +211,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "yyyy-MM-dd HH:mm:ss", "Europe/Athens", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("2010-01-01 12:00:00");
 		assertEquals("2010-01-01 10:00:00", toUTC.format(got));
 
@@ -224,6 +227,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "yyyy-MM-dd HH:mm:ss", "", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("2010-01-01 12:00:00");
 		assertEquals("2010-01-01 12:00:00", toUTC.format(got));
 	}
@@ -235,6 +239,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "yyyy-MM-dd HH:mm:ss", "", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("2010-07-01 12:00:00");
 		assertEquals("2010-07-01 12:00:00", toUTC.format(got));
 	}
@@ -246,6 +251,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "yyyy-MM-dd HH:mm:ss", "UTC", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("2010-01-01 12:00:00");
 		assertEquals("2010-01-01 12:00:00", toUTC.format(got));
 	}
@@ -257,6 +263,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "yyyy-MM-dd HH:mm:ss", "UTC", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("2010-07-01 12:00:00");
 		assertEquals("2010-07-01 12:00:00", toUTC.format(got));
 	}
@@ -268,6 +275,7 @@ public class TestStringConverter
 		StringConverter sc = new StringConverter("", "", "dd-MMM-yy hh.mm.ss.000000 aa", "UTC", false);
 		Timestamp got;
 
+		DateFormat toUTC = getUTCDateFormat();
 		got = sc.parseTimestamp("25-NOV-13 01.29.07.000000 PM");
 		assertEquals("2013-11-25 13:29:07", toUTC.format(got));
 	}
@@ -286,6 +294,7 @@ public class TestStringConverter
 		Time expectTime = java.sql.Time.valueOf("19:51:00");
 		assertEquals(expectTime, gotTime);
 
+		DateFormat toUTC = getUTCDateFormat();
 		Timestamp gotTimestamp = sc.parseTimestamp("2019-09-04 13:45:48.616");
 		assertEquals("2019-09-04 13:45:48", toUTC.format(gotTimestamp));
 
@@ -307,6 +316,7 @@ public class TestStringConverter
 		Time expectTime = java.sql.Time.valueOf("07:31:59");
 		assertEquals(expectTime, gotTime);
 
+		DateFormat toUTC = getUTCDateFormat();
 		// in November Montreal lies 5 hours behind UTC
 		Timestamp gotTimestamp = sc.parseTimestamp("29.11.2020 06:02:00");
 		assertEquals("2020-11-29 11:02:00", toUTC.format(gotTimestamp));

--- a/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
+++ b/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
@@ -29,10 +29,7 @@ import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Properties;
-import java.util.TimeZone;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,7 +40,6 @@ import org.junit.Test;
 public class TestZipFiles
 {
 	private static String filePath;
-	private static DateFormat toUTC;
 	private static String TEST_ZIP_FILENAME_1 = "olympic-medals.zip";
 	private static String TEST_ZIP_FILENAME_2 = "encodings.zip";
 
@@ -64,8 +60,6 @@ public class TestZipFiles
 		{
 			fail("Driver is not in the CLASSPATH -> " + e);
 		}
-		toUTC = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-		toUTC.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}
 
 	@Test


### PR DESCRIPTION
Create `java.text.DateFormat` objects as needed in unit tests, instead of holding one static member, because this class is
not thread-safe.

[SpotBugs](https://spotbugs.github.io/) identified this problem.