### PR TITLE
Avoid warnings for ignored return values

### DIFF
--- a/src/test/java/org/relique/jdbc/csv/TestAggregateFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestAggregateFunctions.java
@@ -92,9 +92,8 @@ public class TestAggregateFunctions
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 			Statement stmt = conn.createStatement())
 		{
-			try
+			try (ResultSet results = stmt.executeQuery("SELECT count(XXXX) FROM sample"))
 			{
-				stmt.executeQuery("SELECT count(XXXX) FROM sample");
 				fail("Should raise a java.sqlSQLException");
 			}
 			catch (SQLException e)
@@ -110,9 +109,8 @@ public class TestAggregateFunctions
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 			Statement stmt = conn.createStatement())
 		{
-			try
+			try (ResultSet results = stmt.executeQuery("SELECT ID, count(ID) FROM sample"))
 			{
-				stmt.executeQuery("SELECT ID, count(ID) FROM sample");
 				fail("Should raise a java.sqlSQLException");
 			}
 			catch (SQLException e)
@@ -154,9 +152,8 @@ public class TestAggregateFunctions
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 			Statement stmt = conn.createStatement())
 		{
-			try
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample where count(*)=1"))
 			{
-				stmt.executeQuery("SELECT * FROM sample where count(*)=1");
 				fail("Should raise a java.sqlSQLException");
 			}
 			catch (SQLException e)

--- a/src/test/java/org/relique/jdbc/csv/TestClasspathResources.java
+++ b/src/test/java/org/relique/jdbc/csv/TestClasspathResources.java
@@ -83,9 +83,8 @@ public class TestClasspathResources
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:classpath:testdata/olympic-medals");
 			Statement stmt = conn.createStatement())
 		{
-			try
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM abc"))
 			{
-				stmt.executeQuery("SELECT * FROM abc");
 				fail("Query should fail");
 			}
 			catch (SQLException e)

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -888,8 +888,10 @@ public class TestCsvDriver
 
 				Statement stmt = conn.createStatement())
 			{
-				stmt.executeQuery("SELECT Id, Name FROM sample");
-				fail("Should raise a java.sqlSQLException");
+				try (ResultSet results = stmt.executeQuery("SELECT Id, Name FROM sample"))
+				{
+					fail("Should raise a java.sqlSQLException");
+				}
 			}
 		}
 		catch (SQLException e)
@@ -909,8 +911,10 @@ public class TestCsvDriver
 
 				Statement stmt = conn.createStatement())
 			{
-				stmt.executeQuery("SELECT Id, XXXX FROM sample");
-				fail("Should raise a java.sqlSQLException");
+				try (ResultSet results = stmt.executeQuery("SELECT Id, XXXX FROM sample"))
+				{
+					fail("Should raise a java.sqlSQLException");
+				}
 			}
 		}
 		catch (SQLException e)
@@ -932,8 +936,10 @@ public class TestCsvDriver
 
 				Statement stmt = conn.createStatement())
 			{
-				stmt.executeQuery("SELECT * FROM sample");
-				fail("Should raise a java.sqlSQLException");
+				try (ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
+				{
+					fail("Should raise a java.sqlSQLException");
+				}
 			}
 		}
 		catch (SQLException e)
@@ -1563,8 +1569,10 @@ public class TestCsvDriver
 
 				Statement stmt = conn.createStatement())
 			{
-				stmt.executeQuery("SELECT Id FROM sample where XXXX='123'");
-				fail("Should raise a java.sqlSQLException");
+				try (ResultSet results = stmt.executeQuery("SELECT Id FROM sample where XXXX='123'"))
+				{
+					fail("Should raise a java.sqlSQLException");
+				}
 			}
 		}
 		catch (SQLException e)
@@ -1736,8 +1744,10 @@ public class TestCsvDriver
 		{
 			try
 			{
-				stmt.executeQuery("select * from sample where Name in ()");
-				fail("SQL Query should fail");
+				try (ResultSet results = stmt.executeQuery("select * from sample where Name in ()"))
+				{
+					fail("SQL Query should fail");
+				}
 			}
 			catch (SQLException e)
 			{
@@ -2364,8 +2374,10 @@ public class TestCsvDriver
 		{
 			try
 			{
-				stmt.executeQuery("SELECT ((ID + 1) as N1 FROM sample5");
-				fail("Should raise a java.sqlSQLException");
+				try (ResultSet results = stmt.executeQuery("SELECT ((ID + 1) as N1 FROM sample5"))
+				{
+					fail("Should raise a java.sqlSQLException");
+				}
 			}
 			catch (SQLException e)
 			{
@@ -3331,8 +3343,10 @@ public class TestCsvDriver
 		{
 			try
 			{
-				stmt.executeQuery("SELECT * FROM not_there");
-				fail("Should not find the table 'not_there'");
+				try (ResultSet results = stmt.executeQuery("SELECT * FROM not_there"))
+				{
+					fail("Should not find the table 'not_there'");
+				}
 			}
 			catch (SQLException e)
 			{
@@ -3370,8 +3384,10 @@ public class TestCsvDriver
 			// load CSV driver
 			try
 			{
-				stmt.executeQuery("SELECT * FROM duplicate_headers");
-				fail("expected exception java.sql.SQLException: " + CsvResources.getString("duplicateColumns"));
+				try (ResultSet results = stmt.executeQuery("SELECT * FROM duplicate_headers"))
+				{
+					fail("expected exception java.sql.SQLException: " + CsvResources.getString("duplicateColumns"));
+				}
 			}
 			catch (SQLException e)
 			{
@@ -3773,8 +3789,10 @@ public class TestCsvDriver
 
 			try
 			{
-				stmt.executeQuery("SELECT * FROM sample");
-				fail("expected exception java.sql.SQLException");
+				try (ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
+				{
+					fail("expected exception java.sql.SQLException");
+				}
 			}
 			catch (SQLException e)
 			{
@@ -4829,8 +4847,10 @@ public class TestCsvDriver
 		{
 			try
 			{
-				stmt.executeQuery("SELECT * FROM X");
-				fail("Should raise a java.sqlSQLException");
+				try (ResultSet results = stmt.executeQuery("SELECT * FROM X"))
+				{
+					fail("Should raise a java.sqlSQLException");
+				}
 			}
 			catch (SQLException e)
 			{

--- a/src/test/java/org/relique/jdbc/csv/TestLimitOffset.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLimitOffset.java
@@ -252,9 +252,8 @@ public class TestLimitOffset
 
 			Statement stmt = conn.createStatement())
 		{
-			try
+			try (ResultSet results = stmt.executeQuery("select * from sample5 limit 5 offset -1"))
 			{
-				stmt.executeQuery("select * from sample5 limit 5 offset -1");
 				fail("Should raise a java.sqlSQLException");
 			}
 			catch (SQLException e)

--- a/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
@@ -401,8 +401,10 @@ public class TestOrderBy
 
 			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT Id FROM sample order by XXXX");
-			fail("Should raise a java.sqlSQLException");
+			try (ResultSet results = stmt.executeQuery("SELECT Id FROM sample order by XXXX"))
+			{
+				fail("Should raise a java.sqlSQLException");
+			}
 		}
 		catch (SQLException e)
 		{
@@ -419,8 +421,10 @@ public class TestOrderBy
 
 			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM sample ORDER BY 99");
-			fail("Should raise a java.sqlSQLException");
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample ORDER BY 99"))
+			{
+				fail("Should raise a java.sqlSQLException");
+			}
 		}
 		catch (SQLException e)
 		{
@@ -437,8 +441,10 @@ public class TestOrderBy
 
 			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM sample ORDER BY 3.14");
-			fail("Should raise a java.sqlSQLException");
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample ORDER BY 3.14"))
+			{
+				fail("Should raise a java.sqlSQLException");
+			}
 		}
 		catch (SQLException e)
 		{
@@ -455,8 +461,10 @@ public class TestOrderBy
 
 			Statement stmt = conn.createStatement())
 		{
-			stmt.executeQuery("SELECT * FROM sample ORDER BY 'X'");
-			fail("Should raise a java.sqlSQLException");
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample ORDER BY 'X'"))
+			{
+				fail("Should raise a java.sqlSQLException");
+			}
 		}
 		catch (SQLException e)
 		{

--- a/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
+++ b/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
@@ -120,9 +120,8 @@ public class TestZipFiles
 			+ filePath + File.separator + TEST_ZIP_FILENAME_1);
 			Statement stmt = conn.createStatement())
 		{
-			try
+			try (ResultSet results = stmt.executeQuery("SELECT * FROM abc"))
 			{
-				stmt.executeQuery("SELECT * FROM abc");
 				fail("Query should fail");
 			}
 			catch (SQLException e)


### PR DESCRIPTION
Refactor unit tests to use try-with-resources for `java.sql.ResultSet` objects to avoid these warnings.

[SpotBugs](https://spotbugs.github.io/) identified this problem.