### PR TITLE
Add more bounds checks in SqlArray.getArray(index, count)

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/SqlArray.java
+++ b/src/main/java/org/relique/jdbc/csv/SqlArray.java
@@ -118,10 +118,14 @@ public class SqlArray implements Array
 	{
 		checkFreed();
 
-		if (index > values.size())
-			throw new SQLException("index " + index + " is out of bounds for array with size " + values.size());
+		if (index < 1 || index > values.size() || count < 0)
+		{
+			throw new SQLException(CsvResources.getString("arraySubListOutOfBounds") + ": " +
+				index + ": " +
+				count + ": ");
+		}
 		int toIndex = Math.min(values.size(),  (int) index - 1 + count);
-		return values.subList((int) index - 1, toIndex);
+		return values.subList((int) index - 1, toIndex).toArray();
 	}
 
 	@Override

--- a/src/main/java/org/relique/jdbc/csv/SqlArray.java
+++ b/src/main/java/org/relique/jdbc/csv/SqlArray.java
@@ -122,7 +122,7 @@ public class SqlArray implements Array
 		{
 			throw new SQLException(CsvResources.getString("arraySubListOutOfBounds") + ": " +
 				index + ": " +
-				count + ": ");
+				count);
 		}
 		int toIndex = Math.min(values.size(),  (int) index - 1 + count);
 		return values.subList((int) index - 1, toIndex).toArray();

--- a/src/main/java/org/relique/jdbc/csv/SqlArray.java
+++ b/src/main/java/org/relique/jdbc/csv/SqlArray.java
@@ -121,8 +121,7 @@ public class SqlArray implements Array
 		if (index < 1 || index > values.size() || count < 0)
 		{
 			throw new SQLException(CsvResources.getString("arraySubListOutOfBounds") + ": " +
-				index + ": " +
-				count);
+				index + ": " + count);
 		}
 		int toIndex = Math.min(values.size(),  (int) index - 1 + count);
 		return values.subList((int) index - 1, toIndex).toArray();

--- a/src/main/resources/org/relique/jdbc/csv/messages.properties
+++ b/src/main/resources/org/relique/jdbc/csv/messages.properties
@@ -16,6 +16,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
+arraySubListOutOfBounds=Array subList out of bounds
 cannotConvertToBigDecimal=Cannot convert value to java.math.BigDecimal
 cannotInferColumns=Cannot infer column types until first row is fetched
 caseNotLogical=CASE condition must result in true or false

--- a/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
@@ -152,4 +152,56 @@ public class TestArrayFunctions
 			}
 		}
 	}
+
+	@Test
+	public void testToArrayWithSubList() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT TO_ARRAY(name, role_1, role_2) AS roles FROM arrays_sample"))
+		{
+			assertTrue(results.next());
+			Array array = results.getArray(1);
+			Object[] data = (Object[]) array.getArray(2, 2);
+			assertEquals(2, data.length);
+			assertEquals("teacher", data[0]);
+			assertEquals("grader", data[1]);
+		}
+	}
+
+	@Test
+	public void testToArrayWithSubListOutOfBounds() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT TO_ARRAY(name, role_1, role_2) AS roles FROM arrays_sample"))
+		{
+			assertTrue(results.next());
+			Array array = results.getArray(1);
+			Object[] data = (Object[]) array.getArray(1, 0);
+			assertEquals(0, data.length);
+
+			try
+			{
+				array.getArray(5, 2);
+				fail("Array index out of bounds should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.toString().startsWith("java.sql.SQLException: " +
+					CsvResources.getString("arraySubListOutOfBounds")));
+			}
+
+			try
+			{
+				array.getArray(-1, 2);
+				fail("Array index out of bounds should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.toString().startsWith("java.sql.SQLException: " +
+					CsvResources.getString("arraySubListOutOfBounds")));
+			}
+		}
+	}
 }


### PR DESCRIPTION
Changed return value of method `SqlArray.getArray(index, count)` from `List<Object>` to `Object[]`, to be consistent with the return value of the `SqlArray.getArray()` method, that returns an `Object[]`.

Added unit tests `testToArrayWithSubList` and
`testToArrayWithSubListOutOfBounds` to test the `SqlArray.getArray(index, count)` method.