### PR TITLE
Migrate from JUnit 4 to 5

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -4,8 +4,20 @@
 	<classpathentry kind="src" path="src/main/javacc"/>
 	<classpathentry kind="src" path="src/main/resources"/>
 	<classpathentry kind="src" path="src/test/java"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.3"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
-	<classpathentry kind="lib" path="lib/dans-dbf-lib-1.0.0-beta-10.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.3">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="lib/dans-dbf-lib-1.0.0-beta-10.jar">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.classpath
+++ b/.classpath
@@ -9,15 +9,11 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="lib" path="lib/dans-dbf-lib-1.0.0-beta-10.jar">
 		<attributes>
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/pom.xml
+++ b/pom.xml
@@ -178,9 +178,21 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite</artifactId>
+      <version>1.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-engine</artifactId>
+      <version>1.10.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/relique/jdbc/csv/RunTests.java
+++ b/src/test/java/org/relique/jdbc/csv/RunTests.java
@@ -18,11 +18,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 package org.relique.jdbc.csv;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
 
-@RunWith(Suite.class)
-@Suite.SuiteClasses({
+@Suite
+@SelectClasses({
 	TestSqlParser.class,
 	TestCsvDriver.class,
 	TestDbfDriver.class,
@@ -45,7 +45,7 @@ import org.junit.runners.Suite;
 })
 
 /**
- * Junit4 test suite for the CsvJdbc driver.
+ * Junit5 test suite for the CsvJdbc driver.
  *
  * @author Jonathan Ackerman
  */

--- a/src/test/java/org/relique/jdbc/csv/TestAggregateFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestAggregateFunctions.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -31,8 +31,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class tests SQL aggregate functions in the CsvJdbc driver.
@@ -41,13 +41,13 @@ public class TestAggregateFunctions
 {
 	public static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -68,7 +68,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("SELECT COUNT(*) FROM sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect count", 6, results.getInt(1));
+			assertEquals(6, results.getInt(1), "Incorrect count");
 			assertFalse(results.next());
 		}
 	}
@@ -81,7 +81,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("SELECT count(ID) FROM sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect count", "6", results.getString(1));
+			assertEquals("6", results.getString(1), "Incorrect count");
 			assertFalse(results.next());
 		}
 	}
@@ -128,7 +128,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("SELECT count(*) C FROM sample where ID like '%234'"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect count", 2, results.getInt("C"));
+			assertEquals(2, results.getInt("C"), "Incorrect count");
 			assertFalse(results.next());
 		}
 	}
@@ -141,7 +141,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("SELECT count(*) FROM sample where ID like 'ZZZ%'"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect count", 0, results.getInt(1));
+			assertEquals(0, results.getInt(1), "Incorrect count");
 			assertFalse(results.next());
 		}
 	}
@@ -174,7 +174,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select MAX(ID) from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect max", 6, results.getInt(1));
+			assertEquals(6, results.getInt(1), "Incorrect max");
 			assertFalse(results.next());
 		}
 	}
@@ -190,7 +190,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select max(name) from sample8 where id < 3"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect max", "Mauricio Hernandez", results.getString(1));
+			assertEquals("Mauricio Hernandez", results.getString(1), "Incorrect max");
 			assertFalse(results.next());
 		}
 	}
@@ -206,7 +206,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select MAX(Name) from sample8 where ID = 999"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect max", null, results.getObject(1));
+			assertEquals(null, results.getObject(1), "Incorrect max");
 			assertFalse(results.next());
 		}
 	}
@@ -219,7 +219,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("SELECT MAX(ID)+1 FROM sample8 WHERE ID > 999"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect max", null, results.getObject(1));
+			assertEquals(null, results.getObject(1), "Incorrect max");
 			assertFalse(results.next());
 		}
 	}
@@ -235,7 +235,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("SELECT ROUND(MAX(C5)) FROM numeric"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect max", 3, results.getInt(1));
+			assertEquals(3, results.getInt(1), "Incorrect max");
 			assertFalse(results.next());
 		}
 	}
@@ -251,7 +251,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select max(d) from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect max", "2010-03-28", results.getObject(1).toString());
+			assertEquals("2010-03-28", results.getObject(1).toString(), "Incorrect max");
 			assertFalse(results.next());
 		}
 	}
@@ -267,7 +267,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select MIN(ID) from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect min", 1, results.getInt(1));
+			assertEquals(1, results.getInt(1), "Incorrect min");
 			assertFalse(results.next());
 		}
 	}
@@ -283,7 +283,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select min(upper(name)) from sample8 where id < 3"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect min", "JUAN PABLO MORALES", results.getString(1));
+			assertEquals("JUAN PABLO MORALES", results.getString(1), "Incorrect min");
 			assertFalse(results.next());
 		}
 	}
@@ -298,8 +298,8 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select MIN(ID), MAX(ID) from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect min", 1, results.getInt(1));
-			assertEquals("Incorrect max", 6, results.getInt(2));
+			assertEquals(1, results.getInt(1), "Incorrect min");
+			assertEquals(6, results.getInt(2), "Incorrect max");
 			assertFalse(results.next());
 		}
 	}
@@ -314,7 +314,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select SUM(ID) from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect sum", 21, results.getInt(1));
+			assertEquals(21, results.getInt(1), "Incorrect sum");
 			assertFalse(results.next());
 		}
 	}
@@ -329,8 +329,8 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select sum(c4), sum(c5) from numeric"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect sum", 989999995600L, results.getLong(1));
-			assertEquals("Incorrect sum", "3.14", results.getString(2));
+			assertEquals(989999995600L, results.getLong(1), "Incorrect sum");
+			assertEquals("3.14", results.getString(2), "Incorrect sum");
 			assertFalse(results.next());
 		}
 	}
@@ -345,7 +345,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select SUM(ID) from sample8 where id > 999"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect sum", null, results.getObject(1));
+			assertEquals(null, results.getObject(1), "Incorrect sum");
 			assertFalse(results.next());
 		}
 	}
@@ -360,7 +360,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select AVG(ID) from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect avg", "3.5", results.getString(1));
+			assertEquals("3.5", results.getString(1), "Incorrect avg");
 			assertFalse(results.next());
 		}
 	}
@@ -375,8 +375,8 @@ public class TestAggregateFunctions
 				ResultSet results = stmt.executeQuery("select avg(c2), avg(c5) from numeric"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect avg", "-497.5", results.getString(1));
-			assertEquals("Incorrect avg", "1.57", results.getString(2));
+			assertEquals("-497.5", results.getString(1), "Incorrect avg");
+			assertEquals("1.57", results.getString(2), "Incorrect avg");
 			assertFalse(results.next());
 		}
 	}
@@ -391,7 +391,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select AVG(ID) from sample8 where id > 999"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect avg", null, results.getObject(1));
+			assertEquals(null, results.getObject(1), "Incorrect avg");
 			assertFalse(results.next());
 		}
 	}
@@ -411,8 +411,8 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select count(distinct FROM_ACCT), count(distinct FROM_BLZ) from transactions"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect count FROM_ACCT", 4, results.getInt(1));
-			assertEquals("Incorrect count FROM_BLZ", 3, results.getInt(2));
+			assertEquals(4, results.getInt(1), "Incorrect count FROM_ACCT");
+			assertEquals(3, results.getInt(2), "Incorrect count FROM_BLZ");
 			assertFalse(results.next());
 		}
 	}
@@ -429,8 +429,8 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select sum(distinct PurchaseCt), round(avg(distinct PurchaseCt)) from Purchase"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect sum", 1 + 3 + 4 + 11, results.getInt(1));
-			assertEquals("Incorrect avg", Math.round((1 + 3 + 4 + 11) / 4.0), results.getInt(2));
+			assertEquals(1 + 3 + 4 + 11, results.getInt(1), "Incorrect sum");
+			assertEquals(Math.round((1 + 3 + 4 + 11) / 4.0), results.getInt(2), "Incorrect avg");
 			assertFalse(results.next());
 		}
 	}
@@ -443,7 +443,7 @@ public class TestAggregateFunctions
 			ResultSet results = stmt.executeQuery("select STRING_AGG(ID, ';') from sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect STRING_AGG", "Q123;A123;B234;C456;D789;X234", results.getString(1));
+			assertEquals("Q123;A123;B234;C456;D789;X234", results.getString(1), "Incorrect STRING_AGG");
 			assertFalse(results.next());
 		}
 	}

--- a/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
@@ -18,25 +18,28 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 package org.relique.jdbc.csv;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.sql.*;
-
-import static org.junit.Assert.*;
 
 public class TestArrayFunctions
 {
 	public static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -57,19 +60,19 @@ public class TestArrayFunctions
 			 ResultSet results = stmt.executeQuery("SELECT name, TO_ARRAY(role_1, role_2) AS roles FROM arrays_sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect row", "alice", results.getString(1));
+			assertEquals("alice", results.getString(1), "Incorrect row");
 			Array array = results.getArray(2);
-			assertEquals("Not an array of strings", "String", array.getBaseTypeName());
-			assertEquals("Not an array of varchar", Types.VARCHAR, array.getBaseType());
+			assertEquals("String", array.getBaseTypeName(), "Not an array of strings");
+			assertEquals(Types.VARCHAR, array.getBaseType(), "Not an array of varchar");
 			Object[] data = (Object[]) array.getArray();
 			assertEquals(2, data.length);
 			assertEquals("teacher", data[0]);
 			assertEquals("grader", data[1]);
 
 			assertTrue(results.next());
-			assertEquals("Incorrect row", "bob", results.getString(1));
+			assertEquals("bob", results.getString(1), "Incorrect row");
 			array = results.getArray(2);
-			assertEquals("Not an array of strings", "String", array.getBaseTypeName());
+			assertEquals("String", array.getBaseTypeName(), "Not an array of strings");
 			data = (Object []) array.getArray();
 			assertEquals(2, data.length);
 			assertEquals("", data[0]);
@@ -85,19 +88,19 @@ public class TestArrayFunctions
 			 ResultSet results = stmt.executeQuery("SELECT name,TO_ARRAY(role_id_1, role_id_2) AS roles FROM arrays_sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect row", "alice", results.getString(1));
+			assertEquals("alice", results.getString(1), "Incorrect row");
 			Array array = results.getArray(2);
-			assertEquals("Not an array of integers", "Int", array.getBaseTypeName());
-			assertEquals("Not an array of integer", Types.INTEGER, array.getBaseType());
+			assertEquals("Int", array.getBaseTypeName(), "Not an array of integers");
+			assertEquals(Types.INTEGER, array.getBaseType(), "Not an array of integer");
 			Object[] data = (Object[]) array.getArray();
 			assertEquals(2, data.length);
 			assertEquals(31, data[0]);
 			assertEquals(76, data[1]);
 
 			assertTrue(results.next());
-			assertEquals("Incorrect row", "bob", results.getString(1));
+			assertEquals("bob", results.getString(1), "Incorrect row");
 			array = results.getArray(2);
-			assertEquals("Not an array of integers", "Int", array.getBaseTypeName());
+			assertEquals("Int", array.getBaseTypeName(), "Not an array of integers");
 			data = (Object []) array.getArray();
 			assertEquals(2, data.length);
 			assertNull(data[0]);
@@ -112,7 +115,7 @@ public class TestArrayFunctions
 			 Statement stmt = conn.createStatement();
 			 ResultSet results = stmt.executeQuery("SELECT name, TO_ARRAY(DISTINCT role_1, role_2) AS roles FROM arrays_sample")) {
 			assertTrue(results.next());
-			assertEquals("Incorrect row", "alice", results.getString(1));
+			assertEquals("alice", results.getString(1), "Incorrect row");
 			Object[] data = (Object[]) results.getArray(2).getArray();
 			assertEquals(2, data.length);
 			assertEquals("teacher", data[0]);
@@ -120,7 +123,7 @@ public class TestArrayFunctions
 
 			assertTrue(results.next());
 			assertTrue(results.next());
-			assertEquals("Incorrect row", "eve", results.getString(1));
+			assertEquals("eve", results.getString(1), "Incorrect row");
 			data = (Object[]) results.getArray(2).getArray();
 			assertEquals(1, data.length);
 			assertEquals("teacher", data[0]);

--- a/src/test/java/org/relique/jdbc/csv/TestClasspathResources.java
+++ b/src/test/java/org/relique/jdbc/csv/TestClasspathResources.java
@@ -1,9 +1,9 @@
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -12,7 +12,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests reading of database tables from classpath resources.
@@ -41,15 +41,15 @@ public class TestClasspathResources
 			ResultSet results = stmt.executeQuery("SELECT * FROM medals2004"))
 		{
 			assertTrue(results.next());
-			assertEquals("The YEAR is wrong", 2004, results.getShort(1));
-			assertEquals("The COUNTRY is wrong", "United States", results.getString(2));
-			assertEquals("The CODE is wrong", "USA", results.getString(3));
-			assertEquals("The GOLD is wrong", 36, results.getShort(4));
+			assertEquals(2004, results.getShort(1), "The YEAR is wrong");
+			assertEquals("United States", results.getString(2), "The COUNTRY is wrong");
+			assertEquals("USA", results.getString(3), "The CODE is wrong");
+			assertEquals(36, results.getShort(4), "The GOLD is wrong");
 			assertTrue(results.next());
-			assertEquals("The YEAR is wrong", 2004, results.getShort(1));
-			assertEquals("The COUNTRY is wrong", "China", results.getString(2));
-			assertEquals("The CODE is wrong", "CHN", results.getString(3));
-			assertEquals("The GOLD is wrong", 32, results.getShort(4));
+			assertEquals(2004, results.getShort(1), "The YEAR is wrong");
+			assertEquals("China", results.getString(2), "The COUNTRY is wrong");
+			assertEquals("CHN", results.getString(3), "The CODE is wrong");
+			assertEquals(32, results.getShort(4), "The GOLD is wrong");
 		}
 	}
 
@@ -60,9 +60,9 @@ public class TestClasspathResources
 			ResultSet results = conn.getMetaData().getTables(null, null, "%", null))
 		{
 			assertTrue(results.next());
-			assertEquals("The TABLE_NAME is wrong", "medals2004", results.getString("TABLE_NAME"));
+			assertEquals("medals2004", results.getString("TABLE_NAME"), "The TABLE_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The TABLE_NAME is wrong", "medals2008", results.getString("TABLE_NAME"));
+			assertEquals("medals2008", results.getString("TABLE_NAME"), "The TABLE_NAME is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -108,11 +108,11 @@ public class TestClasspathResources
 			ResultSet results = stmt.executeQuery("SELECT * FROM iso8859-1"))
 		{
 			assertTrue(results.next());
-			assertEquals("ISO8859-1 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertEquals("K\u00D8BENHAVN", results.getString(1), "ISO8859-1 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("ISO8859-1 encoding is wrong", "100\u00B0", results.getString(1));
+			assertEquals("100\u00B0", results.getString(1), "ISO8859-1 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("ISO8859-1 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			assertEquals("\u00A9 Copyright", results.getString(1), "ISO8859-1 encoding is wrong");
 		}
 	}
 
@@ -129,11 +129,11 @@ public class TestClasspathResources
 			ResultSet results = stmt.executeQuery("SELECT * FROM utf-8"))
 		{
 			assertTrue(results.next());
-			assertEquals("UTF-8 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertEquals("K\u00D8BENHAVN", results.getString(1), "UTF-8 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("UTF-8 encoding is wrong", "100\u00B0", results.getString(1));
+			assertEquals("100\u00B0", results.getString(1), "UTF-8 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("UTF-8 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			assertEquals("\u00A9 Copyright", results.getString(1), "UTF-8 encoding is wrong");
 		}
 	}
 
@@ -150,11 +150,11 @@ public class TestClasspathResources
 			ResultSet results = stmt.executeQuery("SELECT * FROM utf-16"))
 		{
 			assertTrue(results.next());
-			assertEquals("UTF-16 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertEquals("K\u00D8BENHAVN", results.getString(1), "UTF-16 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("UTF-16 encoding is wrong", "100\u00B0", results.getString(1));
+			assertEquals("100\u00B0", results.getString(1), "UTF-16 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("UTF-16 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			assertEquals("\u00A9 Copyright", results.getString(1), "UTF-16 encoding is wrong");
 		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestCryptoFilter.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCryptoFilter.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -36,9 +36,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.relique.io.CryptoFilter;
 import org.relique.io.EncryptedFileOutputStream;
 import org.relique.io.XORCipher;
@@ -56,13 +56,13 @@ public class TestCryptoFilter
 	private static String filePath;
 	private static int testSize = 1100;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -107,7 +107,7 @@ public class TestCryptoFilter
 		}
 	}
 
-	@AfterClass
+	@AfterAll
 	public static void tearDown()
 	{
 		// and delete the files when ready
@@ -158,14 +158,14 @@ public class TestCryptoFilter
 			ResultSet results = stmt.executeQuery("SELECT * FROM scrambled"))
 		{
 			assertTrue(results.next());
-			assertEquals("The key is wrong", "1", results.getString("key"));
-			assertEquals("The value is wrong", "uno", results.getString("value"));
+			assertEquals("1", results.getString("key"), "The key is wrong");
+			assertEquals("uno", results.getString("value"), "The value is wrong");
 			assertTrue(results.next());
-			assertEquals("The key is wrong", "2", results.getString("key"));
-			assertEquals("The value is wrong", "due", results.getString("value"));
+			assertEquals("2", results.getString("key"), "The key is wrong");
+			assertEquals("due", results.getString("value"), "The value is wrong");
 			assertTrue(results.next());
-			assertEquals("The key is wrong", "3", results.getString("key"));
-			assertEquals("The value is wrong", "tre", results.getString("value"));
+			assertEquals("3", results.getString("key"), "The key is wrong");
+			assertEquals("tre", results.getString("value"), "The value is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -236,14 +236,14 @@ public class TestCryptoFilter
 			ResultSet results = stmt.executeQuery("SELECT * FROM scrambled_trailing"))
 		{
 			assertTrue(results.next());
-			assertEquals("The key is wrong", "1", results.getString("key"));
-			assertEquals("The value is wrong", "uno", results.getString("value"));
+			assertEquals("1", results.getString("key"), "The key is wrong");
+			assertEquals("uno", results.getString("value"), "The value is wrong");
 			assertTrue(results.next());
-			assertEquals("The key is wrong", "2", results.getString("key"));
-			assertEquals("The value is wrong", "due", results.getString("value"));
+			assertEquals("2", results.getString("key"), "The key is wrong");
+			assertEquals("due", results.getString("value"), "The value is wrong");
 			assertTrue(results.next());
-			assertEquals("The key is wrong", "3", results.getString("key"));
-			assertEquals("The value is wrong", "tre", results.getString("value"));
+			assertEquals("3", results.getString("key"), "The key is wrong");
+			assertEquals("tre", results.getString("value"), "The value is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -264,24 +264,24 @@ public class TestCryptoFilter
 			try (ResultSet results = stmt.executeQuery("SELECT * FROM scrambled"))
 			{
 				assertTrue(results.next());
-				assertEquals("The key is wrong", "1", results.getString("key"));
-				assertEquals("The value is wrong", "uno", results.getString("value"));
+				assertEquals("1", results.getString("key"), "The key is wrong");
+				assertEquals("uno", results.getString("value"), "The value is wrong");
 				assertTrue(results.next());
-				assertEquals("The key is wrong", "2", results.getString("key"));
-				assertEquals("The value is wrong", "due", results.getString("value"));
+				assertEquals("2", results.getString("key"), "The key is wrong");
+				assertEquals("due", results.getString("value"), "The value is wrong");
 			}
 
 			try (ResultSet results = stmt.executeQuery("SELECT * FROM scrambled"))
 			{
 				assertTrue(results.next());
-				assertEquals("The key is wrong", "1", results.getString("key"));
-				assertEquals("The value is wrong", "uno", results.getString("value"));
+				assertEquals("1", results.getString("key"), "The key is wrong");
+				assertEquals("uno", results.getString("value"), "The value is wrong");
 				assertTrue(results.next());
-				assertEquals("The key is wrong", "2", results.getString("key"));
-				assertEquals("The value is wrong", "due", results.getString("value"));
+				assertEquals("2", results.getString("key"), "The key is wrong");
+				assertEquals("due", results.getString("value"), "The value is wrong");
 				assertTrue(results.next());
-				assertEquals("The key is wrong", "3", results.getString("key"));
-				assertEquals("The value is wrong", "tre", results.getString("value"));
+				assertEquals("3", results.getString("key"), "The key is wrong");
+				assertEquals("tre", results.getString("value"), "The value is wrong");
 				assertTrue(!results.next());
 			}
 		}
@@ -352,9 +352,9 @@ public class TestCryptoFilter
 		// comparing results
 		assertEquals(noEncryptCount, encryptCount);
 
-		assertTrue("timeNoEncrypt = " + timeNoEncrypt
-				+ "ms; timeEncrypt = " + timeEncrypt + "ms",
-				timeEncrypt <= 30 * timeNoEncrypt);
+		assertTrue(timeEncrypt <= 30 * timeNoEncrypt,
+				"timeNoEncrypt = " + timeNoEncrypt
+				+ "ms; timeEncrypt = " + timeEncrypt + "ms");
 	}
 
 	@Test

--- a/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestCsvDriver.java
@@ -18,12 +18,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -55,8 +55,8 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.TimeZone;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class is used to test the CsvJdbc driver.
@@ -71,13 +71,13 @@ public class TestCsvDriver
 	private static String filePath;
 	private static DateTimeFormatter toUTCDateTimeFormatter;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -112,51 +112,41 @@ public class TestCsvDriver
 				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM sample"))
 		{
 			results.next();
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "\"S,\"", results
-					.getString("NAME"));
-			assertEquals("Incorrect EXTRA_FIELD Value", "F", results
-					.getString("EXTRA_FIELD"));
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("\"S,\"", results.getString("NAME"), "Incorrect NAME Value");
+			assertEquals("F", results.getString("EXTRA_FIELD"), "Incorrect EXTRA_FIELD Value");
 
-			assertEquals("Incorrect Column 1 Value", "\"S,\"", results.getString(1));
-			assertEquals("Incorrect Column 2 Value", "Q123", results.getString(2));
-			assertEquals("Incorrect Column 3 Value", "F", results.getString(3));
+			assertEquals("\"S,\"", results.getString(1), "Incorrect Column 1 Value");
+			assertEquals("Q123", results.getString(2), "Incorrect Column 2 Value");
+			assertEquals("F", results.getString(3), "Incorrect Column 3 Value");
 
 			results.next();
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
-					.getString("NAME"));
-			assertEquals("Incorrect EXTRA_FIELD Value", "A", results
-					.getString("EXTRA_FIELD"));
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Jonathan Ackerman", results.getString("NAME"), "Incorrect NAME Value");
+			assertEquals("A", results.getString("EXTRA_FIELD"), "Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertEquals("Incorrect ID Value", "B234", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Grady O'Neil", results
-					.getString("NAME"));
-			assertEquals("Incorrect EXTRA_FIELD Value", "B", results
-					.getString("EXTRA_FIELD"));
+			assertEquals("B234", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Grady O'Neil", results.getString("NAME"), "Incorrect NAME Value");
+			assertEquals("B", results.getString("EXTRA_FIELD"), "Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertEquals("Incorrect ID Value", "C456", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Susan, Peter and Dave", results
-					.getString("NAME"));
-			assertEquals("Incorrect EXTRA_FIELD Value", "C", results
-					.getString("EXTRA_FIELD"));
+			assertEquals("C456", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Susan, Peter and Dave", results.getString("NAME"), "Incorrect NAME Value");
+			assertEquals("C", results.getString("EXTRA_FIELD"), "Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertEquals("Incorrect ID Value", "D789", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Amelia \"meals\" Maurice",
-					results.getString("NAME"));
-			assertEquals("Incorrect EXTRA_FIELD Value", "E", results
-					.getString("EXTRA_FIELD"));
+			assertEquals("D789", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Amelia \"meals\" Maurice", results.getString("NAME"),
+				"Incorrect NAME Value");
+			assertEquals("E", results.getString("EXTRA_FIELD"),
+				"Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
-			assertEquals("Incorrect NAME Value",
-					"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
-							.getString("NAME"));
-			assertEquals("Incorrect EXTRA_FIELD Value", "G", results
-					.getString("EXTRA_FIELD"));
+			assertEquals("X234", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results.getString("NAME"),
+				"Incorrect NAME Value");
+			assertEquals("G", results.getString("EXTRA_FIELD"), "Incorrect EXTRA_FIELD Value");
 		}
 	}
 
@@ -177,8 +167,8 @@ public class TestCsvDriver
 				.executeQuery("SELECT ID,Name FROM sample4 WHERE ID='03'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "Maria Cristina Lucero", results
-					.getString("Name"));
+			assertEquals("Maria Cristina Lucero", results.getString("Name"),
+				"The name is wrong");
 			try
 			{
 				results.getString("Job");
@@ -208,12 +198,12 @@ public class TestCsvDriver
 			ResultSet results = stmt
 				.executeQuery("SELECT Job,ID,Name FROM sample4 WHERE ID='02'"))
 		{
-			assertTrue("no results found - should be one", results.next());
-			assertEquals("The name is wrong", "Mauricio Hernandez", results
-					.getString("Name"));
-			assertEquals("The job is wrong", "Project Manager", results
-					.getString("Job"));
-			assertTrue("more than one matching records", !results.next());
+			assertTrue(results.next(), "no results found - should be one");
+			assertEquals("Mauricio Hernandez", results.getString("Name"),
+				"The name is wrong");
+			assertEquals("Project Manager", results.getString("Job"),
+				"The job is wrong");
+			assertTrue(!results.next(), "more than one matching records");
 		}
 	}
 
@@ -233,46 +223,36 @@ public class TestCsvDriver
 				.executeQuery("SELECT NAME,ID,EXTRA_FIELD FROM sample"))
 		{
 			results.next();
-			assertTrue("Incorrect ID Value", results.getString("ID").equals("Q123"));
-			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-					"\"S;\""));
-			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-					"EXTRA_FIELD").equals("F"));
+			assertTrue(results.getString("ID").equals("Q123"), "Incorrect ID Value");
+			assertTrue(results.getString("NAME").equals("\"S;\""), "Incorrect NAME Value");
+			assertTrue(results.getString("EXTRA_FIELD").equals("F"), "Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertTrue("Incorrect ID Value", results.getString("ID").equals("A123"));
-			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-					"Jonathan Ackerman"));
-			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-					"EXTRA_FIELD").equals("A"));
+			assertTrue(results.getString("ID").equals("A123"), "Incorrect ID Value");
+			assertTrue(results.getString("NAME").equals("Jonathan Ackerman"), "Incorrect NAME Value");
+			assertTrue(results.getString("EXTRA_FIELD").equals("A"), "Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertTrue("Incorrect ID Value", results.getString("ID").equals("B234"));
-			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-					"Grady O'Neil"));
-			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-					"EXTRA_FIELD").equals("B"));
+			assertTrue(results.getString("ID").equals("B234"), "Incorrect ID Value");
+			assertTrue(results.getString("NAME").equals("Grady O'Neil"), "Incorrect NAME Value");
+			assertTrue(results.getString("EXTRA_FIELD").equals("B"), "Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertTrue("Incorrect ID Value", results.getString("ID").equals("C456"));
-			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-					"Susan; Peter and Dave"));
-			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-					"EXTRA_FIELD").equals("C"));
+			assertTrue(results.getString("ID").equals("C456"), "Incorrect ID Value");
+			assertTrue(results.getString("NAME").equals("Susan; Peter and Dave"), "Incorrect NAME Value");
+			assertTrue(results.getString("EXTRA_FIELD").equals("C"), "Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertTrue("Incorrect ID Value", results.getString("ID").equals("D789"));
-			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-					"Amelia \"meals\" Maurice"));
-			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-					"EXTRA_FIELD").equals("E"));
+			assertTrue(results.getString("ID").equals("D789"), "Incorrect ID Value");
+			assertTrue(results.getString("NAME").equals("Amelia \"meals\" Maurice"), "Incorrect NAME Value");
+			assertTrue(results.getString("EXTRA_FIELD").equals("E"), "Incorrect EXTRA_FIELD Value");
 
 			results.next();
-			assertTrue("Incorrect ID Value", results.getString("ID").equals("X234"));
-			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-					"Peter \"peg leg\"; Jimmy & Samantha \"Sam\""));
-			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-					"EXTRA_FIELD").equals("G"));
+			assertTrue(results.getString("ID").equals("X234"), "Incorrect ID Value");
+			assertTrue(results.getString("NAME").equals("Peter \"peg leg\"; Jimmy & Samantha \"Sam\""),
+				"Incorrect NAME Value");
+			assertTrue(results.getString("EXTRA_FIELD").equals("G"),
+				"Incorrect EXTRA_FIELD Value");
 		}
 	}
 
@@ -286,9 +266,9 @@ public class TestCsvDriver
 
 			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			assertEquals("Incorrect Column", 1, results.findColumn("ID"));
-			assertEquals("Incorrect Column", 2, results.findColumn("Name"));
-			assertEquals("Incorrect Column", 3, results.findColumn("EXTRA_FIELD"));
+			assertEquals(1, results.findColumn("ID"), "Incorrect Column");
+			assertEquals(2, results.findColumn("Name"), "Incorrect Column");
+			assertEquals(3, results.findColumn("EXTRA_FIELD"), "Incorrect Column");
 
 			try
 			{
@@ -314,19 +294,13 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("Incorrect Table Name", "sample3", metadata
-					.getTableName(0));
+			assertEquals("sample3", metadata.getTableName(0), "Incorrect Table Name");
 
-			assertEquals("Incorrect Column Name 1", "column 1", metadata
-					.getColumnName(1));
-			assertEquals("Incorrect Column Name 2", "column \"2\" two", metadata
-					.getColumnName(2));
-			assertEquals("Incorrect Column Name 3", "Column 3", metadata
-					.getColumnName(3));
-			assertEquals("Incorrect Column Name 4", "CoLuMn4", metadata
-					.getColumnName(4));
-			assertEquals("Incorrect Column Name 5", "COLumn5", metadata
-					.getColumnName(5));
+			assertEquals("column 1", metadata.getColumnName(1), "Incorrect Column Name 1");
+			assertEquals("column \"2\" two", metadata.getColumnName(2), "Incorrect Column Name 2");
+			assertEquals("Column 3", metadata.getColumnName(3), "Incorrect Column Name 3");
+			assertEquals("CoLuMn4", metadata.getColumnName(4), "Incorrect Column Name 4");
+			assertEquals("COLumn5", metadata.getColumnName(5), "Incorrect Column Name 5");
 		}
 	}
 
@@ -345,15 +319,11 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
-					"sample"));
+			assertTrue(metadata.getTableName(0).equals("sample"), "Incorrect Table Name");
 
-			assertTrue("Incorrect Column Name 1", metadata.getColumnName(1).equals(
-					"COLUMN1"));
-			assertTrue("Incorrect Column Name 2", metadata.getColumnName(2).equals(
-					"COLUMN2"));
-			assertTrue("Incorrect Column Name 3", metadata.getColumnName(3).equals(
-					"COLUMN3"));
+			assertTrue(metadata.getColumnName(1).equals("COLUMN1"), "Incorrect Column Name 1");
+			assertTrue(metadata.getColumnName(2).equals("COLUMN2"), "Incorrect Column Name 2");
+			assertTrue(metadata.getColumnName(3).equals("COLUMN3"), "Incorrect Column Name 3");
 		}
 	}
 
@@ -373,23 +343,23 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
-					.getColumnType(1));
-			assertEquals("type of column 2 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(2));
-			assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(3));
-			assertEquals("type of column 4 is incorrect", Types.TIMESTAMP, metadata
-					.getColumnType(4));
+			assertEquals(Types.INTEGER, metadata.getColumnType(1),
+				"type of column 1 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(2),
+				"type of column 2 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(3),
+				"type of column 3 is incorrect");
+			assertEquals(Types.TIMESTAMP, metadata.getColumnType(4),
+				"type of column 4 is incorrect");
 
-			assertEquals("type of column 1 is incorrect", "Int", metadata
-					.getColumnTypeName(1));
-			assertEquals("type of column 2 is incorrect", "String", metadata
-					.getColumnTypeName(2));
-			assertEquals("type of column 3 is incorrect", "String", metadata
-					.getColumnTypeName(3));
-			assertEquals("type of column 4 is incorrect", "Timestamp", metadata
-					.getColumnTypeName(4));
+			assertEquals("Int", metadata.getColumnTypeName(1),
+				"type of column 1 is incorrect");
+			assertEquals("String", metadata.getColumnTypeName(2),
+				"type of column 2 is incorrect");
+			assertEquals("String", metadata.getColumnTypeName(3),
+				"type of column 3 is incorrect");
+			assertEquals("Timestamp", metadata.getColumnTypeName(4),
+				"type of column 4 is incorrect");
 		}
 	}
 
@@ -409,14 +379,14 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("size of column 1 is incorrect", 20, metadata
-					.getColumnDisplaySize(1));
-			assertEquals("size of column 2 is incorrect", 20, metadata
-					.getColumnDisplaySize(2));
-			assertEquals("size of column 3 is incorrect", 20, metadata
-					.getColumnDisplaySize(3));
-			assertEquals("size of column 4 is incorrect", 20, metadata
-					.getColumnDisplaySize(4));
+			assertEquals(20, metadata.getColumnDisplaySize(1),
+				"size of column 1 is incorrect");
+			assertEquals(20, metadata.getColumnDisplaySize(2),
+				"size of column 2 is incorrect");
+			assertEquals(20, metadata.getColumnDisplaySize(3),
+				"size of column 3 is incorrect");
+			assertEquals(20, metadata.getColumnDisplaySize(4),
+				"size of column 4 is incorrect");
 		}
 	}
 
@@ -439,14 +409,14 @@ public class TestCsvDriver
 			ResultSetMetaData metadata = results.getMetaData();
 
 			// TODO - this fails
-			assertEquals("type of column 1 is incorrect", Types.TIMESTAMP, metadata
-					.getColumnType(1));
-			assertEquals("type of column 2 is incorrect", Types.INTEGER, metadata
-					.getColumnType(2));
-			assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(3));
-			assertEquals("type of column 4 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(4));
+			assertEquals(Types.TIMESTAMP, metadata.getColumnType(1),
+				"type of column 1 is incorrect");
+			assertEquals(Types.INTEGER, metadata.getColumnType(2),
+				"type of column 2 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(3),
+				"type of column 3 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(4),
+				"type of column 4 is incorrect");
 		}
 	}
 
@@ -469,22 +439,22 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
-					.getColumnType(1));
-			assertEquals("type of column 2 is incorrect", Types.TIMESTAMP, metadata
-					.getColumnType(2));
-			assertEquals("type of column 3 is incorrect", Types.INTEGER, metadata
-					.getColumnType(3));
-			assertEquals("type of column 4 is incorrect", Types.INTEGER, metadata
-					.getColumnType(4));
-			assertEquals("type of column 5 is incorrect", Types.DOUBLE, metadata
-					.getColumnType(5));
-			assertEquals("type of column 6 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(6));
-			assertEquals("type of column 7 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(7));
-			assertEquals("type of column 8 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(8));
+			assertEquals(Types.INTEGER, metadata.getColumnType(1),
+				"type of column 1 is incorrect");
+			assertEquals(Types.TIMESTAMP, metadata.getColumnType(2),
+				"type of column 2 is incorrect");
+			assertEquals(Types.INTEGER, metadata.getColumnType(3),
+				"type of column 3 is incorrect");
+			assertEquals(Types.INTEGER, metadata.getColumnType(4),
+				"type of column 4 is incorrect");
+			assertEquals(Types.DOUBLE, metadata.getColumnType(5),
+				"type of column 5 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(6),
+				"type of column 6 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(7),
+				"type of column 7 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(8),
+				"type of column 8 is incorrect");
 		}
 	}
 
@@ -501,10 +471,10 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("Incorrect Table Name", "sample", metadata.getTableName(0));
+			assertEquals("sample", metadata.getTableName(0), "Incorrect Table Name");
 
-			assertEquals("Incorrect Column Name 1", "ID", metadata.getColumnName(1));
-			assertEquals("Incorrect Column Name 2", "NAME", metadata.getColumnName(2));
+			assertEquals("ID", metadata.getColumnName(1), "Incorrect Column Name 1");
+			assertEquals("NAME", metadata.getColumnName(2), "Incorrect Column Name 2");
 		}
 	}
 
@@ -524,12 +494,12 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("name of column 1 is incorrect", "XID", metadata.getColumnName(1));
-			assertEquals("label of column 1 is incorrect", "XID", metadata.getColumnLabel(1));
-			assertEquals("name of column 2 is incorrect", "Name", metadata.getColumnName(2));
-			assertEquals("label of column 2 is incorrect", "Name", metadata.getColumnLabel(2));
-			assertEquals("name of column 3 is incorrect", "DEPT", metadata.getColumnName(3));
-			assertEquals("label of column 3 is incorrect", "DEPT", metadata.getColumnLabel(3));
+			assertEquals("XID", metadata.getColumnName(1), "name of column 1 is incorrect");
+			assertEquals("XID", metadata.getColumnLabel(1), "label of column 1 is incorrect");
+			assertEquals("Name", metadata.getColumnName(2), "name of column 2 is incorrect");
+			assertEquals("Name", metadata.getColumnLabel(2), "label of column 2 is incorrect");
+			assertEquals("DEPT", metadata.getColumnName(3), "name of column 3 is incorrect");
+			assertEquals("DEPT", metadata.getColumnLabel(3), "label of column 3 is incorrect");
 		}
 	}
 
@@ -542,7 +512,7 @@ public class TestCsvDriver
 			DatabaseMetaData metadata = conn.getMetaData();
 			ResultSet results = metadata.getTableTypes();
 			assertTrue(results.next());
-			assertEquals("Wrong table type", "TABLE", results.getString(1));
+			assertEquals("TABLE", results.getString(1), "Wrong table type");
 			assertFalse(results.next());
 		}
 	}
@@ -567,11 +537,11 @@ public class TestCsvDriver
 			ResultSet results = conn.getMetaData().getColumns(null, null, "C D", null))
 		{
 			assertTrue(results.next());
-			assertEquals("Wrong table name", "C D", results.getString("TABLE_NAME"));
-			assertEquals("Wrong column name", "A", results.getString("COLUMN_NAME"));
+			assertEquals("C D", results.getString("TABLE_NAME"), "Wrong table name");
+			assertEquals("A", results.getString("COLUMN_NAME"), "Wrong column name");
 			assertTrue(results.next());
-			assertEquals("Wrong table name", "C D", results.getString("TABLE_NAME"));
-			assertEquals("Wrong column name", "B", results.getString("COLUMN_NAME"));
+			assertEquals("C D", results.getString("TABLE_NAME"), "Wrong table name");
+			assertEquals("B", results.getString("COLUMN_NAME"), "Wrong column name");
 		}
 	}
 
@@ -589,11 +559,11 @@ public class TestCsvDriver
 			ResultSet results = conn.getMetaData().getColumns(null, null, "test", null))
 		{
 			assertTrue(results.next());
-			assertEquals("Wrong table name", "test", results.getString("TABLE_NAME"));
-			assertEquals("Wrong column name", "Datum", results.getString("COLUMN_NAME"));
+			assertEquals("test", results.getString("TABLE_NAME"), "Wrong table name");
+			assertEquals("Datum", results.getString("COLUMN_NAME"), "Wrong column name");
 			assertTrue(results.next());
-			assertEquals("Wrong table name", "test", results.getString("TABLE_NAME"));
-			assertEquals("Wrong column name", "Tijd", results.getString("COLUMN_NAME"));
+			assertEquals("test", results.getString("TABLE_NAME"), "Wrong table name");
+			assertEquals("Tijd", results.getString("COLUMN_NAME"), "Wrong column name");
 		}
 	}
 
@@ -649,9 +619,9 @@ public class TestCsvDriver
 			ResultSet results = conn.getMetaData().getTypeInfo())
 		{
 			assertTrue(results.next());
-			assertEquals("TYPE_NAME is wrong", "String", results.getString("TYPE_NAME"));
-			assertEquals("DATA_TYPE is wrong", Types.VARCHAR, results.getInt("DATA_TYPE"));
-			assertEquals("NULLABLE is wrong", DatabaseMetaData.typeNullable, results.getShort("NULLABLE"));
+			assertEquals("String", results.getString("TYPE_NAME"), "TYPE_NAME is wrong");
+			assertEquals(Types.VARCHAR, results.getInt("DATA_TYPE"), "DATA_TYPE is wrong");
+			assertEquals(DatabaseMetaData.typeNullable, results.getShort("NULLABLE"), "NULLABLE is wrong");
 		}
 	}
 
@@ -668,16 +638,17 @@ public class TestCsvDriver
 				+ "FROM sample5 WHERE Job = 'Project Manager'"))
 		{
 			assertTrue(results.next());
-			assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
-					.getObject("id"));
-			assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
-					.getObject(1));
+			assertEquals(Integer.valueOf(1), results.getObject("id"),
+				"Integer column ID is wrong");
+			assertEquals(Integer.valueOf(1), results.getObject(1),
+				"Integer column 1 is wrong");
 			java.sql.Date shouldBe = java.sql.Date.valueOf("2001-01-02");
-			assertEquals("Date column Start is wrong", shouldBe, results
-					.getObject("start"));
-			assertEquals("Date column 4 is wrong", shouldBe, results.getObject(4));
-			assertEquals("The Name is wrong", "Juan Pablo Morales", results
-					.getObject("name"));
+			assertEquals(shouldBe, results.getObject("start"),
+				"Date column Start is wrong");
+			assertEquals(shouldBe, results.getObject(4),
+				"Date column 4 is wrong");
+			assertEquals("Juan Pablo Morales", results.getObject("name"),
+				"The Name is wrong");
 		}
 	}
 
@@ -694,16 +665,16 @@ public class TestCsvDriver
 				+ "FROM sample5 WHERE Job = 'Project Manager'"))
 		{
 			assertTrue(results.next());
-			assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
-					.getObject("id"));
-			assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
-					.getObject(1));
+			assertEquals(Integer.valueOf(1), results.getObject("id"),
+				"Integer column ID is wrong");
+			assertEquals(Integer.valueOf(1), results.getObject(1),
+				"Integer column 1 is wrong");
 			java.sql.Date shouldBe = java.sql.Date.valueOf("2001-01-02");
-			assertEquals("Date column Start is wrong", shouldBe, results
-					.getObject("start"));
-			assertEquals("Date column 4 is wrong", shouldBe, results.getObject(2));
-			assertEquals("The Name is wrong", "Juan Pablo Morales", results
-					.getObject("name"));
+			assertEquals(shouldBe, results.getObject("start"),
+				"Date column Start is wrong");
+			assertEquals(shouldBe, results.getObject(2), "Date column 4 is wrong");
+			assertEquals("Juan Pablo Morales", results.getObject("name"),
+				"The Name is wrong");
 		}
 	}
 
@@ -722,16 +693,16 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			DateFormat dfp = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-			assertEquals("Integer column ID is wrong", Integer.valueOf(1), results
-					.getObject("id"));
-			assertEquals("Integer column 1 is wrong", Integer.valueOf(1), results
-					.getObject(1));
-			assertEquals("Date column Start is wrong", dfp.parse(results
-					.getString("start")), results.getObject("start"));
-			assertEquals("Date column 4 is wrong", dfp.parse(results
-					.getString("start")), results.getObject(4));
-			assertEquals("The Name is wrong", "Juan Pablo Morales", results
-					.getObject("name"));
+			assertEquals(Integer.valueOf(1), results.getObject("id"),
+				"Integer column ID is wrong");
+			assertEquals(Integer.valueOf(1), results.getObject(1),
+				"Integer column 1 is wrong");
+			assertEquals(dfp.parse(results.getString("start")), results.getObject("start"),
+				"Date column Start is wrong");
+			assertEquals(dfp.parse(results.getString("start")), results.getObject(4),
+				"Date column 4 is wrong");
+			assertEquals("Juan Pablo Morales", results.getObject("name"),
+				"The Name is wrong");
 		}
 	}
 
@@ -754,14 +725,14 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
-			assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
-					.getColumnType(1));
-			assertEquals("type of column 2 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(2));
-			assertEquals("type of column 3 is incorrect", Types.VARCHAR, metadata
-					.getColumnType(3));
-			assertEquals("type of column 4 is incorrect", Types.TIMESTAMP, metadata
-					.getColumnType(4));
+			assertEquals(Types.INTEGER, metadata.getColumnType(1),
+				"type of column 1 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(2),
+				"type of column 2 is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(3),
+				"type of column 3 is incorrect");
+			assertEquals(Types.TIMESTAMP, metadata.getColumnType(4),
+				"type of column 4 is incorrect");
 		}
 	}
 
@@ -788,12 +759,12 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
-			assertEquals("type of column 1 is incorrect", Types.INTEGER, metadata
-					.getColumnType(1));
-			assertEquals("type of column 2 is incorrect", Types.DATE, metadata
-					.getColumnType(2));
-			assertEquals("type of column 3 is incorrect", Types.TIME, metadata
-					.getColumnType(3));
+			assertEquals(Types.INTEGER, metadata.getColumnType(1),
+				"type of column 1 is incorrect");
+			assertEquals(Types.DATE, metadata.getColumnType(2),
+				"type of column 2 is incorrect");
+			assertEquals(Types.TIME, metadata.getColumnType(3),
+				"type of column 3 is incorrect");
 		}
 	}
 
@@ -839,20 +810,20 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
-			assertEquals("type of column 1 is incorrect", Types.TINYINT, metadata
-					.getColumnType(1));
-			assertEquals("type of column 2 is incorrect", Types.SMALLINT, metadata
-					.getColumnType(2));
-			assertEquals("type of column 3 is incorrect", Types.INTEGER, metadata
-					.getColumnType(3));
-			assertEquals("type of column 4 is incorrect", Types.BIGINT, metadata
-					.getColumnType(4));
-			assertEquals("type of column 5 is incorrect", Types.FLOAT, metadata
-					.getColumnType(5));
-			assertEquals("type of column 6 is incorrect", Types.DOUBLE, metadata
-					.getColumnType(6));
-			assertEquals("type of column 7 is incorrect", Types.DECIMAL, metadata
-					.getColumnType(7));
+			assertEquals(Types.TINYINT, metadata.getColumnType(1),
+				"type of column 1 is incorrect");
+			assertEquals(Types.SMALLINT, metadata.getColumnType(2),
+				"type of column 2 is incorrect");
+			assertEquals(Types.INTEGER, metadata.getColumnType(3),
+				"type of column 3 is incorrect");
+			assertEquals(Types.BIGINT, metadata.getColumnType(4),
+				"type of column 4 is incorrect");
+			assertEquals(Types.FLOAT, metadata.getColumnType(5),
+				"type of column 5 is incorrect");
+			assertEquals(Types.DOUBLE, metadata.getColumnType(6),
+				"type of column 6 is incorrect");
+			assertEquals(Types.DECIMAL, metadata.getColumnType(7),
+				"type of column 7 is incorrect");
 		}
 	}
 
@@ -868,11 +839,11 @@ public class TestCsvDriver
 				+ "FROM sample5 WHERE Job = 'Project Manager'"))
 		{
 			assertTrue(results.next());
-			assertEquals("the start time is wrong", "2001-01-02 12:30:00", results
-					.getObject("start"));
-			assertEquals("The ID is wrong", "01", results.getObject("id"));
-			assertEquals("The Name is wrong", "Juan Pablo Morales", results
-					.getObject("name"));
+			assertEquals("2001-01-02 12:30:00", results.getObject("start"),
+				"the start time is wrong");
+			assertEquals("01", results.getObject("id"), "The ID is wrong");
+			assertEquals("Juan Pablo Morales", results.getObject("name"),
+				"The Name is wrong");
 		}
 	}
 
@@ -963,11 +934,11 @@ public class TestCsvDriver
 			assertTrue(results.next());
 			String target = "2001-01-02 12:30:00";
 			DateFormat toUTC = getUTCDateFormat();
-			assertEquals("the start time is wrong", target, toUTC.format(results
-					.getObject("start")));
-			assertEquals("The ID is wrong", Integer.valueOf(1), results.getObject("id"));
-			assertEquals("The Name is wrong", "Juan Pablo Morales", results
-					.getObject("name"));
+			assertEquals(target, toUTC.format(results.getObject("start")),
+				"the start time is wrong");
+			assertEquals(Integer.valueOf(1), results.getObject("id"), "The ID is wrong");
+			assertEquals("Juan Pablo Morales", results.getObject("name"),
+				"The Name is wrong");
 		}
 	}
 
@@ -987,22 +958,22 @@ public class TestCsvDriver
 			try (ResultSet results = stmt.executeQuery("SELECT * from sample5"))
 			{
 				assertTrue(results.next());
-				assertEquals("The sample5 ID is wrong", Integer.valueOf(41), results.getObject("id"));
-				assertEquals("The sample5 Job is wrong", "Piloto", results.getObject("job"));
+				assertEquals(Integer.valueOf(41), results.getObject("id"), "The sample5 ID is wrong");
+				assertEquals("Piloto", results.getObject("job"), "The sample5 Job is wrong");
 			}
 			try (ResultSet results = stmt.executeQuery("SELECT ID,EXTRA_FIELD from sample"))
 			{
 				assertTrue(results.next());
-				assertEquals("The sample ID is wrong", "Q123", results.getObject(1));
-				assertEquals("The sample EXTRA_FIELD is wrong", "F", results.getObject(2));
+				assertEquals("Q123", results.getObject(1), "The sample ID is wrong");
+				assertEquals("F", results.getObject(2), "The sample EXTRA_FIELD is wrong");
 			}
 
 			// column types are inferred from data.
 			try (ResultSet results = stmt.executeQuery("SELECT C2, 'X' as X from numeric"))
 			{
 				assertTrue(results.next());
-				assertEquals("The numeric C2 is wrong", Integer.valueOf(-1010), results.getObject(1));
-				assertEquals("The numeric X is wrong", "X", results.getObject(2));
+				assertEquals(Integer.valueOf(-1010), results.getObject(1), "The numeric C2 is wrong");
+				assertEquals("X", results.getObject(2), "The numeric X is wrong");
 			}
 		}
 	}
@@ -1021,60 +992,60 @@ public class TestCsvDriver
 		{
 			// header is now treated as normal data line
 			results.next();
-			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-					.equals("ID"));
-			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-					.equals("NAME"));
-			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-					.equals("EXTRA_FIELD"));
+			assertTrue(results.getString("COLUMN1").equals("ID"),
+				"Incorrect COLUMN1 Value");
+			assertTrue(results.getString("COLUMN2").equals("NAME"),
+				"Incorrect COLUMN2 Value");
+			assertTrue(results.getString("COLUMN3").equals("EXTRA_FIELD"),
+				"Incorrect COLUMN3 Value");
 
 			results.next();
-			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-					.equals("Q123"));
-			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-					.equals("\"S,\""));
-			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-					.equals("F"));
+			assertTrue(results.getString("COLUMN1").equals("Q123"),
+				"Incorrect COLUMN1 Value");
+			assertTrue(results.getString("COLUMN2").equals("\"S,\""),
+				"Incorrect COLUMN2 Value");
+			assertTrue(results.getString("COLUMN3").equals("F"),
+				"Incorrect COLUMN3 Value");
 
 			results.next();
-			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-					.equals("A123"));
-			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-					.equals("Jonathan Ackerman"));
-			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-					.equals("A"));
+			assertTrue(results.getString("COLUMN1").equals("A123"),
+				"Incorrect COLUMN1 Value");
+			assertTrue(results.getString("COLUMN2").equals("Jonathan Ackerman"),
+				"Incorrect COLUMN2 Value");
+			assertTrue(results.getString("COLUMN3").equals("A"),
+				"Incorrect COLUMN3 Value");
 
 			results.next();
-			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-					.equals("B234"));
-			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-					.equals("Grady O'Neil"));
-			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-					.equals("B"));
+			assertTrue(results.getString("COLUMN1").equals("B234"),
+				"Incorrect COLUMN1 Value");
+			assertTrue(results.getString("COLUMN2").equals("Grady O'Neil"),
+				"Incorrect COLUMN2 Value");
+			assertTrue(results.getString("COLUMN3").equals("B"),
+				"Incorrect COLUMN3 Value");
 
 			results.next();
-			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-					.equals("C456"));
-			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-					.equals("Susan, Peter and Dave"));
-			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-					.equals("C"));
+			assertTrue(results.getString("COLUMN1").equals("C456"),
+				"Incorrect COLUMN1 Value");
+			assertTrue(results.getString("COLUMN2").equals("Susan, Peter and Dave"),
+				"Incorrect COLUMN2 Value");
+			assertTrue(results.getString("COLUMN3").equals("C"),
+				"Incorrect COLUMN3 Value");
 
 			results.next();
-			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-					.equals("D789"));
-			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-					.equals("Amelia \"meals\" Maurice"));
-			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-					.equals("E"));
+			assertTrue(results.getString("COLUMN1").equals("D789"),
+				"Incorrect COLUMN1 Value");
+			assertTrue(results.getString("COLUMN2").equals("Amelia \"meals\" Maurice"),
+				"Incorrect COLUMN2 Value");
+			assertTrue(results.getString("COLUMN3").equals("E"),
+				"Incorrect COLUMN3 Value");
 
 			results.next();
-			assertTrue("Incorrect COLUMN1 Value", results.getString("COLUMN1")
-					.equals("X234"));
-			assertTrue("Incorrect COLUMN2 Value", results.getString("COLUMN2")
-					.equals("Peter \"peg leg\", Jimmy & Samantha \"Sam\""));
-			assertTrue("Incorrect COLUMN3 Value", results.getString("COLUMN3")
-					.equals("G"));
+			assertTrue(results.getString("COLUMN1").equals("X234"),
+				"Incorrect COLUMN1 Value");
+			assertTrue(results.getString("COLUMN2").equals("Peter \"peg leg\", Jimmy & Samantha \"Sam\""),
+				"Incorrect COLUMN2 Value");
+			assertTrue(results.getString("COLUMN3").equals("G"),
+				"Incorrect COLUMN3 Value");
 		}
 	}
 
@@ -1094,8 +1065,8 @@ public class TestCsvDriver
 		{
 			// Test selecting from a file with a multi-line value as the first record.
 			assertTrue(results.next());
-			assertEquals("Incorrect COLUMN1 Value", "Germany", results.getString("COLUMN1"));
-			assertEquals("Incorrect COLUMN2 Value", "Wallstrasse 76-79,\n10179 Berlin", results.getString("COLUMN2"));
+			assertEquals("Germany", results.getString("COLUMN1"), "Incorrect COLUMN1 Value");
+			assertEquals("Wallstrasse 76-79,\n10179 Berlin", results.getString("COLUMN2"), "Incorrect COLUMN2 Value");
 			assertTrue(results.next());
 		}
 	}
@@ -1117,11 +1088,11 @@ public class TestCsvDriver
 						+ File.separator + subPath + File.separator + "sample"))
 		{
 			results.next();
-			assertTrue("Incorrect ID Value", results.getString("ID").equals("Q123"));
-			assertTrue("Incorrect NAME Value", results.getString("NAME").equals(
-					"\"S,\""));
-			assertTrue("Incorrect EXTRA_FIELD Value", results.getString(
-					"EXTRA_FIELD").equals("F"));
+			assertTrue(results.getString("ID").equals("Q123"), "Incorrect ID Value");
+			assertTrue(results.getString("NAME").equals("\"S,\""),
+				"Incorrect NAME Value");
+			assertTrue(results.getString("EXTRA_FIELD").equals("F"),
+				"Incorrect EXTRA_FIELD Value");
 		}
 	}
 
@@ -1137,11 +1108,11 @@ public class TestCsvDriver
 				.executeQuery("SELECT ID, Name, Job FROM sample4 WHERE Job = 'Project Manager'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertEquals("01", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertEquals("02", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertEquals("04", results.getString("ID"), "The ID is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1159,17 +1130,17 @@ public class TestCsvDriver
 				.executeQuery("SELECT ID as i, Name as n, Job as j FROM sample4 WHERE j='Project Manager'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "01", results.getString("i"));
+			assertEquals("01", results.getString("i"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "02", results.getString("i"));
-			assertEquals("The name is wrong", "Mauricio Hernandez", results
-					.getString("N"));
-			assertEquals("The name is wrong", "Mauricio Hernandez", results
-					.getString(2));
-			assertEquals("The job is wrong", "Project Manager", results
-					.getString("J"));
+			assertEquals("02", results.getString("i"), "The ID is wrong");
+			assertEquals("Mauricio Hernandez", results.getString("N"),
+				"The name is wrong");
+			assertEquals("Mauricio Hernandez", results.getString(2),
+				"The name is wrong");
+			assertEquals("Project Manager", results.getString("J"),
+				"The job is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "04", results.getString("i"));
+			assertEquals("04", results.getString("i"), "The ID is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1189,18 +1160,18 @@ public class TestCsvDriver
 			assertEquals("ID", results.getMetaData().getColumnLabel(1).toString());
 
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "01", results.getString("id"));
+			assertEquals("01", results.getString("id"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "02", results.getString("id"));
-			assertEquals("The name is wrong", "Mauricio Hernandez", results
-					.getString("Name"));
-			assertEquals("The name is wrong", "Mauricio Hernandez", results
-					.getString(2));
-			assertEquals("The job is wrong", "Project Manager", results
-					.getString("Job"));
+			assertEquals("02", results.getString("id"), "The ID is wrong");
+			assertEquals("Mauricio Hernandez", results.getString("Name"),
+				"The name is wrong");
+			assertEquals("Mauricio Hernandez", results.getString(2),
+				"The name is wrong");
+			assertEquals("Project Manager", results.getString("Job"),
+				"The job is wrong");
 			assertTrue(results.next());
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "04", results.getString("id"));
+			assertEquals("04", results.getString("id"), "The ID is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1218,9 +1189,9 @@ public class TestCsvDriver
 		{
 			assertEquals("ID2", results.getMetaData().getColumnName(2));
 			assertTrue(results.next());
-			assertEquals("The ID2 is wrong", null, results.getString("id2"));
+			assertEquals(null, results.getString("id2"), "The ID2 is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID2 is wrong", null, results.getObject("id2"));
+			assertEquals(null, results.getObject("id2"), "The ID2 is wrong");
 		}
 	}
 
@@ -1235,14 +1206,14 @@ public class TestCsvDriver
 			ResultSet results = stmt
 				.executeQuery("SELECT Job j,ID i,Name n, 0 c FROM sample4"))
 		{
-			assertTrue("no results found - should be all", results.next());
-			assertTrue("no results found - should be all", results.next());
-			assertEquals("The literal c is wrong", "0", results.getString("c"));
-			assertEquals("The literal c is wrong", "0", results.getString(4));
-			assertEquals("The name is wrong", "Mauricio Hernandez", results
-					.getString("N"));
-			assertEquals("The job is wrong", "Project Manager", results
-					.getString("J"));
+			assertTrue(results.next(), "no results found - should be all");
+			assertTrue(results.next(), "no results found - should be all");
+			assertEquals("0", results.getString("c"), "The literal c is wrong");
+			assertEquals("0", results.getString(4), "The literal c is wrong");
+			assertEquals("Mauricio Hernandez", results.getString("N"),
+				"The name is wrong");
+			assertEquals("Project Manager", results.getString("J"),
+				"The job is wrong");
 		}
 	}
 
@@ -1260,12 +1231,12 @@ public class TestCsvDriver
 			ResultSet results = stmt
 				.executeQuery("SELECT 44, lower(job), ID*2, 'hello', 44 from sample4"))
 		{
-			assertTrue("no results found", results.next());
-			assertEquals("Number 44 is wrong", 44, results.getInt(1));
-			assertEquals("lower(job) is wrong", "project manager", results.getString(2));
-			assertEquals("ID*2 is wrong", 2, results.getInt(3));
-			assertEquals("String 'hello' is wrong", "hello", results.getString(4));
-			assertEquals("Number 44 is wrong", 44, results.getInt(5));
+			assertTrue(results.next(), "no results found");
+			assertEquals(44, results.getInt(1), "Number 44 is wrong");
+			assertEquals("project manager", results.getString(2), "lower(job) is wrong");
+			assertEquals(2, results.getInt(3), "ID*2 is wrong");
+			assertEquals("hello", results.getString(4), "String 'hello' is wrong");
+			assertEquals(44, results.getInt(5), "Number 44 is wrong");
 		}
 	}
 
@@ -1299,11 +1270,11 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM sample4 WHERE Job = 'Project Manager'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertEquals("01", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertEquals("02", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertEquals("04", results.getString("ID"), "The ID is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1320,8 +1291,8 @@ public class TestCsvDriver
 				.executeQuery("SELECT tbl.* FROM sample4 tbl"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "01", results.getString("ID"));
-			assertEquals("The Job is wrong", "Project Manager", results.getString(3));
+			assertEquals("01", results.getString("ID"), "The ID is wrong");
+			assertEquals("Project Manager", results.getString(3), "The Job is wrong");
 		}
 	}
 
@@ -1337,7 +1308,7 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM sample4 WHERE Job = 'Project Manager' AND Name = 'Mauricio Hernandez'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertEquals("02", results.getString("ID"), "The ID is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1354,9 +1325,9 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM sample4 WHERE id BETWEEN '02' AND '03'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertEquals(2, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertEquals(3, results.getInt("ID"), "The ID is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1377,11 +1348,11 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM Purchase WHERE PurchaseDate BETWEEN '1/11/2013' AND '1/15/2013'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The AccountNo is wrong", 58375, results.getInt("AccountNo"));
+			assertEquals(58375, results.getInt("AccountNo"), "The AccountNo is wrong");
 			assertTrue(results.next());
-			assertEquals("The AccountNo is wrong", 34625, results.getInt("AccountNo"));
+			assertEquals(34625, results.getInt("AccountNo"), "The AccountNo is wrong");
 			assertTrue(results.next());
-			assertEquals("The AccountNo is wrong", 34771, results.getInt("AccountNo"));
+			assertEquals(34771, results.getInt("AccountNo"), "The AccountNo is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1402,7 +1373,7 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime BETWEEN '08:30:00' AND '10:00:00'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The AccountNo is wrong", 51002, results.getInt("AccountNo"));
+			assertEquals(51002, results.getInt("AccountNo"), "The AccountNo is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1423,7 +1394,7 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM sample5 WHERE Start BETWEEN '2003-03-01 08:30:00' AND '2003-03-02 17:30:00'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertEquals(3, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1440,9 +1411,9 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM sample4 WHERE Name LIKE 'Ma%'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertEquals(2, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertEquals(3, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1459,9 +1430,9 @@ public class TestCsvDriver
 				.executeQuery("select id from sample where id like '_234'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "B234", results.getString("ID"));
+			assertEquals("B234", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "X234", results.getString("ID"));
+			assertEquals("X234", results.getString("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1478,11 +1449,11 @@ public class TestCsvDriver
 				.executeQuery("select ID from escape where ID like 'index\\__'"))
 			{
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", "index_1", results.getString("ID"));
+				assertEquals("index_1", results.getString("ID"), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", "index_2", results.getString("ID"));
+				assertEquals("index_2", results.getString("ID"), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", "index_3", results.getString("ID"));
+				assertEquals("index_3", results.getString("ID"), "The ID is wrong");
 				assertFalse(results.next());
 			}
 
@@ -1490,11 +1461,11 @@ public class TestCsvDriver
 				.executeQuery("select ID from escape where ID like 'index^__' escape '^'"))
 			{
 				assertTrue(results2.next());
-				assertEquals("The ID is wrong", "index_1", results2.getString("ID"));
+				assertEquals("index_1", results2.getString("ID"), "The ID is wrong");
 				assertTrue(results2.next());
-				assertEquals("The ID is wrong", "index_2", results2.getString("ID"));
+				assertEquals("index_2", results2.getString("ID"), "The ID is wrong");
 				assertTrue(results2.next());
-				assertEquals("The ID is wrong", "index_3", results2.getString("ID"));
+				assertEquals("index_3", results2.getString("ID"), "The ID is wrong");
 				assertFalse(results2.next());
 			}
 
@@ -1502,9 +1473,9 @@ public class TestCsvDriver
 				.executeQuery("select ID from escape where ID like 'index^%%' escape '^'"))
 			{
 				assertTrue(results3.next());
-				assertEquals("The ID is wrong", "index%%", results3.getString("ID"));
+				assertEquals("index%%", results3.getString("ID"), "The ID is wrong");
 				assertTrue(results3.next());
-				assertEquals("The ID is wrong", "index%3", results3.getString("ID"));
+				assertEquals("index%3", results3.getString("ID"), "The ID is wrong");
 				assertFalse(results3.next());
 			}
 		}
@@ -1522,11 +1493,11 @@ public class TestCsvDriver
 				.executeQuery("select N from nikesh where Message like '%SSL%'"))
 		{
 			assertTrue(results.next());
-			assertEquals("N is wrong", 1, results.getInt(1));
+			assertEquals(1, results.getInt(1), "N is wrong");
 			assertTrue(results.next());
-			assertEquals("N is wrong", 2, results.getInt(1));
+			assertEquals(2, results.getInt(1), "N is wrong");
 			assertTrue(results.next());
-			assertEquals("N is wrong", 4, results.getInt(1));
+			assertEquals(4, results.getInt(1), "N is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1552,8 +1523,8 @@ public class TestCsvDriver
 			{
 				assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": id", "" + e);
 			}
-			assertEquals("The name is wrong", "Felipe Grajales", results
-					.getString("name"));
+			assertEquals("Felipe Grajales", results.getString("name"),
+				"The name is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1599,7 +1570,7 @@ public class TestCsvDriver
 
 			double d = results.getDouble("c4");
 			long l = Math.round(d);
-			assertEquals("The c4 is wrong", l, 990000000000l);
+			assertEquals(l, 990000000000l, "The c4 is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1619,16 +1590,16 @@ public class TestCsvDriver
 			try (ResultSet results = stmt.executeQuery("SELECT ID from sample8 where d = '2010-02-02'"))
 			{
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 2, results.getInt(1));
+				assertEquals(2, results.getInt(1), "The ID is wrong");
 				assertFalse(results.next());
 			}
 
 			try (ResultSet results = stmt.executeQuery("SELECT ID from sample8 where '2010-03-24' < d"))
 			{
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 3, results.getInt(1));
+				assertEquals(3, results.getInt(1), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 6, results.getInt(1));
+				assertEquals(6, results.getInt(1), "The ID is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -1650,7 +1621,7 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime >= '12:00:00' and '12:59:59' >= PurchaseTime"))
 		{
 			assertTrue(results.next());
-			assertEquals("The AccountNo is wrong", 34771, results.getInt("AccountNo"));
+			assertEquals(34771, results.getInt("AccountNo"), "The AccountNo is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1671,9 +1642,9 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM sample5 WHERE Start >= '2002-01-01 00:00:00' and '2003-12-31 23:59:59' >= Start"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertEquals(2, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertEquals(3, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1691,11 +1662,11 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("select Name from sample5 where id in (3, 4, 5)"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Name is wrong", "Maria Cristina Lucero", results.getString("Name"));
+			assertEquals("Maria Cristina Lucero", results.getString("Name"), "The Name is wrong");
 			assertTrue(results.next());
-			assertEquals("The Name is wrong", "Felipe Grajales", results.getString("Name"));
+			assertEquals("Felipe Grajales", results.getString("Name"), "The Name is wrong");
 			assertTrue(results.next());
-			assertEquals("The Name is wrong", "Melquisedec Rojas Castillo", results.getString("Name"));
+			assertEquals("Melquisedec Rojas Castillo", results.getString("Name"), "The Name is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1726,11 +1697,11 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("select Id from sample where Id not in ('A123', 'B234', 'X234')"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Id is wrong", "Q123", results.getString("Id"));
+			assertEquals("Q123", results.getString("Id"), "The Id is wrong");
 			assertTrue(results.next());
-			assertEquals("The Id is wrong", "C456", results.getString("Id"));
+			assertEquals("C456", results.getString("Id"), "The Id is wrong");
 			assertTrue(results.next());
-			assertEquals("The Id is wrong", "D789", results.getString("Id"));
+			assertEquals("D789", results.getString("Id"), "The Id is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1772,9 +1743,9 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM Purchase WHERE PurchaseDate IN ('1/9/2013', '1/16/2013')"))
 		{
 			assertTrue(results.next());
-			assertEquals("The AccountNo is wrong", 19685, results.getInt("AccountNo"));
+			assertEquals(19685, results.getInt("AccountNo"), "The AccountNo is wrong");
 			assertTrue(results.next());
-			assertEquals("The AccountNo is wrong", 51002, results.getInt("AccountNo"));
+			assertEquals(51002, results.getInt("AccountNo"), "The AccountNo is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1795,7 +1766,7 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM Purchase WHERE PurchaseTime IN ('10:10:06', '11:10:06')"))
 		{
 			assertTrue(results.next());
-			assertEquals("The AccountNo is wrong", 22021, results.getInt("AccountNo"));
+			assertEquals(22021, results.getInt("AccountNo"), "The AccountNo is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1818,7 +1789,7 @@ public class TestCsvDriver
 					"WHERE Start IN ('2002-02-02 12:30:00', '2004-04-02 12:00:00', '2004-04-02')"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertEquals(2, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -1847,15 +1818,14 @@ public class TestCsvDriver
 			{
 				assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": id", "" + e);
 			}
-			assertEquals("The name is wrong", "3", results.getString("rc"));
+			assertEquals("3", results.getString("rc"), "The name is wrong");
 			// would like to test the full_name_nd, but can't insert the Arabic
 			// string in the code
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "3", results.getString("rc"));
+			assertEquals("3", results.getString("rc"), "The name is wrong");
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "3", results.getString("rc"));
-			assertEquals("The name is wrong", "Tall Dhayl", results
-					.getString("full_name_nd"));
+			assertEquals("3", results.getString("rc"), "The name is wrong");
+			assertEquals("Tall Dhayl", results.getString("full_name_nd"), "The name is wrong");
 		}
 	}
 
@@ -1873,15 +1843,15 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM witheol"))
 		{
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "1", results.getString("key"));
+			assertEquals("1", results.getString("key"), "The name is wrong");
 			// would like to test the full_name_nd, but can't insert the Arabic
 			// string in the code
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "2", results.getString("key"));
+			assertEquals("2", results.getString("key"), "The name is wrong");
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "3", results.getString("key"));
-			assertEquals("The name is wrong", "123\n456\n789", results
-					.getString("value"));
+			assertEquals("3", results.getString("key"), "The name is wrong");
+			assertEquals("123\n456\n789", results.getString("value"),
+				"The name is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -1901,11 +1871,11 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM badquoted"))
 		{
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "Rechtsform unbekannt", results.getString("F2"));
+			assertEquals("Rechtsform unbekannt", results.getString("F2"), "The name is wrong");
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "Rechtsform \nunbekannt", results.getString("F2"));
+			assertEquals("Rechtsform \nunbekannt", results.getString("F2"), "The name is wrong");
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "Rechtsform unbekannt", results.getString("F2"));
+			assertEquals("Rechtsform unbekannt", results.getString("F2"), "The name is wrong");
 			try
 			{
 				results.next();
@@ -1933,11 +1903,10 @@ public class TestCsvDriver
 				.executeQuery("SELECT datum, tijd, station, ai007.000 as value FROM test-001-20081112"))
 		{
 			assertTrue(results.next());
-			assertEquals("The name is wrong", "20-12-2007", results
-					.getString("datum"));
-			assertEquals("The name is wrong", "10:59:00", results.getString("tijd"));
-			assertEquals("The name is wrong", "007", results.getString("station"));
-			assertEquals("The name is wrong", "0.0", results.getString("value"));
+			assertEquals("20-12-2007", results.getString("datum"), "The name is wrong");
+			assertEquals("10:59:00", results.getString("tijd"), "The name is wrong");
+			assertEquals("007", results.getString("station"), "The name is wrong");
+			assertEquals("0.0", results.getString("value"), "The name is wrong");
 		}
 	}
 
@@ -1987,17 +1956,12 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
-					"test"));
+			assertTrue(metadata.getTableName(0).equals("test"), "Incorrect Table Name");
 
-			assertEquals("Incorrect Column Name 1", metadata.getColumnName(1),
-					"location");
-			assertEquals("Incorrect Column Name 2", metadata.getColumnName(2),
-					"Station");
-			assertEquals("Incorrect Column Name 3", metadata.getColumnName(3),
-					"Datum");
-			assertEquals("Incorrect Column Name 4", metadata.getColumnName(4),
-					"Tijd");
+			assertEquals(metadata.getColumnName(1),	"location", "Incorrect Column Name 1");
+			assertEquals(metadata.getColumnName(2),	"Station", "Incorrect Column Name 2");
+			assertEquals(metadata.getColumnName(3),	"Datum", "Incorrect Column Name 3");
+			assertEquals(metadata.getColumnName(4),	"Tijd", "Incorrect Column Name 4");
 
 			assertTrue(results.next());
 			for (int i = 1; i < 12; i++)
@@ -2048,19 +2012,13 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertTrue("Incorrect Table Name", metadata.getTableName(0).equals(
-					"test"));
+			assertTrue(metadata.getTableName(0).equals("test"), "Incorrect Table Name");
 
-			assertEquals("Incorrect Column Name 1", metadata.getColumnName(1),
-					"location");
-			assertEquals("Incorrect Column Name 1", metadata.getColumnName(2),
-					"file_date");
-			assertEquals("Incorrect Column Name 1", metadata.getColumnName(3),
-					"Datum");
-			assertEquals("Incorrect Column Name 2", metadata.getColumnName(4),
-					"Tijd");
-			assertEquals("Incorrect Column Name 3", metadata.getColumnName(5),
-					"Station");
+			assertEquals(metadata.getColumnName(1),	"location", "Incorrect Column Name 1");
+			assertEquals(metadata.getColumnName(2),	"file_date", "Incorrect Column Name 1");
+			assertEquals(metadata.getColumnName(3),	"Datum", "Incorrect Column Name 1");
+			assertEquals(metadata.getColumnName(4),	"Tijd", "Incorrect Column Name 2");
+			assertEquals(metadata.getColumnName(5),	"Station", "Incorrect Column Name 3");
 
 			assertTrue(results.next());
 			for (int i = 1; i < 12; i++)
@@ -2111,7 +2069,7 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM banks"))
 		{
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", "10000000", results.getString("BLZ"));
+			assertEquals("10000000", results.getString("BLZ"), "The BLZ is wrong");
 		}
 	}
 
@@ -2127,17 +2085,17 @@ public class TestCsvDriver
 				.executeQuery("SELECT id + ' ' + job as mix FROM sample4"))
 		{
 			assertTrue(results.next());
-			assertEquals("The mix is wrong", "01 Project Manager", results
-					.getString("mix"));
+			assertEquals("01 Project Manager", results.getString("mix"),
+				"The mix is wrong");
 			assertTrue(results.next());
-			assertEquals("The mix is wrong", "02 Project Manager", results
-					.getString("mix"));
+			assertEquals("02 Project Manager", results.getString("mix"),
+				"The mix is wrong");
 			assertTrue(results.next());
-			assertEquals("The mix is wrong", "03 Finance Manager", results
-					.getString("mix"));
+			assertEquals("03 Finance Manager", results.getString("mix"),
+				"The mix is wrong");
 			assertTrue(results.next());
-			assertEquals("The mix is wrong", "04 Project Manager", results
-					.getString("mix"));
+			assertEquals("04 Project Manager", results.getString("mix"),
+				"The mix is wrong");
 			assertTrue(!results.next());
 		}
 	}
@@ -2159,63 +2117,63 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			Object expect = java.sql.Time.valueOf("12:30:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("12:35:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("12:40:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("12:45:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("01:00:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("01:00:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("01:00:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("00:00:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("00:10:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Time.valueOf("01:23:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 
 			assertFalse(results.next());
 		}
@@ -2239,34 +2197,34 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			Object expect = java.sql.Date.valueOf("2001-04-02");
-			assertEquals("Date is a Date", expect.getClass(), results.getObject(
-					"start").getClass());
-			assertEquals("Date is a Date", expect, results.getObject("start"));
+			assertEquals(expect.getClass(), results.getObject("start").getClass(),
+				"Date is a Date");
+			assertEquals(expect, results.getObject("start"), "Date is a Date");
 			expect = java.sql.Time.valueOf("12:30:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 			expect = java.sql.Timestamp.valueOf("2001-04-02 12:30:00");
-			assertEquals("adding Date to Time", expect.getClass(), results
-					.getObject("ts").getClass());
+			assertEquals(expect.getClass(), results.getObject("ts").getClass(),
+				"adding Date to Time");
 			DateFormat toUTC = getUTCDateFormat();
-			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-					.format(results.getObject("ts")) + ".0");
+			assertEquals(((Timestamp) expect).toString(), toUTC.format(results.getObject("ts")) + ".0",
+				"adding Date to Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Date.valueOf("2004-04-02");
-			assertEquals("Date is a Date", expect.getClass(), results.getObject(
-					"start").getClass());
-			assertEquals("Date is a Date", expect, results.getObject("start"));
+			assertEquals(expect.getClass(), results.getObject("start").getClass(),
+				"Date is a Date");
+			assertEquals(expect, results.getObject("start"), "Date is a Date");
 			expect = java.sql.Time.valueOf("01:00:00");
-			assertEquals("Time is a Time", expect.getClass(), results.getObject(
-					"timeoffset").getClass());
-			assertEquals("Time is a Time", expect, results.getObject("timeoffset"));
+			assertEquals(expect.getClass(), results.getObject("timeoffset").getClass(),
+				"Time is a Time");
+			assertEquals(expect, results.getObject("timeoffset"), "Time is a Time");
 			expect = java.sql.Timestamp.valueOf("2004-04-02 01:00:00");
-			assertEquals("adding Date to Time", expect.getClass(), results
-					.getObject("ts").getClass());
-			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-					.format(results.getObject("ts")) + ".0");
+			assertEquals(expect.getClass(), results.getObject("ts").getClass(),
+				"adding Date to Time");
+			assertEquals(((Timestamp) expect).toString(), toUTC.format(results.getObject("ts")) + ".0",
+				"adding Date to Time");
 
 			assertFalse(results.next());
 		}
@@ -2292,28 +2250,28 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			Object expect = java.sql.Timestamp.valueOf("2001-04-02 12:31:01");
-			assertEquals("adding Date + Time + Int", expect.getClass(), results
-					.getObject("ts").getClass());
+			assertEquals(expect.getClass(), results.getObject("ts").getClass(),
+				"adding Date + Time + Int");
 			DateFormat toUTC = getUTCDateFormat();
-			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-					.format(results.getObject("ts")) + ".0");
+			assertEquals(((Timestamp) expect).toString(), toUTC.format(results.getObject("ts")) + ".0",
+				"adding Date to Time");
 			expect = java.sql.Timestamp.valueOf("2001-04-02 12:28:59");
-			assertEquals("adding Date + Time - Int", expect.getClass(), results
-					.getObject("ts2").getClass());
-			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-					.format(results.getObject("ts2")) + ".0");
+			assertEquals(expect.getClass(), results.getObject("ts2").getClass(),
+				"adding Date + Time - Int");
+			assertEquals(((Timestamp) expect).toString(), toUTC.format(results.getObject("ts2")) + ".0",
+				"adding Date to Time");
 
 			assertTrue(results.next());
 			expect = java.sql.Timestamp.valueOf("2004-04-02 01:01:01");
-			assertEquals("adding Date to Time", expect.getClass(), results
-					.getObject("ts").getClass());
-			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-					.format(results.getObject("ts")) + ".0");
+			assertEquals(expect.getClass(), results.getObject("ts").getClass(),
+				"adding Date to Time");
+			assertEquals(((Timestamp) expect).toString(), toUTC.format(results.getObject("ts")) + ".0",
+				"adding Date to Time");
 			expect = java.sql.Timestamp.valueOf("2004-04-02 00:58:59");
-			assertEquals("adding Date to Time", expect.getClass(), results
-					.getObject("ts2").getClass());
-			assertEquals("adding Date to Time", ((Timestamp) expect).toString(), toUTC
-					.format(results.getObject("ts2")) + ".0");
+			assertEquals(expect.getClass(), results.getObject("ts2").getClass(),
+				"adding Date to Time");
+			assertEquals(((Timestamp) expect).toString(), toUTC.format(results.getObject("ts2")) + ".0",
+				"adding Date to Time");
 
 			assertFalse(results.next());
 		}
@@ -2334,9 +2292,9 @@ public class TestCsvDriver
 				.executeQuery("SELECT 1 + ID * 2 as N1, ID * -3 + 1 as N2, ID+1+2*3+4 as N3 FROM sample5"))
 		{
 			assertTrue(results.next());
-			assertEquals("N1 is wrong", 83, results.getInt("N1"));
-			assertEquals("N2 is wrong", -122, results.getInt("N2"));
-			assertEquals("N3 is wrong", 52, results.getInt("N3"));
+			assertEquals(83, results.getInt("N1"), "N1 is wrong");
+			assertEquals(-122, results.getInt("N2"), "N2 is wrong");
+			assertEquals(52, results.getInt("N3"), "N3 is wrong");
 		}
 	}
 
@@ -2355,9 +2313,9 @@ public class TestCsvDriver
 				.executeQuery("SELECT ( ID + 1 ) as N1, ((ID + 2) * 3) as N2, (3) as N3 FROM sample5 where ( Job = 'Piloto' )"))
 		{
 			assertTrue(results.next());
-			assertEquals("N1 is wrong", 42, results.getInt("N1"));
-			assertEquals("N2 is wrong", 129, results.getInt("N2"));
-			assertEquals("N3 is wrong", 3, results.getInt("N3"));
+			assertEquals(42, results.getInt("N1"), "N1 is wrong");
+			assertEquals(129, results.getInt("N2"), "N2 is wrong");
+			assertEquals(3, results.getInt("N3"), "N3 is wrong");
 		}
 	}
 
@@ -2399,17 +2357,17 @@ public class TestCsvDriver
 			try (ResultSet results = stmt.executeQuery("select lower(job) as ljob, lower('AA') as CAT from sample5"))
 			{
 				assertTrue(results.next());
-				assertEquals("The JOB is wrong", "piloto", results.getString(1));
-				assertEquals("The CAT is wrong", "aa", results.getString(2));
+				assertEquals("piloto", results.getString(1), "The JOB is wrong");
+				assertEquals("aa", results.getString(2), "The CAT is wrong");
 				assertTrue(results.next());
-				assertEquals("The JOB is wrong", "project manager", results.getString(1));
-				assertEquals("The CAT is wrong", "aa", results.getString(2));
+				assertEquals("project manager", results.getString(1), "The JOB is wrong");
+				assertEquals("aa", results.getString(2), "The CAT is wrong");
 			}
 
 			try (ResultSet results = stmt.executeQuery("select ID from sample5 where lower(job) = lower('FINANCE MANAGER')"))
 			{
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 2, results.getInt(1));
+				assertEquals(2, results.getInt(1), "The ID is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -2432,15 +2390,15 @@ public class TestCsvDriver
 			try (ResultSet results = stmt.executeQuery("select UPPER(BANK_NAME) as UC, UPPER('Credit' + 'a') as N2, upper(7) as N3 from banks"))
 			{
 				assertTrue(results.next());
-				assertEquals("The BANK_NAME is wrong", "BUNDESBANK (BERLIN)", results.getString(1));
-				assertEquals("N2 is wrong", "CREDITA", results.getString(2));
-				assertEquals("N3 is wrong", "7", results.getString(3));
+				assertEquals("BUNDESBANK (BERLIN)", results.getString(1), "The BANK_NAME is wrong");
+				assertEquals("CREDITA", results.getString(2), "N2 is wrong");
+				assertEquals("7", results.getString(3), "N3 is wrong");
 			}
 
 			try (ResultSet results = stmt.executeQuery("select BLZ from banks where UPPER(BANK_NAME) = 'POSTBANK (BERLIN)'"))
 			{
 				assertTrue(results.next());
-				assertEquals("The BLZ is wrong", 10010010, results.getInt(1));
+				assertEquals(10010010, results.getInt(1), "The BLZ is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -2460,9 +2418,9 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("select length(Name) as X, length(Job) as Y, length('') as Z from sample5 where id = 8"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Length is wrong", 27, results.getInt(1));
-			assertEquals("The Length is wrong", 15, results.getInt(2));
-			assertEquals("The Length is wrong", 0, results.getInt(3));
+			assertEquals(27, results.getInt(1), "The Length is wrong");
+			assertEquals(15, results.getInt(2), "The Length is wrong");
+			assertEquals(0, results.getInt(3), "The Length is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -2482,27 +2440,27 @@ public class TestCsvDriver
 			try (ResultSet results = stmt.executeQuery("select TRIM(comment), TRIM('\tfoo bar\n') from with_comments"))
 			{
 				assertTrue(results.next());
-				assertEquals("The comment is wrong", "some field", results.getString(1));
-				assertEquals("The trimmed value is wrong", "foo bar", results.getString(2));
+				assertEquals("some field", results.getString(1), "The comment is wrong");
+				assertEquals("foo bar", results.getString(2), "The trimmed value is wrong");
 				assertTrue(results.next());
-				assertEquals("The comment is wrong", "other parameter", results.getString(1));
+				assertEquals("other parameter", results.getString(1), "The comment is wrong");
 				assertTrue(results.next());
-				assertEquals("The comment is wrong", "still a field", results.getString(1));
+				assertEquals("still a field", results.getString(1), "The comment is wrong");
 				assertFalse(results.next());
 			}
 
 			try (ResultSet results = stmt.executeQuery("select TRIM(name, '#'), TRIM(name, '#h'), TRIM('00000', '0') from with_comments"))
 			{
 				assertTrue(results.next());
-				assertEquals("The trimmed value is wrong", "alpha", results.getString(1));
-				assertEquals("The trimmed value is wrong", "alpha", results.getString(2));
-				assertEquals("The trimmed value is wrong", "", results.getString(3));
+				assertEquals("alpha", results.getString(1), "The trimmed value is wrong");
+				assertEquals("alpha", results.getString(2), "The trimmed value is wrong");
+				assertEquals("", results.getString(3), "The trimmed value is wrong");
 				assertTrue(results.next());
-				assertEquals("The trimmed value is wrong", "beta", results.getString(1));
-				assertEquals("The trimmed value is wrong", "beta", results.getString(2));
+				assertEquals("beta", results.getString(1), "The trimmed value is wrong");
+				assertEquals("beta", results.getString(2), "The trimmed value is wrong");
 				assertTrue(results.next());
-				assertEquals("The trimmed value is wrong", "hash", results.getString(1));
-				assertEquals("The trimmed value is wrong", "as", results.getString(2));
+				assertEquals("hash", results.getString(1), "The trimmed value is wrong");
+				assertEquals("as", results.getString(2), "The trimmed value is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -2523,14 +2481,14 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT LTRIM(TO_ACCT,'0'), LTRIM('0000','0'), LTRIM('','0'), LTRIM('  X  ') FROM transactions"))
 		{
 			assertTrue(results.next());
-			assertEquals("The trimmed value is wrong", "27853256", results.getString(1));
-			assertEquals("The trimmed value is wrong", "", results.getString(2));
-			assertEquals("The trimmed value is wrong", "", results.getString(3));
-			assertEquals("The trimmed value is wrong", "X  ", results.getString(4));
+			assertEquals("27853256", results.getString(1), "The trimmed value is wrong");
+			assertEquals("", results.getString(2), "The trimmed value is wrong");
+			assertEquals("", results.getString(3), "The trimmed value is wrong");
+			assertEquals("X  ", results.getString(4), "The trimmed value is wrong");
 			assertTrue(results.next());
-			assertEquals("The trimmed value is wrong", "27234813", results.getString(1));
+			assertEquals("27234813", results.getString(1), "The trimmed value is wrong");
 			assertTrue(results.next());
-			assertEquals("The trimmed value is wrong", "81824588", results.getString(1));
+			assertEquals("81824588", results.getString(1), "The trimmed value is wrong");
 		}
 	}
 
@@ -2549,12 +2507,12 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT RTRIM(BLZ,'0'), RTRIM(' ZZ ') FROM banks"))
 		{
 			assertTrue(results.next());
-			assertEquals("The trimmed value is wrong", "1", results.getString(1));
-			assertEquals("The trimmed value is wrong", " ZZ", results.getString(2));
+			assertEquals("1", results.getString(1), "The trimmed value is wrong");
+			assertEquals(" ZZ", results.getString(2), "The trimmed value is wrong");
 			assertTrue(results.next());
-			assertEquals("The trimmed value is wrong", "1001001", results.getString(1));
+			assertEquals("1001001", results.getString(1), "The trimmed value is wrong");
 			assertTrue(results.next());
-			assertEquals("The trimmed value is wrong", "10010111", results.getString(1));
+			assertEquals("10010111", results.getString(1), "The trimmed value is wrong");
 		}
 	}
 
@@ -2569,9 +2527,9 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT substring(name, 2), substring(name, 3, 4), substring(name, 200) FROM sample4"))
 		{
 			assertTrue(results.next());
-			assertEquals("The substring is wrong", "uan Pablo Morales", results.getString(1));
-			assertEquals("The substring is wrong", "an P", results.getString(2));
-			assertEquals("The substring is wrong", "", results.getString(3));
+			assertEquals("uan Pablo Morales", results.getString(1), "The substring is wrong");
+			assertEquals("an P", results.getString(2), "The substring is wrong");
+			assertEquals("", results.getString(3), "The substring is wrong");
 		}
 	}
 
@@ -2587,10 +2545,10 @@ public class TestCsvDriver
 					"replace(id, '0', ''), replace('abcd0123', id, job) FROM sample4"))
 		{
 			assertTrue(results.next());
-			assertEquals("The replace is wrong", "Juan_Pablo_Morales", results.getString(1));
-			assertEquals("The replace is wrong", "Juan Pablo Morales", results.getString(2));
-			assertEquals("The replace is wrong", "1", results.getString(3));
-			assertEquals("The replace is wrong", "abcdProject Manager23", results.getString(4));
+			assertEquals("Juan_Pablo_Morales", results.getString(1), "The replace is wrong");
+			assertEquals("Juan Pablo Morales", results.getString(2), "The replace is wrong");
+			assertEquals("1", results.getString(3), "The replace is wrong");
+			assertEquals("abcdProject Manager23", results.getString(4), "The replace is wrong");
 		}
 	}
 
@@ -2615,12 +2573,12 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("select ABS(C2) as R1, ABS(C5) as R2, ABS('-123456') as R3 from numeric"))
 		{
 			assertTrue(results.next());
-			assertEquals("R1 is wrong", 1010, results.getInt(1));
-			assertTrue("R2 is wrong", fuzzyEquals(results.getDouble(2), 3.14));
-			assertTrue("R3 is wrong", fuzzyEquals(results.getDouble(3), 123456));
+			assertEquals(1010, results.getInt(1), "R1 is wrong");
+			assertTrue(fuzzyEquals(results.getDouble(2), 3.14), "R2 is wrong");
+			assertTrue(fuzzyEquals(results.getDouble(3), 123456), "R3 is wrong");
 			assertTrue(results.next());
-			assertEquals("R1 is wrong", 15, results.getInt(1));
-			assertTrue("R2 is wrong", fuzzyEquals(results.getDouble(2), 0.0));
+			assertEquals(15, results.getInt(1), "R1 is wrong");
+			assertTrue(fuzzyEquals(results.getDouble(2), 0.0), "R2 is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -2654,20 +2612,20 @@ public class TestCsvDriver
 					+ " where ROUND(C5) = 3"))
 		{
 			assertTrue(results.next());
-			assertEquals("R1 is wrong", 12, results.getInt(1));
-			assertEquals("R2 is wrong", 12, results.getInt(2));
-			assertEquals("R3 is wrong", -1010, results.getInt(3));
-			assertEquals("R4 is wrong", 42871, results.getInt(4));
-			assertEquals("R5 is wrong", 11.8, results.getDouble(5), 0.01);
-			assertEquals("R6 is wrong", 11.7, results.getDouble(6), 0.01);
-			assertEquals("R7 is wrong", 11.8, results.getDouble(7), 0.01);
-			assertEquals("R8 is wrong", 11.8, results.getDouble(8), 0.01);
-			assertEquals("R9 is wrong", -1010.0, results.getDouble(9), 0.01);
-			assertEquals("R10 is wrong", 42871.4, results.getDouble(10), 0.01);
-			assertEquals("R11 is wrong", 42871.43, results.getDouble(11), 0.001);
-			assertEquals("R12 is wrong", 42871.429, results.getDouble(12), 0.0001);
-			assertEquals("R13 is wrong", 12, results.getDouble(13), 0.01);
-			assertEquals("R14 is wrong", 10, results.getDouble(14), 0.01);
+			assertEquals(12, results.getInt(1), "R1 is wrong");
+			assertEquals(12, results.getInt(2), "R2 is wrong");
+			assertEquals(-1010, results.getInt(3), "R3 is wrong");
+			assertEquals(42871, results.getInt(4), "R4 is wrong");
+			assertEquals(11.8, results.getDouble(5), 0.01, "R5 is wrong");
+			assertEquals(11.7, results.getDouble(6), 0.01, "R6 is wrong");
+			assertEquals(11.8, results.getDouble(7), 0.01, "R7 is wrong");
+			assertEquals(11.8, results.getDouble(8), 0.01, "R8 is wrong");
+			assertEquals(-1010.0, results.getDouble(9), 0.01, "R9 is wrong");
+			assertEquals(42871.4, results.getDouble(10), 0.01, "R10 is wrong");
+			assertEquals(42871.43, results.getDouble(11), 0.001, "R11 is wrong");
+			assertEquals(42871.429, results.getDouble(12), 0.0001, "R12 is wrong");
+			assertEquals(12, results.getDouble(13), 0.01, "R13 is wrong");
+			assertEquals(10, results.getDouble(14), 0.01, "R14 is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -2687,12 +2645,12 @@ public class TestCsvDriver
 				"dayofmonth('2013-10-13') as today from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 2, results.getInt(1));
-			assertEquals("today is wrong", 13, results.getInt(2));
+			assertEquals(2, results.getInt(1), "dom is wrong");
+			assertEquals(13, results.getInt(2), "today is wrong");
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 2, results.getInt(1));
+			assertEquals(2, results.getInt(1), "dom is wrong");
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 28, results.getInt(1));
+			assertEquals(28, results.getInt(1), "dom is wrong");
 		}
 	}
 
@@ -2710,12 +2668,12 @@ public class TestCsvDriver
 				"month('2013-10-13') as today from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("month is wrong", 1, results.getInt(1));
-			assertEquals("today is wrong", 10, results.getInt(2));
+			assertEquals(1, results.getInt(1), "month is wrong");
+			assertEquals(10, results.getInt(2), "today is wrong");
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 2, results.getInt(1));
+			assertEquals(2, results.getInt(1), "dom is wrong");
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 3, results.getInt(1));
+			assertEquals(3, results.getInt(1), "dom is wrong");
 		}
 	}
 
@@ -2734,16 +2692,16 @@ public class TestCsvDriver
 				"year('2013-10-13') as today from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("month is wrong", 2010, results.getInt(1));
-			assertEquals("today is wrong", 2013, results.getInt(2));
+			assertEquals(2010, results.getInt(1), "month is wrong");
+			assertEquals(2013, results.getInt(2), "today is wrong");
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 2010, results.getInt(1));
+			assertEquals(2010, results.getInt(1), "dom is wrong");
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 2010, results.getInt(1));
+			assertEquals(2010, results.getInt(1), "dom is wrong");
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 2010, results.getInt(1));
+			assertEquals(2010, results.getInt(1), "dom is wrong");
 			assertTrue(results.next());
-			assertEquals("dom is wrong", 2009, results.getInt(1));
+			assertEquals(2009, results.getInt(1), "dom is wrong");
 		}
 	}
 
@@ -2761,14 +2719,14 @@ public class TestCsvDriver
 				"hourofday('23:41:17') as h from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("hour is wrong", 1, results.getInt(1));
-			assertEquals("h is wrong", 23, results.getInt(2));
+			assertEquals(1, results.getInt(1), "hour is wrong");
+			assertEquals(23, results.getInt(2), "h is wrong");
 			assertTrue(results.next());
-			assertEquals("hour is wrong", 1, results.getInt(1));
+			assertEquals(1, results.getInt(1), "hour is wrong");
 			assertTrue(results.next());
-			assertEquals("hour is wrong", 1, results.getInt(1));
+			assertEquals(1, results.getInt(1), "hour is wrong");
 			assertTrue(results.next());
-			assertEquals("hour is wrong", 5, results.getInt(1));
+			assertEquals(5, results.getInt(1), "hour is wrong");
 		}
 	}
 
@@ -2786,8 +2744,8 @@ public class TestCsvDriver
 				"minute('23:41:17') as m from sample8"))
 		{
 			assertTrue(results.next());
-			assertEquals("minute is wrong", 30, results.getInt(1));
-			assertEquals("m is wrong", 41, results.getInt(2));
+			assertEquals(30, results.getInt(1), "minute is wrong");
+			assertEquals(41, results.getInt(2), "m is wrong");
 		}
 	}
 
@@ -2806,12 +2764,12 @@ public class TestCsvDriver
 				"hourofday(Start), minute(Start), second(Start) from sample5"))
 			{
 				assertTrue(results.next());
-				assertEquals("dayofmonth is wrong", 2, results.getInt(1));
-				assertEquals("month is wrong", 4, results.getInt(2));
-				assertEquals("year is wrong", 2001, results.getInt(3));
-				assertEquals("hourofday is wrong", 12, results.getInt(4));
-				assertEquals("minute is wrong", 30, results.getInt(5));
-				assertEquals("second is wrong", 0, results.getInt(6));
+				assertEquals(2, results.getInt(1), "dayofmonth is wrong");
+				assertEquals(4, results.getInt(2), "month is wrong");
+				assertEquals(2001, results.getInt(3), "year is wrong");
+				assertEquals(12, results.getInt(4), "hourofday is wrong");
+				assertEquals(30, results.getInt(5), "minute is wrong");
+				assertEquals(0, results.getInt(6), "second is wrong");
 			}
 
 			String timestamp = "2013-10-13 14:33:55";
@@ -2821,12 +2779,12 @@ public class TestCsvDriver
 				"second('" + timestamp + "') from sample5"))
 			{
 				assertTrue(results.next());
-				assertEquals("dayofmonth is wrong", 13, results.getInt(1));
-				assertEquals("month is wrong", 10, results.getInt(2));
-				assertEquals("year is wrong", 2013, results.getInt(3));
-				assertEquals("hourofday is wrong", 14, results.getInt(4));
-				assertEquals("minute is wrong", 33, results.getInt(5));
-				assertEquals("second is wrong", 55, results.getInt(6));
+				assertEquals(13, results.getInt(1), "dayofmonth is wrong");
+				assertEquals(10, results.getInt(2), "month is wrong");
+				assertEquals(2013, results.getInt(3), "year is wrong");
+				assertEquals(14, results.getInt(4), "hourofday is wrong");
+				assertEquals(33, results.getInt(5), "minute is wrong");
+				assertEquals(55, results.getInt(6), "second is wrong");
 			}
 		}
 	}
@@ -2846,12 +2804,12 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			java.sql.Date expect = java.sql.Date.valueOf("2024-01-01");
-			assertEquals("start_date plus duration is wrong", expect, results.getDate(1));
-			assertEquals("duration plus start_date is wrong", expect, results.getDate(2));
+			assertEquals(expect, results.getDate(1), "start_date plus duration is wrong");
+			assertEquals(expect, results.getDate(2), "duration plus start_date is wrong");
 			assertTrue(results.next());
 			expect = java.sql.Date.valueOf("2023-04-01");
-			assertEquals("start_date plus duration is wrong", expect, results.getDate(1));
-			assertEquals("duration plus start_date is wrong", expect, results.getDate(2));
+			assertEquals(expect, results.getDate(1), "start_date plus duration is wrong");
+			assertEquals(expect, results.getDate(2), "duration plus start_date is wrong");
 		}
 	}
 
@@ -2869,14 +2827,14 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("select nullif(key, ' - ') as k2 from foodstuffs"))
 		{
 			assertTrue(results.next());
-			assertEquals("K2 is wrong", "orange", results.getString(1));
+			assertEquals("orange", results.getString(1), "K2 is wrong");
 			assertTrue(results.next());
-			assertEquals("K2 is wrong", "apple", results.getString(1));
-			assertTrue(results.next());
-			assertTrue(results.next());
+			assertEquals("apple", results.getString(1), "K2 is wrong");
 			assertTrue(results.next());
 			assertTrue(results.next());
-			assertEquals("K2 is wrong", null, results.getString(1));
+			assertTrue(results.next());
+			assertTrue(results.next());
+			assertEquals(null, results.getString(1), "K2 is wrong");
 			assertTrue(results.wasNull());
 			assertFalse(results.next());
 		}
@@ -2895,11 +2853,11 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT COALESCE(ID, 999) FROM bad_values"))
 		{
 			assertTrue(results.next());
-			assertEquals("ID is wrong", 999, results.getInt(1));
+			assertEquals(999, results.getInt(1), "ID is wrong");
 			assertTrue(results.next());
-			assertEquals("ID is wrong", 999, results.getInt(1));
+			assertEquals(999, results.getInt(1), "ID is wrong");
 			assertTrue(results.next());
-			assertEquals("ID is wrong", 3, results.getInt(1));
+			assertEquals(3, results.getInt(1), "ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -2990,10 +2948,10 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
-			assertEquals("name of column 1 is incorrect", "foo", metadata.getColumnName(1));
-			assertEquals("name of column 2 is incorrect", "bar", metadata.getColumnName(2));
-			assertEquals("Incorrect value 1", "1", results.getString(1));
-			assertEquals("Incorrect value 2", "3", results.getString(2));
+			assertEquals("foo", metadata.getColumnName(1), "name of column 1 is incorrect");
+			assertEquals("bar", metadata.getColumnName(2), "name of column 2 is incorrect");
+			assertEquals("1", results.getString(1), "Incorrect value 1");
+			assertEquals("3", results.getString(2), "Incorrect value 2");
 		}
 	}
 
@@ -3210,32 +3168,32 @@ public class TestCsvDriver
 			 * Check that SQL NULL is returned for empty or invalid numeric, date and time fields,
 			 * and that zero is returned from methods that return a number.
 			 */
-			assertEquals("ID is wrong", 0, results.getInt("ID"));
+			assertEquals(0, results.getInt("ID"), "ID is wrong");
 			assertTrue(results.wasNull());
-			assertEquals("ID + 1 is wrong", 0, results.getInt(2));
+			assertEquals(0, results.getInt(2), "ID + 1 is wrong");
 			assertTrue(results.wasNull());
-			assertEquals("NAME is wrong", "Simon", results.getString(3));
+			assertEquals("Simon", results.getString(3), "NAME is wrong");
 			assertFalse(results.wasNull());
-			assertNull("START_DATE is wrong", results.getDate(4));
+			assertNull(results.getDate(4), "START_DATE is wrong");
 			assertTrue(results.wasNull());
-			assertNull("START_DATE + 1 is wrong", results.getDate(5));
+			assertNull(results.getDate(5), "START_DATE + 1 is wrong");
 			assertTrue(results.wasNull());
-			assertNull("START_TIME is wrong", results.getTime(6));
+			assertNull(results.getTime(6), "START_TIME is wrong");
 			assertTrue(results.wasNull());
 
 			assertTrue(results.next());
 
-			assertNull("ID is wrong", results.getObject("ID"));
+			assertNull(results.getObject("ID"), "ID is wrong");
 			assertTrue(results.wasNull());
-			assertNull("ID + 1 is wrong", results.getObject(2));
+			assertNull(results.getObject(2), "ID + 1 is wrong");
 			assertTrue(results.wasNull());
-			assertEquals("NAME is wrong", "Wally", results.getString(3));
+			assertEquals("Wally", results.getString(3), "NAME is wrong");
 			assertFalse(results.wasNull());
-			assertNull("START_DATE is wrong", results.getObject(4));
+			assertNull(results.getObject(4), "START_DATE is wrong");
 			assertTrue(results.wasNull());
-			assertNull("START_DATE + 1 is wrong", results.getObject(5));
+			assertNull(results.getObject(5), "START_DATE + 1 is wrong");
 			assertTrue(results.wasNull());
-			assertNull("START_TIME is wrong", results.getObject(6));
+			assertNull(results.getObject(6), "START_TIME is wrong");
 			assertTrue(results.wasNull());
 
 			assertTrue(results.next());
@@ -3384,8 +3342,8 @@ public class TestCsvDriver
 			Statement stmt = conn.createStatement();
 			ResultSet results = stmt.executeQuery("SELECT * FROM not_there"))
 		{
-			assertFalse("non existing indexed tables are seen as empty", results
-				.next());
+			assertFalse(results.next(),
+				"non existing indexed tables are seen as empty");
 		}
 	}
 
@@ -3410,8 +3368,8 @@ public class TestCsvDriver
 			}
 			catch (SQLException e)
 			{
-				assertTrue("wrong exception and/or exception text!",
-					e.toString().contains(CsvResources.getString("duplicateColumns")));
+				assertTrue(e.toString().contains(CsvResources.getString("duplicateColumns")),
+					"wrong exception and/or exception text!");
 			}
 		}
 	}
@@ -3435,10 +3393,10 @@ public class TestCsvDriver
 			assertEquals("Name", metadata.getColumnName(3));
 			assertEquals("COLUMN4", metadata.getColumnName(4));
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "1", results.getString("ID"));
-			assertEquals("2:COLUMN2 is wrong", "2", results.getString("COLUMN2"));
-			assertEquals("3:Name is wrong", "george", results.getString("Name"));
-			assertEquals("4:COLUMN4 is wrong", "joe", results.getString("COLUMN4"));
+			assertEquals("1", results.getString("ID"), "1:ID is wrong");
+			assertEquals("2", results.getString("COLUMN2"), "2:COLUMN2 is wrong");
+			assertEquals("george", results.getString("Name"), "3:Name is wrong");
+			assertEquals("joe", results.getString("COLUMN4"), "4:COLUMN4 is wrong");
 		}
 	}
 
@@ -3460,16 +3418,16 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM duplicate_headers"))
 		{
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "1", results.getString(1));
-			assertEquals("2:ID is wrong", "2", results.getString(2));
-			assertEquals("3:ID is wrong", "george", results.getString(3));
-			assertEquals("4:ID is wrong", "joe", results.getString(4));
+			assertEquals("1", results.getString(1), "1:ID is wrong");
+			assertEquals("2", results.getString(2), "2:ID is wrong");
+			assertEquals("george", results.getString(3), "3:ID is wrong");
+			assertEquals("joe", results.getString(4), "4:ID is wrong");
 
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "2", results.getString(1));
-			assertEquals("2:ID is wrong", "2", results.getString(2));
-			assertEquals("3:ID is wrong", "aworth", results.getString(3));
-			assertEquals("4:ID is wrong", "smith", results.getString(4));
+			assertEquals("2", results.getString(1), "1:ID is wrong");
+			assertEquals("2", results.getString(2), "2:ID is wrong");
+			assertEquals("aworth", results.getString(3), "3:ID is wrong");
+			assertEquals("smith", results.getString(4), "4:ID is wrong");
 
 			assertFalse(results.next());
 		}
@@ -3614,8 +3572,8 @@ public class TestCsvDriver
 		}
 		catch (SQLException e)
 		{
-			assertEquals("Wrong exception text",
-				"java.sql.SQLException: " + CsvResources.getString("invalid") + " quotechar: ()", "" + e);
+			assertEquals("java.sql.SQLException: " + CsvResources.getString("invalid") + " quotechar: ()", "" + e,
+				"Wrong exception text");
 		}
 	}
 
@@ -3634,17 +3592,17 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM uses_quotes"))
 		{
 			assertTrue(results.next());
-			assertEquals("COLUMN1 is wrong", "1", results.getString(1));
-			assertEquals("COLUMN2 is wrong", "uno", results.getString(2));
-			assertEquals("COLUMN3 is wrong", "one", results.getString(3));
+			assertEquals("1", results.getString(1), "COLUMN1 is wrong");
+			assertEquals("uno", results.getString(2), "COLUMN2 is wrong");
+			assertEquals("one", results.getString(3), "COLUMN3 is wrong");
 			assertTrue(results.next());
-			assertEquals("COLUMN1 is wrong", "2", results.getString(1));
-			assertEquals("COLUMN2 is wrong", "a 'quote' (source unknown)", results.getString(2));
-			assertEquals("COLUMN3 is wrong", "two", results.getString(3));
+			assertEquals("2", results.getString(1), "COLUMN1 is wrong");
+			assertEquals("a 'quote' (source unknown)", results.getString(2), "COLUMN2 is wrong");
+			assertEquals("two", results.getString(3), "COLUMN3 is wrong");
 			assertTrue(results.next());
-			assertEquals("COLUMN1 is wrong", "3", results.getString(1));
-			assertEquals("COLUMN2 is wrong", "another \"quote\" (also unkown)", results.getString(2));
-			assertEquals("COLUMN3 is wrong", "three", results.getString(3));
+			assertEquals("3", results.getString(1), "COLUMN1 is wrong");
+			assertEquals("another \"quote\" (also unkown)", results.getString(2), "COLUMN2 is wrong");
+			assertEquals("three", results.getString(3), "COLUMN3 is wrong");
 		}
 	}
 
@@ -3665,25 +3623,25 @@ public class TestCsvDriver
 			assertEquals("Name", metadata.getColumnName(2));
 			assertEquals("Birthday", metadata.getColumnName(3));
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "0", results.getString(1));
-			assertEquals("2:Name is wrong", "(Florian)", results.getString(2));
-			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertEquals("0", results.getString(1), "1:ID is wrong");
+			assertEquals("(Florian)", results.getString(2), "2:Name is wrong");
+			assertEquals("01.01.1990", results.getString(3), "3:Birthday is wrong");
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "1", results.getString(1));
-			assertEquals("2:Name is wrong", "(Tobias)", results.getString(2));
-			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertEquals("1", results.getString(1), "1:ID is wrong");
+			assertEquals("(Tobias)", results.getString(2), "2:Name is wrong");
+			assertEquals("01.01.1990", results.getString(3), "3:Birthday is wrong");
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "2", results.getString(1));
-			assertEquals("2:Name is wrong", "(#Mark)", results.getString(2));
-			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertEquals("2", results.getString(1), "1:ID is wrong");
+			assertEquals("(#Mark)", results.getString(2), "2:Name is wrong");
+			assertEquals("01.01.1990", results.getString(3), "3:Birthday is wrong");
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "3", results.getString(1));
-			assertEquals("2:Name is wrong", "(@Jason)", results.getString(2));
-			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertEquals("3", results.getString(1), "1:ID is wrong");
+			assertEquals("(@Jason)", results.getString(2), "2:Name is wrong");
+			assertEquals("01.01.1990", results.getString(3), "3:Birthday is wrong");
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "4", results.getString(1));
-			assertEquals("2:Name is wrong", "Robert", results.getString(2));
-			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertEquals("4", results.getString(1), "1:ID is wrong");
+			assertEquals("Robert", results.getString(2), "2:Name is wrong");
+			assertEquals("01.01.1990", results.getString(3), "3:Birthday is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -3705,9 +3663,9 @@ public class TestCsvDriver
 			assertEquals("Name", metadata.getColumnName(2));
 			assertEquals("Birthday", metadata.getColumnName(3));
 			assertTrue(results.next());
-			assertEquals("1:ID is wrong", "0", results.getString(1));
-			assertEquals("2:Name is wrong", "(Florian)", results.getString(2));
-			assertEquals("3:Birthday is wrong", "01.01.1990", results.getString(3));
+			assertEquals("0", results.getString(1), "1:ID is wrong");
+			assertEquals("(Florian)", results.getString(2), "2:Name is wrong");
+			assertEquals("01.01.1990", results.getString(3), "3:Birthday is wrong");
 		}
 	}
 
@@ -3784,8 +3742,8 @@ public class TestCsvDriver
 			}
 			catch (SQLException e)
 			{
-				assertEquals("wrong exception and/or exception text!",
-					"java.sql.SQLException: " + CsvResources.getString("closedConnection"), "" + e);
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("closedConnection"), "" + e,
+					"wrong exception and/or exception text!");
 			}
 		}
 	}
@@ -3815,8 +3773,8 @@ public class TestCsvDriver
 			}
 			catch (SQLException e)
 			{
-				assertEquals("wrong exception and/or exception text!",
-					"java.sql.SQLException: " + CsvResources.getString("statementClosed"), "" + e);
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("statementClosed"), "" + e,
+					"wrong exception and/or exception text!");
 			}
 		}
 	}
@@ -3858,9 +3816,8 @@ public class TestCsvDriver
 			}
 			catch (SQLException e)
 			{
-				assertEquals("wrong exception and/or exception text!",
-						"java.sql.SQLException: " + CsvResources.getString("statementCancelled"),
-						"" + e);
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("statementCancelled"),
+						"" + e, "wrong exception and/or exception text!");
 			}
 		}
 	}
@@ -3878,33 +3835,33 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM foodstuffs"))
 		{
 			ResultSetMetaData metadata = results.getMetaData();
-			assertEquals("Column Count", 2, metadata.getColumnCount());
-			assertEquals("Column Name 1", "key", metadata.getColumnName(1));
-			assertEquals("Column Name 2", "value", metadata.getColumnName(2));
+			assertEquals(2, metadata.getColumnCount(), "Column Count");
+			assertEquals("key", metadata.getColumnName(1), "Column Name 1");
+			assertEquals("value", metadata.getColumnName(2), "Column Name 2");
 
 			assertTrue(results.next());
-			assertEquals("Row 1 key", "orange", results.getString(1));
-			assertEquals("Row 1 value", "fruit", results.getString(2));
+			assertEquals("orange", results.getString(1), "Row 1 key");
+			assertEquals("fruit", results.getString(2), "Row 1 value");
 
 			assertTrue(results.next());
-			assertEquals("Row 2 key", "apple", results.getString(1));
-			assertEquals("Row 2 value", "fruit", results.getString(2));
+			assertEquals("apple", results.getString(1), "Row 2 key");
+			assertEquals("fruit", results.getString(2), "Row 2 value");
 
 			assertTrue(results.next());
-			assertEquals("Row 3 key", "corn", results.getString(1));
-			assertEquals("Row 3 value", "vegetable", results.getString(2));
+			assertEquals("corn", results.getString(1), "Row 3 key");
+			assertEquals("vegetable", results.getString(2), "Row 3 value");
 
 			assertTrue(results.next());
-			assertEquals("Row 4 key", "lemon", results.getString(1));
-			assertEquals("Row 4 value", "fruit", results.getString(2));
+			assertEquals("lemon", results.getString(1), "Row 4 key");
+			assertEquals("fruit", results.getString(2), "Row 4 value");
 
 			assertTrue(results.next());
-			assertEquals("Row 5 key", "tomato", results.getString(1));
-			assertEquals("Row 5 value", "who knows?", results.getString(2));
+			assertEquals("tomato", results.getString(1), "Row 5 key");
+			assertEquals("who knows?", results.getString(2), "Row 5 value");
 
 			assertTrue(results.next());
-			assertEquals("Row 6 key", " - ", results.getString(1));
-			assertEquals("Row 6 value", " - ", results.getString(2));
+			assertEquals(" - ", results.getString(1), "Row 6 key");
+			assertEquals(" - ", results.getString(2), "Row 6 value");
 
 			assertFalse(results.next());
 		}
@@ -3930,10 +3887,10 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("Empty Column Name 1", "", metadata.getColumnName(1));
+			assertEquals("", metadata.getColumnName(1), "Empty Column Name 1");
 
 			assertTrue(results.next());
-			assertEquals("1 is wrong", "", results.getString(1));
+			assertEquals("", results.getString(1), "1 is wrong");
 			try
 			{
 				results.getString("");
@@ -3941,18 +3898,17 @@ public class TestCsvDriver
 			}
 			catch (SQLException e)
 			{
-				assertEquals("wrong exception and/or exception text!",
-						"java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": ",
-						"" + e);
+				assertEquals("java.sql.SQLException: " + CsvResources.getString("invalidColumnName") + ": ",
+						"" + e, "wrong exception and/or exception text!");
 			}
 
-			assertEquals("2 is wrong", "WNS925", results.getString(2));
-			assertEquals("2 is wrong", "WNS925", results.getString("600-P1201"));
+			assertEquals("WNS925", results.getString(2), "2 is wrong");
+			assertEquals("WNS925", results.getString("600-P1201"), "2 is wrong");
 
 			assertTrue(results.next());
-			assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject(1));
-			assertEquals("2 is wrong", "21", results.getString(2));
-			assertEquals("3 is wrong", "20", results.getString(3));
+			assertEquals("2010-02-21 00:00:00", results.getObject(1), "1 is wrong");
+			assertEquals("21", results.getString(2), "2 is wrong");
+			assertEquals("20", results.getString(3), "3 is wrong");
 		}
 	}
 
@@ -3970,21 +3926,21 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("Incorrect Column Name 1", "COLUMN1", metadata.getColumnName(1));
-			assertEquals("Incorrect Column Name 2", "600-P1201", metadata.getColumnName(2));
+			assertEquals("COLUMN1", metadata.getColumnName(1), "Incorrect Column Name 1");
+			assertEquals("600-P1201", metadata.getColumnName(2), "Incorrect Column Name 2");
 
 			assertTrue(results.next());
-			assertEquals("1 is wrong", "", results.getString(1));
-			assertEquals("1 is wrong", "", results.getString("COLUMN1"));
+			assertEquals("", results.getString(1), "1 is wrong");
+			assertEquals("", results.getString("COLUMN1"), "1 is wrong");
 
-			assertEquals("2 is wrong", "WNS925", results.getString(2));
-			assertEquals("2 is wrong", "WNS925", results.getString("600-P1201"));
+			assertEquals("WNS925", results.getString(2), "2 is wrong");
+			assertEquals("WNS925", results.getString("600-P1201"), "2 is wrong");
 
 			assertTrue(results.next());
-			assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject(1));
-			assertEquals("1 is wrong", "2010-02-21 00:00:00", results.getObject("COLUMN1"));
-			assertEquals("2 is wrong", "21", results.getObject(2));
-			assertEquals("3 is wrong", "20", results.getObject(3));
+			assertEquals("2010-02-21 00:00:00", results.getObject(1), "1 is wrong");
+			assertEquals("2010-02-21 00:00:00", results.getObject("COLUMN1"), "1 is wrong");
+			assertEquals("21", results.getObject(2), "2 is wrong");
+			assertEquals("20", results.getObject(3), "3 is wrong");
 		}
 	}
 
@@ -4001,18 +3957,18 @@ public class TestCsvDriver
 		{
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("Incorrect Column Name 1", "IDX", metadata.getColumnName(1));
-			assertEquals("Incorrect Column Name 2", "COLUMN2", metadata.getColumnName(2));
-			assertEquals("Incorrect Column Name 3", "COLUMN3", metadata.getColumnName(3));
-			assertEquals("Incorrect Column Name 4", "COMMENT", metadata.getColumnName(4));
-			assertEquals("Incorrect Column Name 5", "COLUMN5", metadata.getColumnName(5));
+			assertEquals("IDX", metadata.getColumnName(1), "Incorrect Column Name 1");
+			assertEquals("COLUMN2", metadata.getColumnName(2), "Incorrect Column Name 2");
+			assertEquals("COLUMN3", metadata.getColumnName(3), "Incorrect Column Name 3");
+			assertEquals("COMMENT", metadata.getColumnName(4), "Incorrect Column Name 4");
+			assertEquals("COLUMN5", metadata.getColumnName(5), "Incorrect Column Name 5");
 
 			assertTrue(results.next());
-			assertEquals("1 is wrong", "178", results.getString(1));
-			assertEquals("2 is wrong", "AAX", results.getString("COLUMN2"));
-			assertEquals("3 is wrong", "ED+", results.getString(3));
-			assertEquals("4 is wrong", "NONE", results.getString(4));
-			assertEquals("5 is wrong", "T", results.getString("COLUMN5"));
+			assertEquals("178", results.getString(1), "1 is wrong");
+			assertEquals("AAX", results.getString("COLUMN2"), "2 is wrong");
+			assertEquals("ED+", results.getString(3), "3 is wrong");
+			assertEquals("NONE", results.getString(4), "4 is wrong");
+			assertEquals("T", results.getString("COLUMN5"), "5 is wrong");
 		}
 	}
 
@@ -4032,13 +3988,13 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			DateFormat toUTC = getUTCDateFormat();
-			assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
-					.getObject(1)));
-			assertEquals("1 is wrong", "2010-02-21 00:00:00", toUTC.format(results
-					.getObject("COLUMN1")));
-			assertEquals("2 is wrong", Double.valueOf(21), results.getObject(2));
-			assertEquals("3 is wrong", Double.valueOf(20), results.getObject(3));
-			assertEquals("4 is wrong", Double.valueOf(24), results.getObject(4));
+			assertEquals("2010-02-21 00:00:00", toUTC.format(results.getObject(1)),
+				"1 is wrong");
+			assertEquals("2010-02-21 00:00:00", toUTC.format(results.getObject("COLUMN1")),
+				"1 is wrong");
+			assertEquals(Double.valueOf(21), results.getObject(2), "2 is wrong");
+			assertEquals(Double.valueOf(20), results.getObject(3), "3 is wrong");
+			assertEquals(Double.valueOf(24), results.getObject(4), "4 is wrong");
 		}
 	}
 
@@ -4083,11 +4039,11 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect ID Value", "B234", results.getString(1));
+			assertEquals("B234", results.getString(1), "Incorrect ID Value");
 			assertTrue(results.next());
-			assertEquals("Incorrect ID Value", "C456", results.getString(1));
+			assertEquals("C456", results.getString(1), "Incorrect ID Value");
 			assertTrue(results.next());
-			assertEquals("Incorrect ID Value", "D789", results.getString(1));
+			assertEquals("D789", results.getString(1), "Incorrect ID Value");
 			assertFalse(results.next());
 		}
 	}
@@ -4104,11 +4060,11 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM sample ORDER BY ID"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect ID Value", "A123", results.getString(1));
+			assertEquals("A123", results.getString(1), "Incorrect ID Value");
 			assertTrue(results.next());
-			assertEquals("Incorrect ID Value", "B234", results.getString(1));
+			assertEquals("B234", results.getString(1), "Incorrect ID Value");
 			assertTrue(results.next());
-			assertEquals("Incorrect ID Value", "Q123", results.getString(1));
+			assertEquals("Q123", results.getString(1), "Incorrect ID Value");
 			assertFalse(results.next());
 		}
 	}
@@ -4540,15 +4496,15 @@ public class TestCsvDriver
 				.executeQuery("SELECT name, id, 'Bananas' as t FROM sample"))
 		{
 			results.next();
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
-			assertEquals("Incorrect ID Value", "Bananas", results.getString("t"));
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Bananas", results.getString("T"), "Incorrect ID Value");
+			assertEquals("Bananas", results.getString("t"), "Incorrect ID Value");
 			results.next();
-			assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
+			assertEquals("Bananas", results.getString("T"), "Incorrect ID Value");
 			results.next();
-			assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
+			assertEquals("Bananas", results.getString("T"), "Incorrect ID Value");
 			results.next();
-			assertEquals("Incorrect ID Value", "Bananas", results.getString("T"));
+			assertEquals("Bananas", results.getString("T"), "Incorrect ID Value");
 		}
 	}
 
@@ -4563,7 +4519,7 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT sample.id FROM sample"))
 		{
 			results.next();
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
 		}
 	}
 
@@ -4579,10 +4535,10 @@ public class TestCsvDriver
 				.executeQuery("SELECT S.id, s.Extra_field FROM sample S"))
 		{
 			results.next();
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect ID Value", "F", results.getString("EXTRA_FIELD"));
-			assertEquals("Incorrect ID Value", "Q123", results.getString(1));
-			assertEquals("Incorrect ID Value", "F", results.getString(2));
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("F", results.getString("EXTRA_FIELD"), "Incorrect ID Value");
+			assertEquals("Q123", results.getString(1), "Incorrect ID Value");
+			assertEquals("F", results.getString(2), "Incorrect ID Value");
 		}
 	}
 
@@ -4598,10 +4554,10 @@ public class TestCsvDriver
 				.executeQuery("SELECT * FROM sample AS S where S.ID='A123'"))
 		{
 			results.next();
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect ID Value", "A", results.getString("EXTRA_FIELD"));
-			assertEquals("Incorrect ID Value", "A123", results.getString(1));
-			assertEquals("Incorrect ID Value", "A", results.getString(3));
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("A", results.getString("EXTRA_FIELD"), "Incorrect ID Value");
+			assertEquals("A123", results.getString(1), "Incorrect ID Value");
+			assertEquals("A", results.getString(3), "Incorrect ID Value");
 			assertFalse(results.next());
 		}
 	}
@@ -4615,17 +4571,17 @@ public class TestCsvDriver
 			Statement stmt = conn.createStatement())
 		{
 			stmt.setMaxRows(4);
-			assertEquals("getMaxRows() incorrect", 4, stmt.getMaxRows());
+			assertEquals(4, stmt.getMaxRows(), "getMaxRows() incorrect");
 
 			ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
 			// The maxRows value at the time of the query should be used, not the value below.
 			stmt.setMaxRows(7);
 
-			assertTrue("Reading row 1 failed", results.next());
-			assertTrue("Reading row 2 failed", results.next());
-			assertTrue("Reading row 3 failed", results.next());
-			assertTrue("Reading row 4 failed", results.next());
-			assertFalse("Stopping after row 4 failed", results.next());
+			assertTrue(results.next(), "Reading row 1 failed");
+			assertTrue(results.next(), "Reading row 2 failed");
+			assertTrue(results.next(), "Reading row 3 failed");
+			assertTrue(results.next(), "Reading row 4 failed");
+			assertFalse(results.next(), "Stopping after row 4 failed");
 		}
 	}
 
@@ -4638,12 +4594,12 @@ public class TestCsvDriver
 			Statement stmt = conn.createStatement())
 		{
 			stmt.setFetchSize(50);
-			assertEquals("getFetchSize() incorrect", 50, stmt.getFetchSize());
+			assertEquals(50, stmt.getFetchSize(), "getFetchSize() incorrect");
 
 			ResultSet results = stmt.executeQuery("SELECT * FROM sample5");
-			assertEquals("getFetchSize() incorrect", 50, results.getFetchSize());
+			assertEquals(50, results.getFetchSize(), "getFetchSize() incorrect");
 			results.setFetchSize(20);
-			assertEquals("getFetchSize() incorrect", 20, results.getFetchSize());
+			assertEquals(20, results.getFetchSize(), "getFetchSize() incorrect");
 		}
 	}
 
@@ -4656,13 +4612,13 @@ public class TestCsvDriver
 			Statement stmt = conn.createStatement())
 		{
 			stmt.setFetchDirection(ResultSet.FETCH_UNKNOWN);
-			assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_UNKNOWN, stmt.getFetchDirection());
+			assertEquals(ResultSet.FETCH_UNKNOWN, stmt.getFetchDirection(), "getFetchDirection() incorrect");
 
 			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample5"))
 			{
-				assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_UNKNOWN, results.getFetchDirection());
+				assertEquals(ResultSet.FETCH_UNKNOWN, results.getFetchDirection(), "getFetchDirection() incorrect");
 				results.setFetchDirection(ResultSet.FETCH_FORWARD);
-				assertEquals("getFetchDirection() incorrect", ResultSet.FETCH_FORWARD, results.getFetchDirection());
+				assertEquals(ResultSet.FETCH_FORWARD, results.getFetchDirection(), "getFetchDirection() incorrect");
 			}
 		}
 	}
@@ -4678,15 +4634,15 @@ public class TestCsvDriver
 			// No query executed yet.
 			assertNull(stmt.getResultSet());
 			assertFalse(stmt.getMoreResults());
-			assertEquals("Update count wrong", -1, stmt.getUpdateCount());
+			assertEquals(-1, stmt.getUpdateCount(), "Update count wrong");
 
 			ResultSet results1 = stmt.executeQuery("SELECT * FROM sample5");
 			ResultSet results2 = stmt.getResultSet();
-			assertEquals("Result sets not equal", results1, results2);
-			assertEquals("Update count wrong", -1, stmt.getUpdateCount());
+			assertEquals(results1, results2, "Result sets not equal");
+			assertEquals(-1, stmt.getUpdateCount(), "Update count wrong");
 			assertFalse(stmt.getMoreResults());
-			assertNull("Result set not null", stmt.getResultSet());
-			assertTrue("Result set was not closed", results1.isClosed());
+			assertNull(stmt.getResultSet(), "Result set not null");
+			assertTrue(results1.isClosed(), "Result set was not closed");
 		}
 	}
 
@@ -4700,8 +4656,8 @@ public class TestCsvDriver
 			ResultSet results1 = stmt.executeQuery("SELECT * FROM sample5");
 			ResultSet results2 = stmt.executeQuery("SELECT * FROM sample"))
 		{
-			assertTrue("First result set is not closed", results1.isClosed());
-			assertFalse("Second result set is closed", results2.isClosed());
+			assertTrue(results1.isClosed(), "First result set is not closed");
+			assertFalse(results2.isClosed(), "Second result set is closed");
 			try
 			{
 				results1.next();
@@ -4725,7 +4681,7 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT ID FROM sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
 			results.close();
 			try
 			{
@@ -4757,8 +4713,8 @@ public class TestCsvDriver
 			try (ResultSet results = stmt.executeQuery("SELECT * FROM banks where BANK_NAME like 'Sparkasse%'"))
 			{
 				// Check that column names from headerline are used for table banks.
-				assertEquals("BLZ wrong", "BLZ", results.getMetaData().getColumnName(1));
-				assertEquals("BANK_NAME wrong", "BANK_NAME", results.getMetaData().getColumnName(2));
+				assertEquals("BLZ", results.getMetaData().getColumnName(1), "BLZ wrong");
+				assertEquals("BANK_NAME", results.getMetaData().getColumnName(2), "BANK_NAME wrong");
 				assertFalse(results.next());
 			}
 
@@ -4767,9 +4723,9 @@ public class TestCsvDriver
 				assertTrue(results.next());
 
 				// Check that column names for table transactions are correct too.
-				assertEquals("TRANS_DATE wrong", "19-10-2011", results.getString("TRANS_DATE"));
-				assertEquals("FROM_ACCT wrong", "3670345", results.getString("FROM_ACCT"));
-				assertEquals("AMOUNT wrong", "250.00", results.getString("AMOUNT"));
+				assertEquals("19-10-2011", results.getString("TRANS_DATE"), "TRANS_DATE wrong");
+				assertEquals("3670345", results.getString("FROM_ACCT"), "FROM_ACCT wrong");
+				assertEquals("250.00", results.getString("AMOUNT"), "AMOUNT wrong");
 			}
 		}
 	}
@@ -4790,8 +4746,8 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			// Check that default column names are used.
-			assertEquals("COLUMN1 wrong", "10000000", results.getString("COLUMN1"));
-			assertEquals("COLUMN2 wrong", "Bundesbank (Berlin)", results.getString("COLUMN2"));
+			assertEquals("10000000", results.getString("COLUMN1"), "COLUMN1 wrong");
+			assertEquals("Bundesbank (Berlin)", results.getString("COLUMN2"), "COLUMN2 wrong");
 		}
 	}
 
@@ -4806,9 +4762,9 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
 			assertTrue(results.next());
-			assertNull("Warnings should be null", results.getWarnings());
+			assertNull(results.getWarnings(), "Warnings should be null");
 			results.clearWarnings();
-			assertNull("Warnings should still be null", results.getWarnings());
+			assertNull(results.getWarnings(), "Warnings should still be null");
 		}
 	}
 
@@ -4823,7 +4779,7 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT ID FROM sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("ID wrong", "Q123", results.getString(1));
+			assertEquals("Q123", results.getString(1), "ID wrong");
 			assertFalse(results.wasNull());
 		}
 	}
@@ -4839,7 +4795,7 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT ID FROM sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("ID wrong", "Q123", results.getObject(1));
+			assertEquals("Q123", results.getObject(1), "ID wrong");
 			assertFalse(results.wasNull());
 		}
 	}
@@ -4853,7 +4809,7 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM airline where code='BA'"))
 		{
 			assertTrue(results.next());
-			assertEquals("NAME wrong", "British Airways", results.getString("NAME"));
+			assertEquals("British Airways", results.getString("NAME"), "NAME wrong");
 		}
 	}
 
@@ -4899,9 +4855,9 @@ public class TestCsvDriver
 			ResultSet results = conn.getMetaData().getTables(null, null, "%", null))
 		{
 			assertTrue(results.next());
-			assertEquals("TABLE_NAME wrong", "AIRLINE", results.getString("TABLE_NAME"));
+			assertEquals("AIRLINE", results.getString("TABLE_NAME"), "TABLE_NAME wrong");
 			assertTrue(results.next());
-			assertEquals("TABLE_NAME wrong", "AIRPORT", results.getString("TABLE_NAME"));
+			assertEquals("AIRPORT", results.getString("TABLE_NAME"), "TABLE_NAME wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -4912,7 +4868,7 @@ public class TestCsvDriver
 		String url = "jdbc:relique:csv:class:" + TableReaderTester.class.getName();
 		try (Connection conn = DriverManager.getConnection(url))
 		{
-			assertEquals("URL is wrong", url, conn.getMetaData().getURL());
+			assertEquals(url, conn.getMetaData().getURL(), "URL is wrong");
 		}
 	}
 
@@ -4931,13 +4887,13 @@ public class TestCsvDriver
 		try (Connection conn = DriverManager.getConnection(url, props);
 			Statement stmt = conn.createStatement())
 		{
-			assertEquals("The URL is wrong", url, conn.getMetaData().getURL());
+			assertEquals(url, conn.getMetaData().getURL(), "The URL is wrong");
 
 			try (ResultSet results = stmt.executeQuery("SELECT * FROM banks"))
 			{
 				assertTrue(results.next());
-				assertEquals("The BLZ is wrong", "10000000", results.getString("BLZ"));
-				assertEquals("The NAME is wrong", "Bundesbank (Berlin)", results.getString("NAME"));
+				assertEquals("10000000", results.getString("BLZ"), "The BLZ is wrong");
+				assertEquals("Bundesbank (Berlin)", results.getString("NAME"), "The NAME is wrong");
 			}
 		}
 	}
@@ -4960,7 +4916,7 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM sample"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "Q123", results.getString("ID"));
+			assertEquals("Q123", results.getString("ID"), "The ID is wrong");
 		}
 	}
 
@@ -4978,7 +4934,7 @@ public class TestCsvDriver
 				.executeQuery("select id from sample5 where name = '\u00C9rica Jeanine M\u00e9ndez M\u00e9ndez'"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect ID Value", "08", results.getString(1));
+			assertEquals("08", results.getString(1), "Incorrect ID Value");
 			assertFalse(results.next());
 		}
 	}
@@ -4994,15 +4950,15 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("select distinct job from sample5"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 1", "Piloto", results.getString(1));
+			assertEquals("Piloto", results.getString(1), "Incorrect distinct value 1");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 2", "Project Manager", results.getString(1));
+			assertEquals("Project Manager", results.getString(1), "Incorrect distinct value 2");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 3", "Finance Manager", results.getString(1));
+			assertEquals("Finance Manager", results.getString(1), "Incorrect distinct value 3");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 4", "Office Manager", results.getString(1));
+			assertEquals("Office Manager", results.getString(1), "Incorrect distinct value 4");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 5", "Office Employee", results.getString(1));
+			assertEquals("Office Employee", results.getString(1), "Incorrect distinct value 5");
 			assertFalse(results.next());
 		}
 	}
@@ -5018,15 +4974,15 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("select distinct S.job from sample5 S"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 1", "Piloto", results.getString(1));
+			assertEquals("Piloto", results.getString(1), "Incorrect distinct value 1");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 2", "Project Manager", results.getString(1));
+			assertEquals("Project Manager", results.getString(1), "Incorrect distinct value 2");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 3", "Finance Manager", results.getString(1));
+			assertEquals("Finance Manager", results.getString(1), "Incorrect distinct value 3");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 4", "Office Manager", results.getString(1));
+			assertEquals("Office Manager", results.getString(1), "Incorrect distinct value 4");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct value 5", "Office Employee", results.getString(1));
+			assertEquals("Office Employee", results.getString(1), "Incorrect distinct value 5");
 			assertFalse(results.next());
 		}
 	}
@@ -5048,11 +5004,11 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("select distinct TO_ACCT, TO_BLZ from transactions where AMOUNT<50"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct TO_ACCT value 1", 27234813, results.getInt(1));
-			assertEquals("Incorrect distinct TO_BLZ value 1", 10020500, results.getInt(2));
+			assertEquals(27234813, results.getInt(1), "Incorrect distinct TO_ACCT value 1");
+			assertEquals(10020500, results.getInt(2), "Incorrect distinct TO_BLZ value 1");
 			assertTrue(results.next());
-			assertEquals("Incorrect distinct TO_ACCT value 2", 3670345, results.getInt(1));
-			assertEquals("Incorrect distinct TO_BLZ value 2", 10010010, results.getInt(2));
+			assertEquals(3670345, results.getInt(1), "Incorrect distinct TO_ACCT value 2");
+			assertEquals(10010010, results.getInt(2), "Incorrect distinct TO_BLZ value 2");
 			assertFalse(results.next());
 		}
 	}
@@ -5066,15 +5022,15 @@ public class TestCsvDriver
 		{
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
-			assertEquals("column 1 type is incorrect", Types.VARCHAR, metadata.getColumnType(1));
-			assertEquals("column 2 type is incorrect", Types.VARCHAR, metadata.getColumnType(2));
-			assertEquals("column 3 type is incorrect", Types.INTEGER, metadata.getColumnType(3));
+			assertEquals(Types.VARCHAR, metadata.getColumnType(1), "column 1 type is incorrect");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(2), "column 2 type is incorrect");
+			assertEquals(Types.INTEGER, metadata.getColumnType(3), "column 3 type is incorrect");
 
-			assertEquals("column 2 name is incorrect", "W", metadata.getColumnName(2));
+			assertEquals("W", metadata.getColumnName(2), "column 2 name is incorrect");
 
-			assertEquals("column 1 value is incorrect", "Hello", results.getString(1));
-			assertEquals("column 2 value is incorrect", "World", results.getString(2));
-			assertEquals("column 3 value is incorrect", 12, results.getInt(3));
+			assertEquals("Hello", results.getString(1), "column 1 value is incorrect");
+			assertEquals("World", results.getString(2), "column 2 value is incorrect");
+			assertEquals(12, results.getInt(3), "column 3 value is incorrect");
 			assertFalse(results.next());
 		}
 	}
@@ -5111,67 +5067,67 @@ public class TestCsvDriver
 			// Select the ID and NAME columns from sample.csv
 			try (ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample"))
 			{
-				assertEquals("incorrect row #", 0, results.getRow());
+				assertEquals(0, results.getRow(), "incorrect row #");
 				assertFalse(results.isAfterLast());
 				assertTrue(results.next());
-				assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-				assertEquals("incorrect row #", 1, results.getRow());
+				assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+				assertEquals(1, results.getRow(), "incorrect row #");
 				assertFalse(results.isAfterLast());
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 2, results.getRow());
+				assertEquals(2, results.getRow(), "incorrect row #");
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 3, results.getRow());
+				assertEquals(3, results.getRow(), "incorrect row #");
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 4, results.getRow());
+				assertEquals(4, results.getRow(), "incorrect row #");
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 5, results.getRow());
+				assertEquals(5, results.getRow(), "incorrect row #");
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 6, results.getRow());
+				assertEquals(6, results.getRow(), "incorrect row #");
 				assertFalse(results.next());
-				assertEquals("incorrect row #", 0, results.getRow());
+				assertEquals(0, results.getRow(), "incorrect row #");
 				assertTrue(results.isAfterLast());
 			}
 
 			try (ResultSet results = stmt.executeQuery("SELECT ID,NAME FROM sample ORDER BY ID"))
 			{
-				assertEquals("incorrect row #", 0, results.getRow());
+				assertEquals(0, results.getRow(), "incorrect row #");
 				assertFalse(results.isAfterLast());
 				assertTrue(results.next());
-				assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-				assertEquals("incorrect row #", 1, results.getRow());
+				assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+				assertEquals(1, results.getRow(), "incorrect row #");
 				assertFalse(results.isAfterLast());
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 2, results.getRow());
+				assertEquals(2, results.getRow(), "incorrect row #");
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 3, results.getRow());
+				assertEquals(3, results.getRow(), "incorrect row #");
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 4, results.getRow());
+				assertEquals(4, results.getRow(), "incorrect row #");
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 5, results.getRow());
+				assertEquals(5, results.getRow(), "incorrect row #");
 				assertTrue(results.next());
-				assertEquals("incorrect row #", 6, results.getRow());
+				assertEquals(6, results.getRow(), "incorrect row #");
 				assertFalse(results.next());
-				assertEquals("incorrect row #", 0, results.getRow());
+				assertEquals(0, results.getRow(), "incorrect row #");
 				assertTrue(results.isAfterLast());
 			}
 
 			try (ResultSet results = stmt.executeQuery("SELECT COUNT(*) FROM sample"))
 			{
-				assertEquals("incorrect row #", 0, results.getRow());
+				assertEquals(0, results.getRow(), "incorrect row #");
 				assertFalse(results.isAfterLast());
 				assertTrue(results.next());
-				assertEquals("Incorrect COUNT Value", 6, results.getInt(1));
-				assertEquals("incorrect row #", 1, results.getRow());
+				assertEquals(6, results.getInt(1), "Incorrect COUNT Value");
+				assertEquals(1, results.getRow(), "incorrect row #");
 				assertFalse(results.isAfterLast());
 				assertFalse(results.next());
-				assertEquals("incorrect row #", 0, results.getRow());
+				assertEquals(0, results.getRow(), "incorrect row #");
 				assertTrue(results.isAfterLast());
 			}
 
 			// Test result set returning no rows.
 			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample WHERE ID = 'unknown'"))
 			{
-				assertEquals("incorrect row #", 0, results.getRow());
+				assertEquals(0, results.getRow(), "incorrect row #");
 				assertFalse(results.isAfterLast());
 				assertFalse(results.next());
 				assertFalse(results.isAfterLast());
@@ -5229,9 +5185,9 @@ public class TestCsvDriver
 
 				while (line1 != null || line2 != null)
 				{
-					assertTrue("line1 is null", line1 != null);
-					assertTrue("line2 is null", line2 != null);
-					assertEquals("lines do not match", line1, line2);
+					assertTrue(line1 != null, "line1 is null");
+					assertTrue(line2 != null, "line2 is null");
+					assertEquals(line1, line2, "lines do not match");
 					line1 = reader1.readLine();
 					line2 = reader2.readLine();
 				}
@@ -5278,14 +5234,14 @@ public class TestCsvDriver
 
 				while (line1 != null || line2 != null)
 				{
-					assertTrue("line1 is null", line1 != null);
-					assertTrue("line2 is null", line2 != null);
-					assertTrue("lines do not match", line1.equalsIgnoreCase(line2));
+					assertTrue(line1 != null, "line1 is null");
+					assertTrue(line2 != null, "line2 is null");
+					assertTrue(line1.equalsIgnoreCase(line2), "lines do not match");
 					line1 = reader1.readLine();
 					line2 = reader2.readLine();
 				}
-				assertNull("line1 not empty", line1);
-				assertNull("line2 not empty", line2);
+				assertNull(line1, "line1 not empty");
+				assertNull(line2, "line2 not empty");
 			}
 		}
 	}
@@ -5302,15 +5258,15 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM bool"))
 		{
 			assertTrue(results.next());
-			assertEquals("incorrect I", Boolean.FALSE, Boolean.valueOf(results.getBoolean(1)));
-			assertEquals("incorrect J", Boolean.TRUE, Boolean.valueOf(results.getBoolean(2)));
-			assertEquals("incorrect K", Boolean.FALSE, Boolean.valueOf(results.getBoolean(3)));
-			assertEquals("incorrect L", Boolean.TRUE, Boolean.valueOf(results.getBoolean(4)));
+			assertEquals(Boolean.FALSE, Boolean.valueOf(results.getBoolean(1)), "incorrect I");
+			assertEquals(Boolean.TRUE, Boolean.valueOf(results.getBoolean(2)), "incorrect J");
+			assertEquals(Boolean.FALSE, Boolean.valueOf(results.getBoolean(3)), "incorrect K");
+			assertEquals(Boolean.TRUE, Boolean.valueOf(results.getBoolean(4)), "incorrect L");
 			assertTrue(results.next());
-			assertEquals("incorrect I", Boolean.TRUE, Boolean.valueOf(results.getBoolean("I")));
-			assertEquals("incorrect J", Boolean.FALSE, Boolean.valueOf(results.getBoolean("J")));
-			assertEquals("incorrect K", Boolean.FALSE, Boolean.valueOf(results.getBoolean("K")));
-			assertEquals("incorrect L", Boolean.FALSE, Boolean.valueOf(results.getBoolean("L")));
+			assertEquals(Boolean.TRUE, Boolean.valueOf(results.getBoolean("I")), "incorrect I");
+			assertEquals(Boolean.FALSE, Boolean.valueOf(results.getBoolean("J")), "incorrect J");
+			assertEquals(Boolean.FALSE, Boolean.valueOf(results.getBoolean("K")), "incorrect K");
+			assertEquals(Boolean.FALSE, Boolean.valueOf(results.getBoolean("L")), "incorrect L");
 		}
 	}
 
@@ -5323,12 +5279,12 @@ public class TestCsvDriver
 			Statement stmt = conn.createStatement())
 		{
 			boolean hasResults = stmt.execute("SELECT * FROM sample");
-			assertTrue("execute hasResults", hasResults);
+			assertTrue(hasResults, "execute hasResults");
 			ResultSet results = stmt.getResultSet();
 			assertNotNull(results);
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "Q123", results.getString(1));
-			assertFalse("getMoreResults", stmt.getMoreResults());
+			assertEquals("Q123", results.getString(1), "The ID is wrong");
+			assertFalse(stmt.getMoreResults(), "getMoreResults");
 		}
 	}
 
@@ -5341,21 +5297,21 @@ public class TestCsvDriver
 			Statement stmt = conn.createStatement())
 		{
 			boolean hasResults = stmt.execute("SELECT ID FROM sample;\nSELECT Name FROM sample2;");
-			assertTrue("execute hasResults", hasResults);
+			assertTrue(hasResults, "execute hasResults");
 			try (ResultSet results1 = stmt.getResultSet())
 			{
 				assertNotNull(results1);
 				assertTrue(results1.next());
-				assertEquals("The ID is wrong", "Q123", results1.getString(1));
+				assertEquals("Q123", results1.getString(1), "The ID is wrong");
 
-				assertTrue("getMoreResults", stmt.getMoreResults());
+				assertTrue(stmt.getMoreResults(), "getMoreResults");
 				try (ResultSet results2 = stmt.getResultSet())
 				{
 					assertNotNull(results2);
 					assertTrue(results1.isClosed());
 					assertTrue(results2.next());
-					assertEquals("The Name is wrong", "Aman", results2.getString(1));
-					assertFalse("getMoreResults", stmt.getMoreResults());
+					assertEquals("Aman", results2.getString(1), "The Name is wrong");
+					assertFalse(stmt.getMoreResults(), "getMoreResults");
 					assertTrue(results2.isClosed());
 				}
 			}
@@ -5379,34 +5335,34 @@ public class TestCsvDriver
 			try (ResultSet results = stmt.executeQuery("SELECT POW(C1, 2) FROM numeric"))
 			{
 				assertTrue(results.next());
-				assertEquals("pow is wrong", 99 * 99, Math.round(results.getDouble(1)));
+				assertEquals(99 * 99, Math.round(results.getDouble(1)), "pow is wrong");
 				assertTrue(results.next());
-				assertEquals("pow is wrong", -22 * -22, Math.round(results.getDouble(1)));
+				assertEquals(-22 * -22, Math.round(results.getDouble(1)), "pow is wrong");
 			}
 
 			try (ResultSet results = stmt.executeQuery("SELECT BITCOUNT(C1) FROM numeric"))
 			{
 				assertTrue(results.next());
-				assertEquals("bitcount is wrong", Integer.bitCount(99), results.getInt(1));
+				assertEquals(Integer.bitCount(99), results.getInt(1), "bitcount is wrong");
 				assertTrue(results.next());
-				assertEquals("bitcount is wrong", Integer.bitCount(-22), results.getInt(1));
+				assertEquals(Integer.bitCount(-22), results.getInt(1), "bitcount is wrong");
 			}
 
 			String separator = System.getProperty("file.separator");
 			try (ResultSet results = stmt.executeQuery("SELECT PROPERTY('file.separator') || ID FROM sample"))
 			{
 				assertTrue(results.next());
-				assertEquals("property is wrong", separator + "Q123", results.getString(1));
+				assertEquals(separator + "Q123", results.getString(1), "property is wrong");
 				assertTrue(results.next());
-				assertEquals("property is wrong", separator + "A123", results.getString(1));
+				assertEquals(separator + "A123", results.getString(1), "property is wrong");
 			}
 
 			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample WHERE RLIKE('.*234', ID) = 'true'"))
 			{
 				assertTrue(results.next());
-				assertEquals("ID is wrong", "B234", results.getString(1));
+				assertEquals("B234", results.getString(1), "ID is wrong");
 				assertTrue(results.next());
-				assertEquals("ID is wrong", "X234", results.getString(1));
+				assertEquals("X234", results.getString(1), "ID is wrong");
 				assertFalse(results.next());
 			}
 
@@ -5416,7 +5372,7 @@ public class TestCsvDriver
 				assertTrue(results.next());
 				long t = results.getLong(1);
 				long t2 = System.currentTimeMillis();
-				assertTrue("CurrentTimeMillis is wrong", t >= t1 && t <= t2);
+				assertTrue(t >= t1 && t <= t2, "CurrentTimeMillis is wrong");
 			}
 		}
 	}
@@ -5435,9 +5391,9 @@ public class TestCsvDriver
 			ResultSet results = stmt.executeQuery("SELECT FORMAT('%04d%06d %x', C1, C2, 255) FROM numeric"))
 		{
 			assertTrue(results.next());
-			assertEquals("format is wrong", "0099-01010 ff", results.getString(1));
+			assertEquals("0099-01010 ff", results.getString(1), "format is wrong");
 			assertTrue(results.next());
-			assertEquals("format is wrong", "-022000015 ff", results.getString(1));
+			assertEquals("-022000015 ff", results.getString(1), "format is wrong");
 		}
 	}
 
@@ -5468,7 +5424,7 @@ public class TestCsvDriver
 			conn.rollback(savepoint1);
 			Savepoint savepoint2 = conn.setSavepoint("name1");
 			String name = savepoint2.getSavepointName();
-			assertEquals("Incorrect Savepoint name", "name1", name);
+			assertEquals("name1", name, "Incorrect Savepoint name");
 			conn.rollback(savepoint2);
 			conn.close();
 

--- a/src/test/java/org/relique/jdbc/csv/TestDbfDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestDbfDriver.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -37,8 +37,8 @@ import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.relique.jdbc.dbf.DbfClassNotFoundException;
 
 /**
@@ -50,13 +50,13 @@ public class TestDbfDriver
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -91,20 +91,15 @@ public class TestDbfDriver
 					.executeQuery("SELECT * FROM sample"))
 			{
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Gianni", results
-						.getString("Name"));
+				assertEquals("Gianni", results.getString("Name"), "The name is wrong");
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Reinout", results
-						.getString("Name"));
+				assertEquals("Reinout", results.getString("Name"), "The name is wrong");
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Alex", results
-						.getString("Name"));
+				assertEquals("Alex", results.getString("Name"), "The name is wrong");
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Gianni", results
-						.getString("Name"));
+				assertEquals("Gianni", results.getString("Name"), "The name is wrong");
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Mario", results
-						.getString("Name"));
+				assertEquals("Mario", results.getString("Name"), "The name is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -133,20 +128,14 @@ public class TestDbfDriver
 					.executeQuery("SELECT * FROM sample WHERE key = 'op'"))
 			{
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Gianni", results
-						.getString("Name"));
-				assertEquals("The name is wrong", "debian", results
-						.getString("value"));
+				assertEquals("Gianni", results.getString("Name"), "The name is wrong");
+				assertEquals("debian", results.getString("value"), "The name is wrong");
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Reinout", results
-						.getString("Name"));
-				assertEquals("The name is wrong", "ubuntu", results
-						.getString("value"));
+				assertEquals("Reinout", results.getString("Name"), "The name is wrong");
+				assertEquals("ubuntu", results.getString("value"), "The name is wrong");
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Alex", results
-						.getString("Name"));
-				assertEquals("The name is wrong", "windows", results
-						.getString("value"));
+				assertEquals("Alex", results.getString("Name"), "The name is wrong");
+				assertEquals("windows", results.getString("value"), "The name is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -175,15 +164,11 @@ public class TestDbfDriver
 					.executeQuery("SELECT * FROM sample WHERE key = 'todo'"))
 			{
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Gianni", results
-						.getString("Name"));
-				assertEquals("The name is wrong", "none", results
-						.getString("value"));
+				assertEquals("Gianni", results.getString("Name"), "The name is wrong");
+				assertEquals("none", results.getString("value"), "The name is wrong");
 				assertTrue(results.next());
-				assertEquals("The name is wrong", "Mario", results
-						.getString("Name"));
-				assertEquals("The name is wrong", "sleep", results
-						.getString("value"));
+				assertEquals("Mario", results.getString("Name"), "The name is wrong");
+				assertEquals("sleep", results.getString("value"), "The name is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -236,12 +221,11 @@ public class TestDbfDriver
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("Incorrect Table Name", "fox_samp", metadata
-					.getTableName(0));
-			assertEquals("Incorrect Column Count", 57, metadata.getColumnCount());
-			assertEquals("Incorrect Column Type", Types.VARCHAR, metadata.getColumnType(1));
-			assertEquals("Incorrect Column Type", Types.BOOLEAN, metadata.getColumnType(2));
-			assertEquals("Incorrect Column Type", Types.DOUBLE, metadata.getColumnType(3));
+			assertEquals("fox_samp", metadata.getTableName(0), "Incorrect Table Name");
+			assertEquals(57, metadata.getColumnCount(), "Incorrect Column Count");
+			assertEquals(Types.VARCHAR, metadata.getColumnType(1), "Incorrect Column Type");
+			assertEquals(Types.BOOLEAN, metadata.getColumnType(2), "Incorrect Column Type");
+			assertEquals(Types.DOUBLE, metadata.getColumnType(3), "Incorrect Column Type");
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -264,11 +248,11 @@ public class TestDbfDriver
 			ResultSet results = stmt.executeQuery("SELECT NOTE FROM xbase"))
 		{
 			assertTrue(results.next());
-			assertEquals("The NOTE is wrong", "This is a memo fore record no one", results.getString(1));
+			assertEquals("This is a memo fore record no one", results.getString(1), "The NOTE is wrong");
 			assertTrue(results.next());
-			assertEquals("The NOTE is wrong", "This is memo for record 2", results.getString(1));
+			assertEquals("This is memo for record 2", results.getString(1), "The NOTE is wrong");
 			assertTrue(results.next());
-			assertEquals("The NOTE is wrong", "This is memo 3", results.getString(1));
+			assertEquals("This is memo 3", results.getString(1), "The NOTE is wrong");
 			assertFalse(results.next());
 		}
 		catch (DbfClassNotFoundException e)
@@ -293,7 +277,7 @@ public class TestDbfDriver
 		{
 			assertTrue(results.next());
 			long l = Math.round(7.63 * 1000);
-			assertEquals("The floatfield is wrong", l, Math.round(results.getDouble(1) * 1000));
+			assertEquals(l, Math.round(results.getDouble(1) * 1000), "The floatfield is wrong");
 			assertFalse(results.next());
 		}
 		catch (DbfClassNotFoundException e)
@@ -321,9 +305,9 @@ public class TestDbfDriver
 			assertTrue(results.next());
 			ResultSetMetaData metadata = results.getMetaData();
 
-			assertEquals("Incorrect Column Size", 11, metadata.getColumnDisplaySize(1));
-			assertEquals("Incorrect Column Size", 1, metadata.getColumnDisplaySize(2));
-			assertEquals("Incorrect Column Size", 4, metadata.getColumnDisplaySize(3));
+			assertEquals(11, metadata.getColumnDisplaySize(1), "Incorrect Column Size");
+			assertEquals(1, metadata.getColumnDisplaySize(2), "Incorrect Column Size");
+			assertEquals(4, metadata.getColumnDisplaySize(3), "Incorrect Column Size");
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -363,7 +347,7 @@ public class TestDbfDriver
 			current.add(results.getString("TABLE_NAME"));
 			assertFalse(results.next());
 
-			assertEquals("Incorrect table names", target, current);
+			assertEquals(target, current, "Incorrect table names");
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -385,7 +369,7 @@ public class TestDbfDriver
 			ResultSet results = conn.getMetaData().getTables(null, null, "x%", new String[]{"TABLE"}))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect table name", "xbase", results.getString("TABLE_NAME"));
+			assertEquals("xbase", results.getString("TABLE_NAME"), "Incorrect table name");
 			assertFalse(results.next());
 		}
 		catch (DbfClassNotFoundException e)
@@ -407,13 +391,13 @@ public class TestDbfDriver
 			ResultSet results = conn.getMetaData().getColumns(null, null, "sample", "%"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect table name", "sample", results.getString("TABLE_NAME"));
-			assertEquals("Incorrect column name", "NAME", results.getString("COLUMN_NAME"));
-			assertEquals("Incorrect column type", Types.VARCHAR, results.getInt("DATA_TYPE"));
-			assertEquals("Incorrect column type", "String", results.getString("TYPE_NAME"));
-			assertEquals("Incorrect ordinal position", 1, results.getInt("ORDINAL_POSITION"));
+			assertEquals("sample", results.getString("TABLE_NAME"), "Incorrect table name");
+			assertEquals("NAME", results.getString("COLUMN_NAME"), "Incorrect column name");
+			assertEquals(Types.VARCHAR, results.getInt("DATA_TYPE"), "Incorrect column type");
+			assertEquals("String", results.getString("TYPE_NAME"), "Incorrect column type");
+			assertEquals(1, results.getInt("ORDINAL_POSITION"), "Incorrect ordinal position");
 			assertTrue(results.next());
-			assertEquals("Incorrect column name", "KEY", results.getString(4));
+			assertEquals("KEY", results.getString(4), "Incorrect column name");
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -434,11 +418,11 @@ public class TestDbfDriver
 			ResultSet results = conn.getMetaData().getColumns(null, null, "x%", "M%"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect table name", "xbase", results.getString("TABLE_NAME"));
-			assertEquals("Incorrect column name", "MSG", results.getString("COLUMN_NAME"));
-			assertEquals("Incorrect column type", Types.VARCHAR, results.getInt("DATA_TYPE"));
-			assertEquals("Incorrect column type", "String", results.getString("TYPE_NAME"));
-			assertEquals("Incorrect ordinal position", 2, results.getInt("ORDINAL_POSITION"));
+			assertEquals("xbase", results.getString("TABLE_NAME"), "Incorrect table name");
+			assertEquals("MSG", results.getString("COLUMN_NAME"), "Incorrect column name");
+			assertEquals(Types.VARCHAR, results.getInt("DATA_TYPE"), "Incorrect column type");
+			assertEquals("String", results.getString("TYPE_NAME"), "Incorrect column type");
+			assertEquals(2, results.getInt("ORDINAL_POSITION"), "Incorrect ordinal position");
 			assertFalse(results.next());
 		}
 		catch (DbfClassNotFoundException e)
@@ -462,12 +446,12 @@ public class TestDbfDriver
 			ResultSet results = stmt.executeQuery("SELECT * FROM fox_samp"))
 		{
 			assertTrue(results.next());
-			assertEquals("The NCOUNTYCOD is wrong", 33, results.getByte("NCOUNTYCOD"));
-			assertEquals("The NCOUNTYCOD is wrong", 33, results.getShort("NCOUNTYCOD"));
-			assertEquals("The NTAXYEAR is wrong", 2011, results.getInt("NTAXYEAR"));
-			assertEquals("The NNOTFCV is wrong", 0, results.getLong("NNOTFCV"));
-			assertEquals("The NASSASSRAT is wrong", 7250, Math.round(results.getFloat("NASSASSRAT") * 1000));
-			assertEquals("The NASSASSRAT is wrong", 7250, Math.round(results.getDouble("NASSASSRAT") * 1000));
+			assertEquals(33, results.getByte("NCOUNTYCOD"), "The NCOUNTYCOD is wrong");
+			assertEquals(33, results.getShort("NCOUNTYCOD"), "The NCOUNTYCOD is wrong");
+			assertEquals(2011, results.getInt("NTAXYEAR"), "The NTAXYEAR is wrong");
+			assertEquals(0, results.getLong("NNOTFCV"), "The NNOTFCV is wrong");
+			assertEquals(7250, Math.round(results.getFloat("NASSASSRAT") * 1000), "The NASSASSRAT is wrong");
+			assertEquals(7250, Math.round(results.getDouble("NASSASSRAT") * 1000), "The NASSASSRAT is wrong");
 			assertFalse(results.next());
 		}
 		catch (DbfClassNotFoundException e)
@@ -491,7 +475,7 @@ public class TestDbfDriver
 			ResultSet results = stmt.executeQuery("SELECT DASSDATE FROM fox_samp"))
 		{
 			assertTrue(results.next());
-			assertEquals("The DASSDATE is wrong", Date.valueOf("2012-12-25"), results.getDate(1));
+			assertEquals(Date.valueOf("2012-12-25"), results.getDate(1), "The DASSDATE is wrong");
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -514,8 +498,8 @@ public class TestDbfDriver
 			ResultSet results = stmt.executeQuery("SELECT DASSDATE FROM fox_samp"))
 		{
 			assertTrue(results.next());
-			assertEquals("The DASSDATE is wrong", Timestamp.valueOf("2012-12-25 00:00:00"),
-					results.getTimestamp(1));
+			assertEquals(Timestamp.valueOf("2012-12-25 00:00:00"),
+					results.getTimestamp(1), "The DASSDATE is wrong");
 		}
 		catch (DbfClassNotFoundException e)
 		{
@@ -539,13 +523,13 @@ public class TestDbfDriver
 			ResultSet results = stmt.executeQuery("SELECT HOTELNAME FROM hotel"))
 		{
 			assertTrue(results.next());
-			assertEquals("The HOTELNAME is wrong", "M\u00DCNCHEN HOTEL", results.getString(1));
+			assertEquals("M\u00DCNCHEN HOTEL", results.getString(1), "The HOTELNAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The HOTELNAME is wrong", "MALM\u00D6 INN", results.getString(1));
+			assertEquals("MALM\u00D6 INN", results.getString(1), "The HOTELNAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The HOTELNAME is wrong", "K\u00D8BENHAVN HOTEL", results.getString(1));
+			assertEquals("K\u00D8BENHAVN HOTEL", results.getString(1), "The HOTELNAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The HOTELNAME is wrong", "C\u00F3rdoba Hotel", results.getString(1));
+			assertEquals("C\u00F3rdoba Hotel", results.getString(1), "The HOTELNAME is wrong");
 			assertFalse(results.next());
 		}
 		catch (DbfClassNotFoundException e)

--- a/src/test/java/org/relique/jdbc/csv/TestDoubleQuoting.java
+++ b/src/test/java/org/relique/jdbc/csv/TestDoubleQuoting.java
@@ -18,9 +18,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -30,20 +30,20 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestDoubleQuoting
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -83,22 +83,22 @@ public class TestDoubleQuoting
 
 			ResultSet rs1 = stmt.executeQuery("SELECT \"A\", \"B\" + 100, \"[A]\", \"A-B\", \"A B\" FROM \"C D\""))
 		{
-			assertEquals("Column name A is wrong", "A", rs1.getMetaData().getColumnName(1));
+			assertEquals("A", rs1.getMetaData().getColumnName(1), "Column name A is wrong");
 
-			assertEquals("Column name [A] is wrong", "[A]", rs1.getMetaData().getColumnName(3));
-			assertEquals("Column name A-B is wrong", "A-B", rs1.getMetaData().getColumnName(4));
-			assertEquals("Column name A B is wrong", "A B", rs1.getMetaData().getColumnName(5));
+			assertEquals("[A]", rs1.getMetaData().getColumnName(3), "Column name [A] is wrong");
+			assertEquals("A-B", rs1.getMetaData().getColumnName(4), "Column name A-B is wrong");
+			assertEquals("A B", rs1.getMetaData().getColumnName(5), "Column name A B is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The A is wrong", 1, rs1.getInt("A"));
-			assertEquals("The [A] is wrong", 3, rs1.getInt("[A]"));
-			assertEquals("The A-B is wrong", 4, rs1.getInt("A-B"));
-			assertEquals("The A-B is wrong", 5, rs1.getInt("A B"));
+			assertEquals(1, rs1.getInt("A"), "The A is wrong");
+			assertEquals(3, rs1.getInt("[A]"), "The [A] is wrong");
+			assertEquals(4, rs1.getInt("A-B"), "The A-B is wrong");
+			assertEquals(5, rs1.getInt("A B"), "The A-B is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The A is wrong", 6, rs1.getInt(1));
-			assertEquals("The B + 100 is wrong", 7 + 100, rs1.getInt(2));
-			assertEquals("The [A] is wrong", 8, rs1.getInt(3));
-			assertEquals("The A-B is wrong", 9, rs1.getInt(4));
-			assertEquals("The A-B is wrong", 10, rs1.getInt(5));
+			assertEquals(6, rs1.getInt(1), "The A is wrong");
+			assertEquals(7 + 100, rs1.getInt(2), "The B + 100 is wrong");
+			assertEquals(8, rs1.getInt(3), "The [A] is wrong");
+			assertEquals(9, rs1.getInt(4), "The A-B is wrong");
+			assertEquals(10, rs1.getInt(5), "The A-B is wrong");
 		}
 	}
 
@@ -117,8 +117,8 @@ public class TestDoubleQuoting
 				"FROM sample AS " + alias))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The ID is wrong", "Q123", rs1.getString(1));
-			assertEquals("The EXTRA_FIELD is wrong", "F", rs1.getString(2));
+			assertEquals("Q123", rs1.getString(1), "The ID is wrong");
+			assertEquals("F", rs1.getString(2), "The EXTRA_FIELD is wrong");
 		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
@@ -19,9 +19,9 @@
 
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -31,21 +31,21 @@ import java.io.InputStreamReader;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.relique.io.FileSetInputStream;
 
 public class TestFileSetInputStream
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 		filePath = filePath + File.separator;
 
 		// load CSV driver
@@ -83,8 +83,8 @@ public class TestFileSetInputStream
 				testSet.add(lineTest);
 			}
 			while (lineRef != null && lineTest != null);
-			assertTrue("refSet contains testSet", refSet.containsAll(testSet));
-			assertTrue("testSet contains refSet", testSet.containsAll(refSet));
+			assertTrue(refSet.containsAll(testSet), "refSet contains testSet");
+			assertTrue(testSet.containsAll(refSet), "testSet contains refSet");
 		}
 	}
 
@@ -112,8 +112,8 @@ public class TestFileSetInputStream
 				testSet.add(lineTest);
 			}
 			while (lineRef != null && lineTest != null);
-			assertTrue("refSet contains testSet", refSet.containsAll(testSet));
-			assertTrue("testSet contains refSet", testSet.containsAll(refSet));
+			assertTrue(refSet.containsAll(testSet), "refSet contains testSet");
+			assertTrue(testSet.containsAll(refSet), "testSet contains refSet");
 		}
 	}
 
@@ -139,8 +139,8 @@ public class TestFileSetInputStream
 				testSet.add(lineTest);
 			}
 			while (lineRef != null && lineTest != null);
-			assertTrue("refSet contains testSet", refSet.containsAll(testSet));
-			assertTrue("testSet contains refSet", testSet.containsAll(refSet));
+			assertTrue(refSet.containsAll(testSet), "refSet contains testSet");
+			assertTrue(testSet.containsAll(refSet), "testSet contains refSet");
 		}
 	}
 
@@ -166,8 +166,8 @@ public class TestFileSetInputStream
 				testSet.add(lineTest);
 			}
 			while (lineRef != null && lineTest != null);
-			assertTrue("refSet contains testSet", refSet.containsAll(testSet));
-			assertTrue("testSet contains refSet", testSet.containsAll(refSet));
+			assertTrue(refSet.containsAll(testSet), "refSet contains testSet");
+			assertTrue(testSet.containsAll(refSet), "testSet contains refSet");
 		}
 	}
 
@@ -189,7 +189,7 @@ public class TestFileSetInputStream
 				String []columns = lineTest.split(separator);
 				// CSV file contains two columns, plus two extra columns from filename
 				int expectedColumns = 4;
-				assertEquals("Expected number of columns", expectedColumns, columns.length);
+				assertEquals(expectedColumns, columns.length, "Expected number of columns");
 				lineTest = inputTest.readLine();
 			}
 		}

--- a/src/test/java/org/relique/jdbc/csv/TestFixedWidthFiles.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFixedWidthFiles.java
@@ -18,9 +18,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -31,20 +31,20 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestFixedWidthFiles
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -72,20 +72,20 @@ public class TestFixedWidthFiles
 			ResultSet rs1 = stmt.executeQuery("SELECT * FROM currency-exchange-rates-fixed"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("Country rate is wrong", "GERMANY", rs1.getString("Country"));
-			assertEquals("Currency rate is wrong", "Euro", rs1.getString("Currency"));
-			assertEquals("ISO rate is wrong", "EUR", rs1.getString("ISO"));
-			assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString("YESTERDY"));
-			assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString("TODAY_"));
-			assertEquals("% Change rate is wrong", "0.002102", rs1.getString("% Change"));
+			assertEquals("GERMANY", rs1.getString("Country"), "Country rate is wrong");
+			assertEquals("Euro", rs1.getString("Currency"), "Currency rate is wrong");
+			assertEquals("EUR", rs1.getString("ISO"), "ISO rate is wrong");
+			assertEquals("0.761645", rs1.getString("YESTERDY"), "YESTERDY rate is wrong");
+			assertEquals("0.763246", rs1.getString("TODAY_"), "TODAY_ rate is wrong");
+			assertEquals("0.002102", rs1.getString("% Change"), "% Change rate is wrong");
 
 			assertTrue(rs1.next());
-			assertEquals("Country rate is wrong", "GREECE", rs1.getString(1));
-			assertEquals("Currency rate is wrong", "Euro", rs1.getString(2));
-			assertEquals("ISO rate is wrong", "EUR", rs1.getString(3));
-			assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString(4));
-			assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString(5));
-			assertEquals("% Change rate is wrong", "0.002102", rs1.getString(6));
+			assertEquals("GREECE", rs1.getString(1), "Country rate is wrong");
+			assertEquals("Euro", rs1.getString(2), "Currency rate is wrong");
+			assertEquals("EUR", rs1.getString(3), "ISO rate is wrong");
+			assertEquals("0.761645", rs1.getString(4), "YESTERDY rate is wrong");
+			assertEquals("0.763246", rs1.getString(5), "TODAY_ rate is wrong");
+			assertEquals("0.002102", rs1.getString(6), "% Change rate is wrong");
 
 			assertTrue(rs1.next());
 		}
@@ -114,10 +114,10 @@ public class TestFixedWidthFiles
 				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'GERMANY'"))
 			{
 				assertTrue(rs1.next());
-				assertEquals("ISO rate is wrong", "EUR", rs1.getString("ISO"));
-				assertEquals("YESTERDY rate is wrong", "0.761645", rs1.getString("PREV_DAY"));
-				assertEquals("TODAY_ rate is wrong", "0.763246", rs1.getString("TODAY"));
-				assertEquals("% Change rate is wrong", "0.002102", rs1.getString("PTChange"));
+				assertEquals("EUR", rs1.getString("ISO"), "ISO rate is wrong");
+				assertEquals("0.761645", rs1.getString("PREV_DAY"), "YESTERDY rate is wrong");
+				assertEquals("0.763246", rs1.getString("TODAY"), "TODAY_ rate is wrong");
+				assertEquals("0.002102", rs1.getString("PTChange"), "% Change rate is wrong");
 			}
 
 			// HUNGARY         Forint  HUF       226.1222226.67130.002429
@@ -125,10 +125,10 @@ public class TestFixedWidthFiles
 				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'HUNGARY'"))
 			{
 				assertTrue(rs2.next());
-				assertEquals("ISO rate is wrong", "HUF", rs2.getString("ISO"));
-				assertEquals("YESTERDY rate is wrong", "226.1222", rs2.getString("PREV_DAY"));
-				assertEquals("TODAY_ rate is wrong", "226.6713", rs2.getString("TODAY"));
-				assertEquals("% Change rate is wrong", "0.002429", rs2.getString("PTChange"));
+				assertEquals("HUF", rs2.getString("ISO"), "ISO rate is wrong");
+				assertEquals("226.1222", rs2.getString("PREV_DAY"), "YESTERDY rate is wrong");
+				assertEquals("226.6713", rs2.getString("TODAY"), "TODAY_ rate is wrong");
+				assertEquals("0.002429", rs2.getString("PTChange"), "% Change rate is wrong");
 			}
 
 			// PERU            Sol     PEN       2.6618362.661836       0
@@ -136,10 +136,10 @@ public class TestFixedWidthFiles
 				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'PERU'"))
 			{
 				assertTrue(rs3.next());
-				assertEquals("ISO rate is wrong", "PEN", rs3.getString("ISO"));
-				assertEquals("YESTERDY rate is wrong", "2.661836", rs3.getString("PREV_DAY"));
-				assertEquals("TODAY_ rate is wrong", "2.661836", rs3.getString("TODAY"));
-				assertEquals("% Change rate is wrong", "0.0", rs3.getString("PTChange"));
+				assertEquals("PEN", rs3.getString("ISO"), "ISO rate is wrong");
+				assertEquals("2.661836", rs3.getString("PREV_DAY"), "YESTERDY rate is wrong");
+				assertEquals("2.661836", rs3.getString("TODAY"), "TODAY_ rate is wrong");
+				assertEquals("0.0", rs3.getString("PTChange"), "% Change rate is wrong");
 			}
 
 			//SAUDI ARABIA    Riyal   SAR       3.7504133.750361-1.4E-05
@@ -147,10 +147,10 @@ public class TestFixedWidthFiles
 				.executeQuery("SELECT * FROM currency-exchange-rates-fixed c WHERE c.Country = 'SAUDI ARABIA'"))
 			{
 				assertTrue(rs4.next());
-				assertEquals("ISO rate is wrong", "SAR", rs4.getString("ISO"));
-				assertEquals("YESTERDY rate is wrong", "3.750413", rs4.getString("PREV_DAY"));
-				assertEquals("TODAY_ rate is wrong", "3.750361", rs4.getString("TODAY"));
-				assertEquals("% Change rate is wrong", "-1.4E-5", rs4.getString("PTChange"));
+				assertEquals("SAR", rs4.getString("ISO"), "ISO rate is wrong");
+				assertEquals("3.750413", rs4.getString("PREV_DAY"), "YESTERDY rate is wrong");
+				assertEquals("3.750361", rs4.getString("TODAY"), "TODAY_ rate is wrong");
+				assertEquals("-1.4E-5", rs4.getString("PTChange"), "% Change rate is wrong");
 			}
 		}
 	}
@@ -174,14 +174,14 @@ public class TestFixedWidthFiles
 		{
 			int multiplier = 1000;
 			assertTrue(rs1.next());
-			assertEquals("TODAY_ is wrong", Math.round(6.76557 * multiplier), Math.round(rs1.getDouble("YESTERDY") * multiplier));
-			assertEquals("YESTERDY is wrong", Math.round(6.752711 * multiplier), Math.round(rs1.getDouble("TODAY_") * multiplier));
-			assertEquals("% Change is wrong", Math.round(-0.0019 * multiplier), Math.round(rs1.getDouble("% Change") * multiplier));
+			assertEquals(Math.round(6.76557 * multiplier), Math.round(rs1.getDouble("YESTERDY") * multiplier), "TODAY_ is wrong");
+			assertEquals(Math.round(6.752711 * multiplier), Math.round(rs1.getDouble("TODAY_") * multiplier), "YESTERDY is wrong");
+			assertEquals(Math.round(-0.0019 * multiplier), Math.round(rs1.getDouble("% Change") * multiplier), "% Change is wrong");
 
 			assertTrue(rs1.next());
-			assertEquals("TODAY_ is wrong", Math.round(0.915347 * multiplier), Math.round(rs1.getDouble("YESTERDY") * multiplier));
-			assertEquals("YESTERDY is wrong", Math.round(0.917832 * multiplier), Math.round(rs1.getDouble("TODAY_") * multiplier));
-			assertEquals("% Change is wrong", Math.round(0.002715 * multiplier), Math.round(rs1.getDouble("% Change") * multiplier));
+			assertEquals(Math.round(0.915347 * multiplier), Math.round(rs1.getDouble("YESTERDY") * multiplier), "TODAY_ is wrong");
+			assertEquals(Math.round(0.917832 * multiplier), Math.round(rs1.getDouble("TODAY_") * multiplier), "YESTERDY is wrong");
+			assertEquals(Math.round(0.002715 * multiplier), Math.round(rs1.getDouble("% Change") * multiplier), "% Change is wrong");
 		}
 	}
 
@@ -200,9 +200,9 @@ public class TestFixedWidthFiles
 			ResultSet rs1 = stmt.executeQuery("SELECT Country,YESTERDY,ISO FROM currency-exchange-rates-fixed"))
 		{
 			ResultSetMetaData meta = rs1.getMetaData();
-			assertEquals("Incorrect Column Size", 16, meta.getColumnDisplaySize(1));
-			assertEquals("Incorrect Column Size", 8, meta.getColumnDisplaySize(2));
-			assertEquals("Incorrect Column Size", 3, meta.getColumnDisplaySize(3));
+			assertEquals(16, meta.getColumnDisplaySize(1), "Incorrect Column Size");
+			assertEquals(8, meta.getColumnDisplaySize(2), "Incorrect Column Size");
+			assertEquals(3, meta.getColumnDisplaySize(3), "Incorrect Column Size");
 		}
 	}
 
@@ -221,24 +221,24 @@ public class TestFixedWidthFiles
 			ResultSet rs1 = stmt.executeQuery("SELECT * FROM flights"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("Column 1 is wrong", "A18", rs1.getString(1));
-			assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
-			assertEquals("Column 3 is wrong", "", rs1.getString(3));
+			assertEquals("A18", rs1.getString(1), "Column 1 is wrong");
+			assertEquals(1, rs1.getInt(2), "Column 2 is wrong");
+			assertEquals("", rs1.getString(3), "Column 3 is wrong");
 
 			assertTrue(rs1.next());
-			assertEquals("Column 1 is wrong", "B2", rs1.getString(1));
-			assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
-			assertEquals("Column 3 is wrong", "", rs1.getString(3));
+			assertEquals("B2", rs1.getString(1), "Column 1 is wrong");
+			assertEquals(1, rs1.getInt(2), "Column 2 is wrong");
+			assertEquals("", rs1.getString(3), "Column 3 is wrong");
 
 			assertTrue(rs1.next());
-			assertEquals("Column 1 is wrong", "D4", rs1.getString(1));
-			assertEquals("Column 2 is wrong", 2, rs1.getInt(2));
-			assertEquals("Column 3 is wrong", "", rs1.getString(3));
+			assertEquals("D4", rs1.getString(1), "Column 1 is wrong");
+			assertEquals(2, rs1.getInt(2), "Column 2 is wrong");
+			assertEquals("", rs1.getString(3), "Column 3 is wrong");
 
 			assertTrue(rs1.next());
-			assertEquals("Column 1 is wrong", "A22", rs1.getString(1));
-			assertEquals("Column 2 is wrong", 1, rs1.getInt(2));
-			assertEquals("Column 3 is wrong", "1320", rs1.getString(3));
+			assertEquals("A22", rs1.getString(1), "Column 1 is wrong");
+			assertEquals(1, rs1.getInt(2), "Column 2 is wrong");
+			assertEquals("1320", rs1.getString(3), "Column 3 is wrong");
 		}
 	}
 
@@ -258,16 +258,16 @@ public class TestFixedWidthFiles
 			ResultSet rs1 = stmt.executeQuery("SELECT * FROM single-char-cols-fixed"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("Column 1 value is wrong", "BB", rs1.getString("TwoChars"));
-			assertEquals("Column 2 value is wrong", "A", rs1.getString("OneChar"));
-			assertEquals("Column 3 value is wrong", "CCC",rs1.getString("ThreeChars"));
-			assertEquals("Column 4 value is wrong", "D", rs1.getString("YetAnotherOneChar"));
+			assertEquals("BB", rs1.getString("TwoChars"), "Column 1 value is wrong");
+			assertEquals("A", rs1.getString("OneChar"), "Column 2 value is wrong");
+			assertEquals("CCC",rs1.getString("ThreeChars"), "Column 3 value is wrong");
+			assertEquals("D", rs1.getString("YetAnotherOneChar"), "Column 4 value is wrong");
 
 			assertTrue(rs1.next());
-			assertEquals("Column 1 value is wrong", "22", rs1.getString(1));
-			assertEquals("Column 2 value is wrong", "1", rs1.getString(2));
-			assertEquals("Column 3 value is wrong", "333", rs1.getString(3));
-			assertEquals("Column 4 value is wrong", "4", rs1.getString(4));
+			assertEquals("22", rs1.getString(1), "Column 1 value is wrong");
+			assertEquals("1", rs1.getString(2), "Column 2 value is wrong");
+			assertEquals("333", rs1.getString(3), "Column 3 value is wrong");
+			assertEquals("4", rs1.getString(4), "Column 4 value is wrong");
 
 			assertTrue(rs1.next());
 		}
@@ -292,16 +292,16 @@ public class TestFixedWidthFiles
 			ResultSet rs1 = stmt.executeQuery("SELECT * FROM single-char-cols-fixed"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("Column 1 value is wrong", "BB", rs1.getString("Column1"));
-			assertEquals("Column 2 value is wrong", "A", rs1.getString("Column2"));
-			assertEquals("Column 3 value is wrong", "CCC",rs1.getString("Column3"));
-			assertEquals("Column 4 value is wrong", "D", rs1.getString("Column4"));
+			assertEquals("BB", rs1.getString("Column1"), "Column 1 value is wrong");
+			assertEquals("A", rs1.getString("Column2"), "Column 2 value is wrong");
+			assertEquals("CCC",rs1.getString("Column3"), "Column 3 value is wrong");
+			assertEquals("D", rs1.getString("Column4"), "Column 4 value is wrong");
 
 			assertTrue(rs1.next());
-			assertEquals("Column 1 value is wrong", "22", rs1.getString(1));
-			assertEquals("Column 2 value is wrong", "1", rs1.getString(2));
-			assertEquals("Column 3 value is wrong", "333", rs1.getString(3));
-			assertEquals("Column 4 value is wrong", "4", rs1.getString(4));
+			assertEquals("22", rs1.getString(1), "Column 1 value is wrong");
+			assertEquals("1", rs1.getString(2), "Column 2 value is wrong");
+			assertEquals("333", rs1.getString(3), "Column 3 value is wrong");
+			assertEquals("4", rs1.getString(4), "Column 4 value is wrong");
 
 			assertTrue(rs1.next());
 		}

--- a/src/test/java/org/relique/jdbc/csv/TestGroupBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestGroupBy.java
@@ -18,14 +18,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.File;
 import java.sql.*;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests use of SQL GROUP BY clause.
@@ -34,13 +39,13 @@ public class TestGroupBy
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -71,13 +76,13 @@ public class TestGroupBy
 				.executeQuery("select TO_BLZ from transactions group by TO_BLZ"))
 		{
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertEquals(10020500, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
+			assertEquals(10010424, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
+			assertEquals(10020400, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
+			assertEquals(10010010, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -101,26 +106,26 @@ public class TestGroupBy
 				.executeQuery("select TRANS_DATE, TO_BLZ from transactions group by TRANS_DATE, TO_BLZ"))
 		{
 			assertTrue(results.next());
-			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-19"), results.getDate("TRANS_DATE"));
-			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertEquals(Date.valueOf("2011-10-19"), results.getDate("TRANS_DATE"), "The TRANS_DATE is wrong");
+			assertEquals(10020500, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-21"), results.getDate("TRANS_DATE"));
-			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertEquals(Date.valueOf("2011-10-21"), results.getDate("TRANS_DATE"), "The TRANS_DATE is wrong");
+			assertEquals(10020500, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-21"), results.getDate("TRANS_DATE"));
-			assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
+			assertEquals(Date.valueOf("2011-10-21"), results.getDate("TRANS_DATE"), "The TRANS_DATE is wrong");
+			assertEquals(10010424, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-24"), results.getDate("TRANS_DATE"));
-			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertEquals(Date.valueOf("2011-10-24"), results.getDate("TRANS_DATE"), "The TRANS_DATE is wrong");
+			assertEquals(10020500, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-27"), results.getDate("TRANS_DATE"));
-			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
+			assertEquals(Date.valueOf("2011-10-27"), results.getDate("TRANS_DATE"), "The TRANS_DATE is wrong");
+			assertEquals(10020500, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-28"), results.getDate("TRANS_DATE"));
-			assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
+			assertEquals(Date.valueOf("2011-10-28"), results.getDate("TRANS_DATE"), "The TRANS_DATE is wrong");
+			assertEquals(10020400, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The TRANS_DATE is wrong", Date.valueOf("2011-10-31"), results.getDate("TRANS_DATE"));
-			assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
+			assertEquals(Date.valueOf("2011-10-31"), results.getDate("TRANS_DATE"), "The TRANS_DATE is wrong");
+			assertEquals(10010010, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -153,13 +158,13 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select ID from sample4 GROUP BY ID"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertEquals("01", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertEquals("02", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "03", results.getString("ID"));
+			assertEquals("03", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertEquals("04", results.getString("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -177,11 +182,11 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select Job from sample5 WHERE ID >= 5 GROUP BY Job"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Piloto", results.getString("Job"));
+			assertEquals("Piloto", results.getString("Job"), "The Job is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Office Manager", results.getString("Job"));
+			assertEquals("Office Manager", results.getString("Job"), "The Job is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Office Employee", results.getString("Job"));
+			assertEquals("Office Employee", results.getString("Job"), "The Job is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -198,9 +203,9 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select Job from sample4 GROUP BY Job ORDER BY Job"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertEquals("Finance Manager", results.getString("Job"), "The Job is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
+			assertEquals("Project Manager", results.getString("Job"), "The Job is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -223,17 +228,17 @@ public class TestGroupBy
 				.executeQuery("select TO_BLZ, COUNT(TO_BLZ) AS N from transactions group by TO_BLZ"))
 		{
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-			assertEquals("The COUNT is wrong", 5, results.getInt("N"));
+			assertEquals(10020500, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
+			assertEquals(5, results.getInt("N"), "The COUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
-			assertEquals("The COUNT is wrong", 2, results.getInt("N"));
+			assertEquals(10010424, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
+			assertEquals(2, results.getInt("N"), "The COUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
-			assertEquals("The COUNT is wrong", 1, results.getInt("N"));
+			assertEquals(10020400, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
+			assertEquals(1, results.getInt("N"), "The COUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
-			assertEquals("The COUNT is wrong", 1, results.getInt("N"));
+			assertEquals(10010010, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
+			assertEquals(1, results.getInt("N"), "The COUNT is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -251,14 +256,14 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select NAME, count(*) from scores group by NAME"))
 		{
 			assertTrue(results.next());
-			assertEquals("The NAME is wrong", "Daniel", results.getString(1));
-			assertEquals("The COUNT is wrong", 3, results.getInt(2));
+			assertEquals("Daniel", results.getString(1), "The NAME is wrong");
+			assertEquals(3, results.getInt(2), "The COUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The NAME is wrong", "Mark", results.getString(1));
-			assertEquals("The COUNT is wrong", 3, results.getInt(2));
+			assertEquals("Mark", results.getString(1), "The NAME is wrong");
+			assertEquals(3, results.getInt(2), "The COUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The NAME is wrong", "Maria", results.getString(1));
-			assertEquals("The COUNT is wrong", 3, results.getInt(2));
+			assertEquals("Maria", results.getString(1), "The NAME is wrong");
+			assertEquals(3, results.getInt(2), "The COUNT is wrong");
 		}
 	}
 
@@ -274,14 +279,14 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select NAME, COUNT(NULLIF(SCORE, 'NA')) FROM scores GROUP BY NAME"))
 		{
 			assertTrue(results.next());
-			assertEquals("The NAME is wrong", "Daniel", results.getString(1));
-			assertEquals("The COUNT is wrong", 2, results.getInt(2));
+			assertEquals("Daniel", results.getString(1), "The NAME is wrong");
+			assertEquals(2, results.getInt(2), "The COUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The NAME is wrong", "Mark", results.getString(1));
-			assertEquals("The COUNT is wrong", 3, results.getInt(2));
+			assertEquals("Mark", results.getString(1), "The NAME is wrong");
+			assertEquals(3, results.getInt(2), "The COUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The NAME is wrong", "Maria", results.getString(1));
-			assertEquals("The COUNT is wrong", 1, results.getInt(2));
+			assertEquals("Maria", results.getString(1), "The NAME is wrong");
+			assertEquals(1, results.getInt(2), "The COUNT is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -312,21 +317,21 @@ public class TestGroupBy
 				.executeQuery("select TO_BLZ, MIN(AMOUNT) AS MIN_AMOUNT, MAX(AMOUNT) AS MAX_AMOUNT from transactions group by TO_BLZ"))
 		{
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10020500, results.getInt("TO_BLZ"));
-			assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(21.23, results.getDouble("MIN_AMOUNT")));
-			assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(250.00, results.getDouble("MAX_AMOUNT")));
+			assertEquals(10020500, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
+			assertTrue(fuzzyEquals(21.23, results.getDouble("MIN_AMOUNT")), "The MIN_AMOUNT is wrong");
+			assertTrue(fuzzyEquals(250.00, results.getDouble("MAX_AMOUNT")), "The MAX_AMOUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10010424, results.getInt("TO_BLZ"));
-			assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(460.00, results.getDouble("MIN_AMOUNT")));
-			assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(999.00, results.getDouble("MAX_AMOUNT")));
+			assertEquals(10010424, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
+			assertTrue(fuzzyEquals(460.00, results.getDouble("MIN_AMOUNT")), "The MIN_AMOUNT is wrong");
+			assertTrue(fuzzyEquals(999.00, results.getDouble("MAX_AMOUNT")), "The MAX_AMOUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10020400, results.getInt("TO_BLZ"));
-			assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(1012.74, results.getDouble("MIN_AMOUNT")));
-			assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(1012.74, results.getDouble("MAX_AMOUNT")));
+			assertEquals(10020400, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
+			assertTrue(fuzzyEquals(1012.74, results.getDouble("MIN_AMOUNT")), "The MIN_AMOUNT is wrong");
+			assertTrue(fuzzyEquals(1012.74, results.getDouble("MAX_AMOUNT")), "The MAX_AMOUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The TO_BLZ is wrong", 10010010, results.getInt("TO_BLZ"));
-			assertTrue("The MIN_AMOUNT is wrong", fuzzyEquals(7.23, results.getDouble("MIN_AMOUNT")));
-			assertTrue("The MAX_AMOUNT is wrong", fuzzyEquals(7.23, results.getDouble("MAX_AMOUNT")));
+			assertEquals(10010010, results.getInt("TO_BLZ"), "The TO_BLZ is wrong");
+			assertTrue(fuzzyEquals(7.23, results.getDouble("MIN_AMOUNT")), "The MIN_AMOUNT is wrong");
+			assertTrue(fuzzyEquals(7.23, results.getDouble("MAX_AMOUNT")), "The MAX_AMOUNT is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -341,11 +346,11 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select Job, string_agg(Name, ';') from sample4 GROUP BY Job"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Project Manager", results.getString(1));
-			assertEquals("The string_agg is wrong", "Juan Pablo Morales;Mauricio Hernandez;Felipe Grajales", results.getString(2));
+			assertEquals("Project Manager", results.getString(1), "The Job is wrong");
+			assertEquals("Juan Pablo Morales;Mauricio Hernandez;Felipe Grajales", results.getString(2), "The string_agg is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Finance Manager", results.getString(1));
-			assertEquals("The string_agg is wrong", "Maria Cristina Lucero", results.getString(2));
+			assertEquals("Finance Manager", results.getString(1), "The Job is wrong");
+			assertEquals("Maria Cristina Lucero", results.getString(2), "The string_agg is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -358,14 +363,13 @@ public class TestGroupBy
 			 ResultSet results = stmt.executeQuery("select Job, ARRAY_AGG(Name) from sample4 GROUP BY Job"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Project Manager", results.getString(1));
+			assertEquals("Project Manager", results.getString(1), "The Job is wrong");
 			Array array = results.getArray(2);
 			assertNotNull(array);
 			Object[] data = (Object[]) array.getArray();
 			assertEquals(3, data.length);
-			assertArrayEquals("The array is wrong",
-					new String[]{ "Juan Pablo Morales", "Mauricio Hernandez","Felipe Grajales"},
-					data);
+			assertArrayEquals(new String[]{ "Juan Pablo Morales", "Mauricio Hernandez","Felipe Grajales"},
+				data, "The array is wrong");
 		}
 	}
 
@@ -383,11 +387,11 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select Job, COUNT(Job) C from sample4 GROUP BY Job ORDER BY C DESC"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
-			assertEquals("The COUNT is wrong", 3, results.getInt("C"));
+			assertEquals("Project Manager", results.getString("Job"), "The Job is wrong");
+			assertEquals(3, results.getInt("C"), "The COUNT is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
-			assertEquals("The COUNT is wrong", 1, results.getInt("C"));
+			assertEquals("Finance Manager", results.getString("Job"), "The Job is wrong");
+			assertEquals(1, results.getInt("C"), "The COUNT is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -404,9 +408,9 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select Job from sample4 GROUP BY 1"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
+			assertEquals("Project Manager", results.getString("Job"), "The Job is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertEquals("Finance Manager", results.getString("Job"), "The Job is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -423,9 +427,9 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select Job from sample4 T GROUP BY T.Job"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
+			assertEquals("Project Manager", results.getString("Job"), "The Job is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertEquals("Finance Manager", results.getString("Job"), "The Job is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -449,13 +453,13 @@ public class TestGroupBy
 				.executeQuery("select FROM_ACCT + '/' + FROM_BLZ as KEY from transactions group by KEY"))
 		{
 			assertTrue(results.next());
-			assertEquals("The KEY is wrong", "3670345/10010010", results.getString("KEY"));
+			assertEquals("3670345/10010010", results.getString("KEY"), "The KEY is wrong");
 			assertTrue(results.next());
-			assertEquals("The KEY is wrong", "97540210/10020500", results.getString("KEY"));
+			assertEquals("97540210/10020500", results.getString("KEY"), "The KEY is wrong");
 			assertTrue(results.next());
-			assertEquals("The KEY is wrong", "58340576/10010010", results.getString("KEY"));
+			assertEquals("58340576/10010010", results.getString("KEY"), "The KEY is wrong");
 			assertTrue(results.next());
-			assertEquals("The KEY is wrong", "2340529/10020200", results.getString("KEY"));
+			assertEquals("2340529/10020200", results.getString("KEY"), "The KEY is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -472,11 +476,11 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select Job + '/' C1, 7 C2 from sample4 GROUP BY Job"))
 		{
 			assertTrue(results.next());
-			assertEquals("The C1 is wrong", "Project Manager/", results.getString("C1"));
-			assertEquals("The C2 is wrong", "7", results.getString("C2"));
+			assertEquals("Project Manager/", results.getString("C1"), "The C1 is wrong");
+			assertEquals("7", results.getString("C2"), "The C2 is wrong");
 			assertTrue(results.next());
-			assertEquals("The C1 is wrong", "Finance Manager/", results.getString("C1"));
-			assertEquals("The C2 is wrong", "7", results.getString("C2"));
+			assertEquals("Finance Manager/", results.getString("C1"), "The C1 is wrong");
+			assertEquals("7", results.getString("C2"), "The C2 is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -553,9 +557,9 @@ public class TestGroupBy
 				.executeQuery("select FROM_BLZ from transactions group by FROM_BLZ having FROM_BLZ > 10020000"))
 		{
 			assertTrue(results.next());
-			assertEquals("The FROM_BLZ is wrong", 10020500, results.getInt("FROM_BLZ"));
+			assertEquals(10020500, results.getInt("FROM_BLZ"), "The FROM_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The FROM_BLZ is wrong", 10020200, results.getInt("FROM_BLZ"));
+			assertEquals(10020200, results.getInt("FROM_BLZ"), "The FROM_BLZ is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -573,11 +577,11 @@ public class TestGroupBy
 				.executeQuery("select Job from sample5 group by Job having COUNT(Job) = 1"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Piloto", results.getString("Job"));
+			assertEquals("Piloto", results.getString("Job"), "The Job is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Finance Manager", results.getString("Job"));
+			assertEquals("Finance Manager", results.getString("Job"), "The Job is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Office Manager", results.getString("Job"));
+			assertEquals("Office Manager", results.getString("Job"), "The Job is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -595,11 +599,11 @@ public class TestGroupBy
 				.executeQuery("select Job, COUNT(Job) from sample5 group by Job having COUNT(Job) > 1"))
 		{
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Project Manager", results.getString("Job"));
-			assertEquals("The COUNT(Job) is wrong", 3, results.getInt(2));
+			assertEquals("Project Manager", results.getString("Job"), "The Job is wrong");
+			assertEquals(3, results.getInt(2), "The COUNT(Job) is wrong");
 			assertTrue(results.next());
-			assertEquals("The Job is wrong", "Office Employee", results.getString("Job"));
-			assertEquals("The COUNT(Job) is wrong", 4, results.getInt(2));
+			assertEquals("Office Employee", results.getString("Job"), "The Job is wrong");
+			assertEquals(4, results.getInt(2), "The COUNT(Job) is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -658,14 +662,14 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select FROM_BLZ, count(distinct FROM_ACCT) from transactions group by FROM_BLZ order by FROM_BLZ"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect FROM_BLZ", "10010010", results.getString(1));
-			assertEquals("Incorrect count FROM_ACCT", 2, results.getInt(2));
+			assertEquals("10010010", results.getString(1), "Incorrect FROM_BLZ");
+			assertEquals(2, results.getInt(2), "Incorrect count FROM_ACCT");
 			assertTrue(results.next());
-			assertEquals("Incorrect FROM_BLZ", "10020200", results.getString(1));
-			assertEquals("Incorrect count FROM_ACCT", 1, results.getInt(2));
+			assertEquals("10020200", results.getString(1), "Incorrect FROM_BLZ");
+			assertEquals(1, results.getInt(2), "Incorrect count FROM_ACCT");
 			assertTrue(results.next());
-			assertEquals("Incorrect FROM_BLZ", "10020500", results.getString(1));
-			assertEquals("Incorrect count FROM_ACCT", 1, results.getInt(2));
+			assertEquals("10020500", results.getString(1), "Incorrect FROM_BLZ");
+			assertEquals(1, results.getInt(2), "Incorrect count FROM_ACCT");
 			assertFalse(results.next());
 		}
 	}
@@ -684,17 +688,17 @@ public class TestGroupBy
 			ResultSet results = stmt.executeQuery("select CampaignNo, sum(distinct PurchaseCt), round(avg(distinct PurchaseCt)*10) from Purchase group by CampaignNo order by CampaignNo"))
 		{
 			assertTrue(results.next());
-			assertEquals("Incorrect CampaignNo", 1, results.getInt(1));
-			assertEquals("Incorrect sum PurchaseCt", 4 + 1 + 11, results.getInt(2));
-			assertEquals("Incorrect avg PurchaseCt", Math.round((4 + 1 + 11) / 3.0 * 10), results.getInt(3));
+			assertEquals(1, results.getInt(1), "Incorrect CampaignNo");
+			assertEquals(4 + 1 + 11, results.getInt(2), "Incorrect sum PurchaseCt");
+			assertEquals(Math.round((4 + 1 + 11) / 3.0 * 10), results.getInt(3), "Incorrect avg PurchaseCt");
 			assertTrue(results.next());
-			assertEquals("Incorrect CampaignNo", 21, results.getInt(1));
-			assertEquals("Incorrect sum PurchaseCt", 1 + 3, results.getInt(2));
-			assertEquals("Incorrect avg PurchaseCt", Math.round((1 + 3) / 2.0 * 10), results.getInt(3));
+			assertEquals(21, results.getInt(1), "Incorrect CampaignNo");
+			assertEquals(1 + 3, results.getInt(2), "Incorrect sum PurchaseCt");
+			assertEquals(Math.round((1 + 3) / 2.0 * 10), results.getInt(3), "Incorrect avg PurchaseCt");
 			assertTrue(results.next());
-			assertEquals("Incorrect CampaignNo", 61, results.getInt(1));
-			assertEquals("Incorrect sum PurchaseCt", 4, results.getInt(2));
-			assertEquals("Incorrect avg PurchaseCt", 4 * 10, results.getInt(3));
+			assertEquals(61, results.getInt(1), "Incorrect CampaignNo");
+			assertEquals(4, results.getInt(2), "Incorrect sum PurchaseCt");
+			assertEquals(4 * 10, results.getInt(3), "Incorrect avg PurchaseCt");
 			assertFalse(results.next());
 		}
 	}

--- a/src/test/java/org/relique/jdbc/csv/TestJoinedTables.java
+++ b/src/test/java/org/relique/jdbc/csv/TestJoinedTables.java
@@ -18,10 +18,10 @@
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -31,21 +31,21 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestJoinedTables
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -82,7 +82,7 @@ public class TestJoinedTables
 
 			ResultSet results = stmt.executeQuery("SELECT * FROM twojoinedtables01"))
 		{
-			assertTrue("there should be results", results.next());
+			assertTrue(results.next(), "there should be results");
 			assertEquals("l1", results.getObject("L"));
 			assertEquals("p1", results.getObject("P"));
 			assertEquals("k1", results.getObject("K"));
@@ -92,7 +92,7 @@ public class TestJoinedTables
 			assertEquals("t1", results.getObject("T"));
 			assertEquals("v11", results.getObject("V"));
 
-			assertTrue("there should be results", results.next());
+			assertTrue(results.next(), "there should be results");
 			assertEquals("l2", results.getObject("L"));
 			assertEquals("p2", results.getObject("P"));
 			assertEquals("k2", results.getObject("K"));
@@ -518,7 +518,7 @@ public class TestJoinedTables
 	}
 
 	@Test
-	@Ignore
+	@Disabled
 	public void donttestHeaderLooksLikeHeaderIndexedDifferentLength() throws SQLException
 	{
 		Properties props = new Properties();

--- a/src/test/java/org/relique/jdbc/csv/TestLimitOffset.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLimitOffset.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -31,8 +31,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class tests SQL LIMIT OFFSET keywords in the CsvJdbc driver.
@@ -41,13 +41,13 @@ public class TestLimitOffset
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -74,13 +74,13 @@ public class TestLimitOffset
 				.executeQuery("select id from sample5 limit 4"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertEquals(41, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 1, results.getInt("ID"));
+			assertEquals(1, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertEquals(2, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertEquals(3, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -99,13 +99,13 @@ public class TestLimitOffset
 				.executeQuery("select id from sample4 limit 999"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 1, results.getInt("ID"));
+			assertEquals(1, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertEquals(2, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertEquals(3, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 4, results.getInt("ID"));
+			assertEquals(4, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -124,11 +124,11 @@ public class TestLimitOffset
 				.executeQuery("select id from sample5 where id > 6 limit 3"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertEquals(41, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 7, results.getInt("ID"));
+			assertEquals(7, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertEquals(8, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -147,9 +147,9 @@ public class TestLimitOffset
 				.executeQuery("select id, name from sample5 order by id desc limit 2"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertEquals(41, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 9, results.getInt("ID"));
+			assertEquals(9, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -168,9 +168,9 @@ public class TestLimitOffset
 				.executeQuery("select id from sample5 limit 9 offset 8"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertEquals(8, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 9, results.getInt("ID"));
+			assertEquals(9, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -206,11 +206,11 @@ public class TestLimitOffset
 				.executeQuery("select id from sample5 where id > 2 limit 3 offset 4"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 6, results.getInt("ID"));
+			assertEquals(6, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 7, results.getInt("ID"));
+			assertEquals(7, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertEquals(8, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -229,15 +229,15 @@ public class TestLimitOffset
 				.executeQuery("select * from sample5 order by id limit 99 offset 5"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 6, results.getInt("ID"));
+			assertEquals(6, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 7, results.getInt("ID"));
+			assertEquals(7, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertEquals(8, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 9, results.getInt("ID"));
+			assertEquals(9, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertEquals(41, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}

--- a/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
+++ b/src/test/java/org/relique/jdbc/csv/TestOrderBy.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -31,8 +31,8 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests use of SQL ORDER BY clause.
@@ -41,13 +41,13 @@ public class TestOrderBy
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -79,35 +79,35 @@ public class TestOrderBy
 				.executeQuery("SELECT * FROM banks ORDER BY BANK_NAME"))
 		{
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10010424, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "Aareal Bank (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10010424, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("Aareal Bank (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10020200, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "BHF-BANK (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10020200, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("BHF-BANK (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10020500, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10020500, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("Bank f\u00FCr Sozialwirtschaft (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10020000, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "Berliner Bank -alt- (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10020000, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("Berliner Bank -alt- (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10000000, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "Bundesbank (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10000000, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("Bundesbank (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10020400, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "Citadele Bank Zndl Deutschland (M\u00FCnchen)", results.getString("BANK_NAME"));
+			assertEquals(10020400, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("Citadele Bank Zndl Deutschland (M\u00FCnchen)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10019610, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "Dexia Kommunalbank Deutschland (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10019610, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("Dexia Kommunalbank Deutschland (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10010010, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "Postbank (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10010010, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("Postbank (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10010111, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "SEB (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10010111, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("SEB (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10010222, results.getInt("BLZ"));
-			assertEquals("The BLZ_NAME is wrong", "The Royal Bank of Scotland, Niederlassung Deutschland (Berlin)", results.getString("BANK_NAME"));
+			assertEquals(10010222, results.getInt("BLZ"), "The BLZ is wrong");
+			assertEquals("The Royal Bank of Scotland, Niederlassung Deutschland (Berlin)", results.getString("BANK_NAME"), "The BLZ_NAME is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -126,25 +126,25 @@ public class TestOrderBy
 				.executeQuery("SELECT * FROM sample5 ORDER BY 1"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 1, results.getInt("ID"));
+			assertEquals(1, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 2, results.getInt("ID"));
+			assertEquals(2, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 3, results.getInt("ID"));
+			assertEquals(3, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 4, results.getInt("ID"));
+			assertEquals(4, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 5, results.getInt("ID"));
+			assertEquals(5, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 6, results.getInt("ID"));
+			assertEquals(6, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 7, results.getInt("ID"));
+			assertEquals(7, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 8, results.getInt("ID"));
+			assertEquals(8, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 9, results.getInt("ID"));
+			assertEquals(9, results.getInt("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 41, results.getInt("ID"));
+			assertEquals(41, results.getInt("ID"), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -163,9 +163,9 @@ public class TestOrderBy
 				.executeQuery("SELECT ID+10 AS ID10 FROM sample5 ORDER BY 1"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 11, results.getInt("ID10"));
+			assertEquals(11, results.getInt("ID10"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 12, results.getInt("ID10"));
+			assertEquals(12, results.getInt("ID10"), "The ID is wrong");
 			assertTrue(results.next());
 		}
 	}
@@ -188,25 +188,25 @@ public class TestOrderBy
 				.executeQuery("SELECT BLZ FROM banks ORDER BY BLZ DESC"))
 		{
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10020500, results.getInt(1));
+			assertEquals(10020500, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10020400, results.getInt(1));
+			assertEquals(10020400, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10020200, results.getInt(1));
+			assertEquals(10020200, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10020000, results.getInt(1));
+			assertEquals(10020000, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10019610, results.getInt(1));
+			assertEquals(10019610, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10010424, results.getInt(1));
+			assertEquals(10010424, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10010222, results.getInt(1));
+			assertEquals(10010222, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10010111, results.getInt(1));
+			assertEquals(10010111, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10010010, results.getInt(1));
+			assertEquals(10010010, results.getInt(1), "The BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The BLZ is wrong", 10000000, results.getInt(1));
+			assertEquals(10000000, results.getInt(1), "The BLZ is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -229,32 +229,32 @@ public class TestOrderBy
 				.executeQuery("select * from transactions order by from_blz, from_acct"))
 		{
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
+			assertEquals(10010010, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(3670345, results.getInt("from_acct"), "The from_acct is wrong");
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
+			assertEquals(10010010, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(3670345, results.getInt("from_acct"), "The from_acct is wrong");
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
+			assertEquals(10010010, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(3670345, results.getInt("from_acct"), "The from_acct is wrong");
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 3670345, results.getInt("from_acct"));
+			assertEquals(10010010, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(3670345, results.getInt("from_acct"), "The from_acct is wrong");
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10010010, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 58340576, results.getInt("from_acct"));
+			assertEquals(10010010, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(58340576, results.getInt("from_acct"), "The from_acct is wrong");
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10020200, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 2340529, results.getInt("from_acct"));
+			assertEquals(10020200, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(2340529, results.getInt("from_acct"), "The from_acct is wrong");
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
+			assertEquals(10020500, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(97540210, results.getInt("from_acct"), "The from_acct is wrong");
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
+			assertEquals(10020500, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(97540210, results.getInt("from_acct"), "The from_acct is wrong");
 			assertTrue(results.next());
-			assertEquals("The from_blz is wrong", 10020500, results.getInt("from_blz"));
-			assertEquals("The from_acct is wrong", 97540210, results.getInt("from_acct"));
+			assertEquals(10020500, results.getInt("from_blz"), "The from_blz is wrong");
+			assertEquals(97540210, results.getInt("from_acct"), "The from_acct is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -277,14 +277,14 @@ public class TestOrderBy
 				.executeQuery("SELECT FROM_ACCT, FROM_BLZ from transactions where AMOUNT < 50 ORDER BY AMOUNT"))
 		{
 			assertTrue(results.next());
-			assertEquals("The FROM_ACCT is wrong", 97540210, results.getInt("FROM_ACCT"));
-			assertEquals("The FROM_BLZ is wrong", 10020500, results.getInt("FROM_BLZ"));
+			assertEquals(97540210, results.getInt("FROM_ACCT"), "The FROM_ACCT is wrong");
+			assertEquals(10020500, results.getInt("FROM_BLZ"), "The FROM_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt("FROM_ACCT"));
-			assertEquals("The FROM_BLZ is wrong", 10010010, results.getInt("FROM_BLZ"));
+			assertEquals(3670345, results.getInt("FROM_ACCT"), "The FROM_ACCT is wrong");
+			assertEquals(10010010, results.getInt("FROM_BLZ"), "The FROM_BLZ is wrong");
 			assertTrue(results.next());
-			assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt("FROM_ACCT"));
-			assertEquals("The FROM_BLZ is wrong", 10010010, results.getInt("FROM_BLZ"));
+			assertEquals(3670345, results.getInt("FROM_ACCT"), "The FROM_ACCT is wrong");
+			assertEquals(10010010, results.getInt("FROM_BLZ"), "The FROM_BLZ is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -315,13 +315,13 @@ public class TestOrderBy
 				.executeQuery("SELECT FROM_ACCT, AMOUNT * 0.01 as FEE from transactions ORDER BY FEE"))
 		{
 			assertTrue(results.next());
-			assertEquals("The FROM_ACCT is wrong", 97540210, results.getInt(1));
+			assertEquals(97540210, results.getInt(1), "The FROM_ACCT is wrong");
 			double fee = results.getDouble(2);
-			assertTrue("The FEE is wrong", fuzzyEquals(7.23 * 0.01, fee));
+			assertTrue(fuzzyEquals(7.23 * 0.01, fee), "The FEE is wrong");
 			assertTrue(results.next());
-			assertEquals("The FROM_ACCT is wrong", 3670345, results.getInt(1));
+			assertEquals(3670345, results.getInt(1), "The FROM_ACCT is wrong");
 			fee = results.getDouble(2);
-			assertTrue("The FEE is wrong", fuzzyEquals(21.23 * 0.01, fee));
+			assertTrue(fuzzyEquals(21.23 * 0.01, fee), "The FEE is wrong");
 		}
 	}
 
@@ -345,11 +345,11 @@ public class TestOrderBy
 			assertTrue(results.next());
 			double a0 = results.getFloat("AI007.000");
 			double a1 = results.getFloat("AI007.001");
-			assertTrue("The sort order is wrong", fuzzyEquals(26.54, a0 + a1));
+			assertTrue(fuzzyEquals(26.54, a0 + a1), "The sort order is wrong");
 			assertTrue(results.next());
 			a0 = results.getFloat("AI007.000");
 			a1 = results.getFloat("AI007.001");
-			assertTrue("The sort order is wrong", fuzzyEquals(26.54, a0 + a1));
+			assertTrue(fuzzyEquals(26.54, a0 + a1), "The sort order is wrong");
 		}
 	}
 
@@ -369,25 +369,25 @@ public class TestOrderBy
 				.executeQuery("select * from sample5 order by start+timeoffset asc"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 1, results.getInt(1));
+			assertEquals(1, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 41, results.getInt(1));
+			assertEquals(41, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 2, results.getInt(1));
+			assertEquals(2, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 3, results.getInt(1));
+			assertEquals(3, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 7, results.getInt(1));
+			assertEquals(7, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 8, results.getInt(1));
+			assertEquals(8, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 4, results.getInt(1));
+			assertEquals(4, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 5, results.getInt(1));
+			assertEquals(5, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 6, results.getInt(1));
+			assertEquals(6, results.getInt(1), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", 9, results.getInt(1));
+			assertEquals(9, results.getInt(1), "The ID is wrong");
 			assertFalse(results.next());
 		}
 	}

--- a/src/test/java/org/relique/jdbc/csv/TestPrepareStatement.java
+++ b/src/test/java/org/relique/jdbc/csv/TestPrepareStatement.java
@@ -18,11 +18,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -32,8 +32,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class is used to test the CsvJdbc driver.
@@ -44,13 +44,13 @@ public class TestPrepareStatement
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -101,11 +101,11 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(1), results.getObject("id"));
+				assertEquals(Integer.valueOf(1), results.getObject("id"), "Integer column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(2), results.getObject("id"));
+				assertEquals(Integer.valueOf(2), results.getObject("id"), "Integer column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(3), results.getObject("id"));
+				assertEquals(Integer.valueOf(3), results.getObject("id"), "Integer column ID is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -122,7 +122,7 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("Column EXTRA_FIELD is wrong", "A", results.getString("EXTRA_FIELD"));
+				assertEquals("A", results.getString("EXTRA_FIELD"), "Column EXTRA_FIELD is wrong");
 				conn.close();
 				assertTrue(prepstmt.isClosed());
 			}
@@ -143,7 +143,7 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("Column Job is wrong", "Finance Manager", results.getString("Job"));
+				assertEquals("Finance Manager", results.getString("Job"), "Column Job is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -168,7 +168,7 @@ public class TestPrepareStatement
 			ResultSet results = prepstmt.executeQuery();
 
 			assertTrue(results.next());
-			assertEquals("Column BANK_NAME is wrong", "BHF-BANK (Berlin)", results.getString("BANK_NAME"));
+			assertEquals("BHF-BANK (Berlin)", results.getString("BANK_NAME"), "Column BANK_NAME is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -186,7 +186,7 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("Column C5 is wrong", "0.0", results.getString("C5"));
+				assertEquals("0.0", results.getString("C5"), "Column C5 is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -205,7 +205,7 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("Column C6 is wrong", "-0.0", results.getString("C6"));
+				assertEquals("-0.0", results.getString("C6"), "Column C6 is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -224,7 +224,7 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("Column ID is wrong", 3, results.getInt("ID"));
+				assertEquals(3, results.getInt("ID"), "Column ID is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -255,7 +255,7 @@ public class TestPrepareStatement
 				{
 					assertTrue(results1.isClosed());
 					assertTrue(results2.next());
-					assertEquals("Integer column ID is wrong", Integer.valueOf(41), results2.getObject("id"));
+					assertEquals(Integer.valueOf(41), results2.getObject("id"), "Integer column ID is wrong");
 					assertFalse(results2.next());
 				}
 			}
@@ -276,11 +276,11 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(1), results.getObject("id"));
+				assertEquals(Integer.valueOf(1), results.getObject("id"), "Integer column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(3), results.getObject("id"));
+				assertEquals(Integer.valueOf(3), results.getObject("id"), "Integer column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(4), results.getObject("id"));
+				assertEquals(Integer.valueOf(4), results.getObject("id"), "Integer column ID is wrong");
 				assertFalse(results.next());
 			}
 
@@ -288,13 +288,13 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(6), results.getObject("id"));
+				assertEquals(Integer.valueOf(6), results.getObject("id"), "Integer column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(7), results.getObject("id"));
+				assertEquals(Integer.valueOf(7), results.getObject("id"), "Integer column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(8), results.getObject("id"));
+				assertEquals(Integer.valueOf(8), results.getObject("id"), "Integer column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("Integer column ID is wrong", Integer.valueOf(9), results.getObject("id"));
+				assertEquals(Integer.valueOf(9), results.getObject("id"), "Integer column ID is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -330,7 +330,7 @@ public class TestPrepareStatement
 			try (ResultSet results = stmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("NAME wrong", "Paris Charles De Gaulle", results.getString("NAME"));
+				assertEquals("Paris Charles De Gaulle", results.getString("NAME"), "NAME wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -350,11 +350,11 @@ public class TestPrepareStatement
 			try (ResultSet results = prepstmt.executeQuery())
 			{
 				assertTrue(results.next());
-				assertEquals("column ID is wrong", 8, results.getInt("ID"));
+				assertEquals(8, results.getInt("ID"), "column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("column ID is wrong", 9, results.getInt("ID"));
+				assertEquals(9, results.getInt("ID"), "column ID is wrong");
 				assertTrue(results.next());
-				assertEquals("column ID is wrong", 41, results.getInt("ID"));
+				assertEquals(41, results.getInt("ID"), "column ID is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -374,9 +374,9 @@ public class TestPrepareStatement
 			assertTrue(prepstmt.execute());
 			try (ResultSet results = prepstmt.getResultSet())
 			{
-				assertNotNull("ResultSet is null", results);
+				assertNotNull(results, "ResultSet is null");
 				assertTrue(results.next());
-				assertEquals("column Job is wrong", "Finance Manager", results.getString("Job"));
+				assertEquals("Finance Manager", results.getString("Job"), "column Job is wrong");
 				assertFalse(results.next());
 				assertFalse(prepstmt.getMoreResults());
 			}
@@ -416,11 +416,11 @@ public class TestPrepareStatement
 
 			try (ResultSet results = prepstmt.executeQuery()) {
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 6, results.getInt("ID"));
+				assertEquals(6, results.getInt("ID"), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 7, results.getInt("ID"));
+				assertEquals(7, results.getInt("ID"), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 8, results.getInt("ID"));
+				assertEquals(8, results.getInt("ID"), "The ID is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -440,11 +440,11 @@ public class TestPrepareStatement
 
 			try (ResultSet results = prepstmt.executeQuery()) {
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 6, results.getInt("ID"));
+				assertEquals(6, results.getInt("ID"), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 7, results.getInt("ID"));
+				assertEquals(7, results.getInt("ID"), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 8, results.getInt("ID"));
+				assertEquals(8, results.getInt("ID"), "The ID is wrong");
 				assertFalse(results.next());
 			}
 		}
@@ -465,11 +465,11 @@ public class TestPrepareStatement
 
 			try (ResultSet results = prepstmt.executeQuery()) {
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 6, results.getInt("ID"));
+				assertEquals(6, results.getInt("ID"), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 7, results.getInt("ID"));
+				assertEquals(7, results.getInt("ID"), "The ID is wrong");
 				assertTrue(results.next());
-				assertEquals("The ID is wrong", 8, results.getInt("ID"));
+				assertEquals(8, results.getInt("ID"), "The ID is wrong");
 				assertFalse(results.next());
 			}
 		}

--- a/src/test/java/org/relique/jdbc/csv/TestScrollableDriver.java
+++ b/src/test/java/org/relique/jdbc/csv/TestScrollableDriver.java
@@ -18,11 +18,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -31,8 +31,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class is used to test the CsvJdbc Scrollable driver.
@@ -43,13 +43,13 @@ public class TestScrollableDriver
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -79,31 +79,31 @@ public class TestScrollableDriver
 		{
 			// dump out the results
 			results.next();
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "\"S,\"", results
-					.getString("NAME"));
-			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("\"S,\"", results.getString("NAME"),
+				"Incorrect NAME Value");
+			assertEquals(1, results.getRow(), "incorrect row #");
 
 			results.next();
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
-					.getString("NAME"));
-			assertEquals("incorrect row #", 2, results.getRow());
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Jonathan Ackerman", results.getString("NAME"),
+				"Incorrect NAME Value");
+			assertEquals(2, results.getRow(), "incorrect row #");
 
 			results.previous();
-			assertEquals("incorrect row #", 1, results.getRow());
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "\"S,\"", results
-					.getString("NAME"));
+			assertEquals(1, results.getRow(), "incorrect row #");
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("\"S,\"", results.getString("NAME"),
+				"Incorrect NAME Value");
 
 			results.first();
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "\"S,\"", results
-					.getString("NAME"));
-			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("\"S,\"", results.getString("NAME"),
+				"Incorrect NAME Value");
+			assertEquals(1, results.getRow(), "incorrect row #");
 
 			assertFalse(results.previous());
-			assertEquals("incorrect row #", 0, results.getRow());
+			assertEquals(0, results.getRow(), "incorrect row #");
 			try
 			{
 				results.getString("ID");
@@ -124,66 +124,64 @@ public class TestScrollableDriver
 			}
 
 			results.next();
-			assertEquals("incorrect row #", 1, results.getRow());
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "\"S,\"", results
-					.getString("NAME"));
+			assertEquals(1, results.getRow(), "incorrect row #");
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("\"S,\"", results.getString("NAME"),
+				"Incorrect NAME Value");
 
 			results.next();
-			assertEquals("incorrect row #", 2, results.getRow());
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
-					.getString("NAME"));
+			assertEquals(2, results.getRow(), "incorrect row #");
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Jonathan Ackerman", results.getString("NAME"),
+				"Incorrect NAME Value");
 
 			results.absolute(1);
-			assertEquals("incorrect row #", 1, results.getRow());
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "\"S,\"", results
-					.getString("NAME"));
+			assertEquals(1, results.getRow(), "incorrect row #");
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("\"S,\"", results.getString("NAME"),
+				"Incorrect NAME Value");
 
 			results.absolute(2);
-			assertEquals("incorrect row #", 2, results.getRow());
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Jonathan Ackerman", results
-					.getString("NAME"));
+			assertEquals(2, results.getRow(), "incorrect row #");
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Jonathan Ackerman", results.getString("NAME"),
+				"Incorrect NAME Value");
 
 			results.relative(2);
-			assertEquals("incorrect row #", 4, results.getRow());
-			assertEquals("Incorrect ID Value", "C456", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Susan, Peter and Dave", results
-					.getString("NAME"));
+			assertEquals(4, results.getRow(), "incorrect row #");
+			assertEquals("C456", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Susan, Peter and Dave", results.getString("NAME"),
+				"Incorrect NAME Value");
 
 			results.relative(-3);
-			assertEquals("incorrect row #", 1, results.getRow());
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "\"S,\"", results
-					.getString("NAME"));
+			assertEquals(1, results.getRow(), "incorrect row #");
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("\"S,\"", results.getString("NAME"),
+				"Incorrect NAME Value");
 
 			results.relative(0);
-			assertEquals("incorrect row #", 1, results.getRow());
-			assertEquals("Incorrect ID Value", "Q123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", results.getString("NAME"),
-					"\"S,\"");
+			assertEquals(1, results.getRow(), "incorrect row #");
+			assertEquals("Q123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals(results.getString("NAME"),	"\"S,\"",
+				"Incorrect NAME Value");
 
 			results.last();
-			assertEquals("incorrect row #", 6, results.getRow());
-			assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
-			assertEquals("Incorrect NAME Value",
-					"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
-							.getString("NAME"));
+			assertEquals(6, results.getRow(), "incorrect row #");
+			assertEquals("X234", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Peter \"peg leg\", Jimmy & Samantha \"Sam\"",
+				results.getString("NAME"), "Incorrect NAME Value");
 
 			results.absolute(-1);
-			assertEquals("incorrect row #", 6, results.getRow());
-			assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
-			assertEquals("Incorrect NAME Value",
-					"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
-							.getString("NAME"));
+			assertEquals(6, results.getRow(), "incorrect row #");
+			assertEquals("X234", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Peter \"peg leg\", Jimmy & Samantha \"Sam\"",
+				results.getString("NAME"), "Incorrect NAME Value");
 
 			results.absolute(-2);
-			assertEquals("incorrect row #", 5, results.getRow());
-			assertEquals("Incorrect ID Value", "D789", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Amelia \"meals\" Maurice",
-					results.getString("NAME"));
+			assertEquals(5, results.getRow(), "incorrect row #");
+			assertEquals("D789", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Amelia \"meals\" Maurice",
+					results.getString("NAME"), "Incorrect NAME Value");
 
 			results.last();
 			results.next();
@@ -191,18 +189,17 @@ public class TestScrollableDriver
 			assertNull(results.getString("NAME"));
 
 			results.previous();
-			assertEquals("Incorrect ID Value", "X234", results.getString("ID"));
-			assertEquals("Incorrect NAME Value",
-					"Peter \"peg leg\", Jimmy & Samantha \"Sam\"", results
-							.getString("NAME"));
+			assertEquals("X234", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Peter \"peg leg\", Jimmy & Samantha \"Sam\"",
+				results.getString("NAME"), "Incorrect NAME Value");
 
 			assertFalse(results.relative(100));
-			assertEquals("incorrect row #", 7, results.getRow());
+			assertEquals(7, results.getRow(), "incorrect row #");
 			assertNull(results.getString("ID"));
 			assertNull(results.getString("NAME"));
 
 			assertFalse(results.relative(-100));
-			assertEquals("incorrect row #", 0, results.getRow());
+			assertEquals(0, results.getRow(), "incorrect row #");
 			try
 			{
 				results.getString("ID");
@@ -224,18 +221,18 @@ public class TestScrollableDriver
 			}
 
 			results.relative(2);
-			assertEquals("incorrect row #", 2, results.getRow());
-			assertEquals("Incorrect ID Value", results.getString("ID"), "A123");
-			assertEquals("Incorrect NAME Value", results.getString("NAME"),
-					"Jonathan Ackerman");
+			assertEquals(2, results.getRow(), "incorrect row #");
+			assertEquals(results.getString("ID"), "A123", "Incorrect ID Value");
+			assertEquals(results.getString("NAME"),
+					"Jonathan Ackerman", "Incorrect NAME Value");
 
 			results.absolute(7);
-			assertEquals("incorrect row #", 7, results.getRow());
+			assertEquals(7, results.getRow(), "incorrect row #");
 			assertNull(results.getString("ID"));
 			assertNull(results.getString("NAME"));
 
 			assertFalse(results.absolute(-10));
-			assertEquals("incorrect row #", 0, results.getRow());
+			assertEquals(0, results.getRow(), "incorrect row #");
 			try
 			{
 				results.getString("ID");
@@ -257,9 +254,9 @@ public class TestScrollableDriver
 			}
 
 			results.absolute(2);
-			assertEquals("Incorrect ID Value", results.getString("ID"), "A123");
-			assertEquals("Incorrect NAME Value", results.getString("NAME"),
-					"Jonathan Ackerman");
+			assertEquals(results.getString("ID"), "A123", "Incorrect ID Value");
+			assertEquals(results.getString("NAME"),
+					"Jonathan Ackerman", "Incorrect NAME Value");
 
 			assertFalse(results.absolute(0));
 			try
@@ -322,57 +319,57 @@ public class TestScrollableDriver
 		{
 			// dump out the results
 			results.next();
-			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals(1, results.getRow(), "incorrect row #");
 			assertTrue(results.isFirst());
 			assertFalse(results.isLast());
 			assertFalse(results.isBeforeFirst());
 			assertFalse(results.isAfterLast());
 
 			results.next();
-			assertEquals("incorrect row #", 2, results.getRow());
+			assertEquals(2, results.getRow(), "incorrect row #");
 			assertFalse(results.isFirst());
 			assertFalse(results.isLast());
 
 			results.previous();
-			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals(1, results.getRow(), "incorrect row #");
 			assertTrue(results.isFirst());
 			assertFalse(results.isLast());
 
 			results.first();
-			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals(1, results.getRow(), "incorrect row #");
 			assertTrue(results.isFirst());
 			assertFalse(results.isLast());
 
 			results.previous();
-			assertEquals("incorrect row #", 0, results.getRow());
+			assertEquals(0, results.getRow(), "incorrect row #");
 			assertTrue(results.isBeforeFirst());
 			assertFalse(results.isAfterLast());
 			assertFalse(results.isFirst());
 			assertFalse(results.isLast());
 
 			results.next();
-			assertEquals("incorrect row #", 1, results.getRow());
+			assertEquals(1, results.getRow(), "incorrect row #");
 			assertTrue(results.isFirst());
 			assertFalse(results.isLast());
 
 			results.last();
-			assertEquals("incorrect row #", 6, results.getRow());
+			assertEquals(6, results.getRow(), "incorrect row #");
 			assertFalse(results.isFirst());
 			assertTrue(results.isLast());
 
 			results.absolute(-1);
-			assertEquals("incorrect row #", 6, results.getRow());
+			assertEquals(6, results.getRow(), "incorrect row #");
 			assertFalse(results.isBeforeFirst());
 			assertFalse(results.isAfterLast());
 			assertFalse(results.isFirst());
 			assertTrue(results.isLast());
 
 			results.afterLast();
-			assertEquals("incorrect row #", 7, results.getRow());
+			assertEquals(7, results.getRow(), "incorrect row #");
 			assertFalse(results.isBeforeFirst());
 			assertTrue(results.isAfterLast());
-			assertFalse("is seen as first", results.isFirst());
-			assertFalse("is seen as last", results.isLast());
+			assertFalse(results.isFirst(), "is seen as first");
+			assertFalse(results.isLast(), "is seen as last");
 		}
 	}
 
@@ -397,16 +394,16 @@ public class TestScrollableDriver
 		{
 			// dump out the results
 			results.next();
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Aman", results.getString("NAME"), "Incorrect NAME Value");
 
 			results.next();
-			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+			assertEquals("B223", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Binoy", results.getString("NAME"), "Incorrect NAME Value");
 
 			results.first();
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Aman", results.getString("NAME"), "Incorrect NAME Value");
 
 			assertFalse(results.previous());
 			try
@@ -429,53 +426,52 @@ public class TestScrollableDriver
 			}
 
 			results.next();
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Aman", results.getString("NAME"), "Incorrect NAME Value");
 
 			results.next();
-			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+			assertEquals("B223", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Binoy", results.getString("NAME"), "Incorrect NAME Value");
 
 			results.relative(2);
-			assertEquals("Incorrect ID Value", "D456", results.getString("ID"));
-			assertEquals("Incorrect NAME Value",
-					"Dilip \"meals\" Maurice\n ~In New  LIne~ \nDone", results
-							.getString("NAME"));
+			assertEquals("D456", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Dilip \"meals\" Maurice\n ~In New  LIne~ \nDone",
+				results.getString("NAME"), "Incorrect NAME Value");
 
 			results.relative(-3);
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Aman", results.getString("NAME"), "Incorrect NAME Value");
 
 			results.relative(0);
-			assertEquals("Incorrect ID Value", "A123", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Aman", results.getString("NAME"));
+			assertEquals("A123", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Aman", results.getString("NAME"), "Incorrect NAME Value");
 
 			results.absolute(2);
-			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+			assertEquals("B223", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Binoy", results.getString("NAME"), "Incorrect NAME Value");
 
 			results.absolute(-2);
-			assertEquals("Incorrect ID Value", "E589", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "\"Elephant\"", results
-					.getString("NAME"));
+			assertEquals("E589", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("\"Elephant\"", results.getString("NAME"),
+				"Incorrect NAME Value");
 
 			results.last();
-			assertEquals("Incorrect ID Value", "F634", results.getString("ID"));
+			assertEquals("F634", results.getString("ID"), "Incorrect ID Value");
 			assertEquals(
-					"Incorrect NAME Value",
 					"Fandu \"\"peg leg\"\", Jimmy & Samantha \n~In Another New  LIne~ \n\"\"Sam\"\"",
-					results.getString("NAME"));
+					results.getString("NAME"),
+					"Incorrect NAME Value");
 
 			results.next();
 			assertNull(results.getString("ID"));
 			assertNull(results.getString("NAME"));
 
 			results.previous();
-			assertEquals("Incorrect ID Value", "F634", results.getString("ID"));
+			assertEquals("F634", results.getString("ID"), "Incorrect ID Value");
 			assertEquals(
-					"Incorrect NAME Value",
 					"Fandu \"\"peg leg\"\", Jimmy & Samantha \n~In Another New  LIne~ \n\"\"Sam\"\"",
-					results.getString("NAME"));
+					results.getString("NAME"),
+					"Incorrect NAME Value");
 
 			results.relative(100);
 			assertNull(results.getString("ID"));
@@ -502,8 +498,8 @@ public class TestScrollableDriver
 			}
 
 			results.relative(2);
-			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+			assertEquals("B223", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Binoy", results.getString("NAME"), "Incorrect NAME Value");
 
 			results.absolute(7);
 			assertNull(results.getString("ID"));
@@ -530,8 +526,8 @@ public class TestScrollableDriver
 			}
 
 			results.absolute(2);
-			assertEquals("Incorrect ID Value", "B223", results.getString("ID"));
-			assertEquals("Incorrect NAME Value", "Binoy", results.getString("NAME"));
+			assertEquals("B223", results.getString("ID"), "Incorrect ID Value");
+			assertEquals("Binoy", results.getString("NAME"), "Incorrect NAME Value");
 
 			assertFalse(results.absolute(0));
 			try
@@ -593,7 +589,7 @@ public class TestScrollableDriver
 			ResultSet results = stmt
 				.executeQuery("SELECT ID,Name FROM sample4 WHERE ID='05'"))
 		{
-			assertFalse("There are some junk records found", results.next());
+			assertFalse(results.next(), "There are some junk records found");
 			assertFalse(results.last());
 			try
 			{
@@ -613,7 +609,7 @@ public class TestScrollableDriver
 			{
 				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
 			}
-			assertTrue("Is not last", results.isLast());
+			assertTrue(results.isLast(), "Is not last");
 			assertFalse(results.absolute(0));
 			try
 			{
@@ -633,12 +629,12 @@ public class TestScrollableDriver
 			{
 				assertEquals("java.sql.SQLException: " + CsvResources.getString("noCurrentRow"), "" + e);
 			}
-			assertTrue("Is not last", results.isLast());
+			assertTrue(results.isLast(), "Is not last");
 			assertFalse(results.absolute(0));
-			assertTrue("Is not before first", results.isBeforeFirst());
+			assertTrue(results.isBeforeFirst(), "Is not before first");
 			results.previous();
-			assertTrue("Is not before first", results.isBeforeFirst());
-			assertTrue("Is not last", results.isLast());
+			assertTrue(results.isBeforeFirst(), "Is not before first");
+			assertTrue(results.isLast(), "Is not last");
 			// Following throws exception
 			// assertTrue("Is not before first", results.isAfterLast());
 		}
@@ -662,29 +658,29 @@ public class TestScrollableDriver
 				.executeQuery("SELECT ID,Name FROM singlerecord"))
 		{
 			assertTrue(results.last());
-			assertEquals("Invalid Id", "A123", results.getString("ID"));
-			assertEquals("Invalid Name", "Jonathan Ackerman", results
-					.getString("NAME"));
+			assertEquals("A123", results.getString("ID"), "Invalid Id");
+			assertEquals("Jonathan Ackerman", results.getString("NAME"),
+				"Invalid Name");
 			results.absolute(1);
-			assertEquals("Invalid Id", "A123", results.getString("ID"));
-			assertEquals("Invalid Name", "Jonathan Ackerman", results
-					.getString("NAME"));
-			assertTrue("Is not last", results.isLast());
-			assertTrue("Is not first", results.isFirst());
+			assertEquals("A123", results.getString("ID"), "Invalid Id");
+			assertEquals("Jonathan Ackerman", results.getString("NAME"),
+				"Invalid Name");
+			assertTrue(results.isLast(), "Is not last");
+			assertTrue(results.isFirst(), "Is not first");
 			results.absolute(0);
-			assertTrue("Is not before first", results.isBeforeFirst());
+			assertTrue(results.isBeforeFirst(), "Is not before first");
 			results.previous();
-			assertTrue("Is not before first", results.isBeforeFirst());
+			assertTrue(results.isBeforeFirst(), "Is not before first");
 			assertTrue(results.next());
-			assertEquals("Invalid Id", "A123", results.getString("ID"));
-			assertEquals("Invalid Name", "Jonathan Ackerman", results
-					.getString("NAME"));
+			assertEquals("A123", results.getString("ID"), "Invalid Id");
+			assertEquals("Jonathan Ackerman", results.getString("NAME"),
+				"Invalid Name");
 			results.relative(1);
-			assertTrue("Is not after last", results.isAfterLast());
+			assertTrue(results.isAfterLast(), "Is not after last");
 			results.previous();
-			assertEquals("Invalid Id", "A123", results.getString("ID"));
-			assertEquals("Invalid Name", "Jonathan Ackerman", results
-					.getString("NAME"));
+			assertEquals("A123", results.getString("ID"), "Invalid Id");
+			assertEquals("Jonathan Ackerman", results.getString("NAME"),
+				"Invalid Name");
 		}
 	}
 
@@ -706,35 +702,34 @@ public class TestScrollableDriver
 				.executeQuery("SELECT ID, Name, Job FROM sample4 WHERE Job = 'Project Manager'"))
 		{
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "01", results.getString("ID"));
+			assertEquals("01", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertEquals("02", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.next());
-			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertEquals("04", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.first());
-			assertEquals("The ID is wrong when using first", "01", results
-					.getString("ID"));
+			assertEquals("01", results.getString("ID"), "The ID is wrong when using first");
 
 			assertTrue(results.absolute(3));
-			assertEquals("The ID is wrong", "04", results.getString("ID"));
+			assertEquals("04", results.getString("ID"), "The ID is wrong");
 
 			assertTrue(results.last());
-			assertEquals("The ID is wrong", "04", results.getString("ID"));
-			assertFalse("It has records after last", results.next());
-			assertTrue("Is not after Last", results.isAfterLast());
+			assertEquals("04", results.getString("ID"), "The ID is wrong");
+			assertFalse(results.next(), "It has records after last");
+			assertTrue(results.isAfterLast(), "Is not after Last");
 			assertTrue(results.previous());
 			assertTrue(results.previous());
-			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertEquals("02", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.relative(0));
-			assertEquals("The ID is wrong", "02", results.getString("ID"));
+			assertEquals("02", results.getString("ID"), "The ID is wrong");
 			assertTrue(results.relative(1));
-			assertEquals("The ID is wrong", "04", results.getString("ID"));
-			assertTrue("Is not last", results.isLast());
+			assertEquals("04", results.getString("ID"), "The ID is wrong");
+			assertTrue(results.isLast(), "Is not last");
 			assertTrue(results.relative(-2));
-			assertEquals("The ID is wrong", "01", results.getString("ID"));
-			assertTrue("Is not first", results.isFirst());
+			assertEquals("01", results.getString("ID"), "The ID is wrong");
+			assertTrue(results.isFirst(), "Is not first");
 			results.previous();
-			assertTrue("Is not before first", results.isBeforeFirst());
+			assertTrue(results.isBeforeFirst(), "Is not before first");
 		}
 	}
 
@@ -747,19 +742,19 @@ public class TestScrollableDriver
 			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE, ResultSet.CONCUR_READ_ONLY))
 		{
 			stmt.setMaxRows(4);
-			assertEquals("getMaxRows() incorrect", 4, stmt.getMaxRows());
+			assertEquals(4, stmt.getMaxRows(), "getMaxRows() incorrect");
 
 			try (ResultSet results = stmt.executeQuery("SELECT * FROM sample5"))
 			{
-				assertTrue("Moving to last record failed", results.last());
-				assertEquals("Last record wrong", 4, results.getRow());
-				assertEquals("The ID is wrong", "03", results.getString("ID"));
-				assertTrue("Moving to first record failed", results.first());
-				assertEquals("The ID is wrong", "41", results.getString("ID"));
-				assertTrue("Reading row 2 failed", results.next());
-				assertTrue("Reading row 3 failed", results.next());
-				assertTrue("Reading row 4 failed", results.next());
-				assertFalse("Stopping after row 4 failed", results.next());
+				assertTrue(results.last(), "Moving to last record failed");
+				assertEquals(4, results.getRow(), "Last record wrong");
+				assertEquals("03", results.getString("ID"), "The ID is wrong");
+				assertTrue(results.first(), "Moving to first record failed");
+				assertEquals("41", results.getString("ID"), "The ID is wrong");
+				assertTrue(results.next(), "Reading row 2 failed");
+				assertTrue(results.next(), "Reading row 3 failed");
+				assertTrue(results.next(), "Reading row 4 failed");
+				assertFalse(results.next(), "Stopping after row 4 failed");
 			}
 		}
 	}

--- a/src/test/java/org/relique/jdbc/csv/TestSqlParser.java
+++ b/src/test/java/org/relique/jdbc/csv/TestSqlParser.java
@@ -18,10 +18,10 @@
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.StringReader;
 import java.sql.Date;
@@ -31,7 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class is used to test the SqlParser class.
@@ -46,28 +46,28 @@ public class TestSqlParser
 		SqlParser parser = new SqlParser();
 
 		parser.parse("SELECT location, parameter, ts, waarde, unit FROM total");
-		assertTrue("Incorrect table name", parser.getTableNames().get(0).equals("total"));
+		assertTrue(parser.getTableNames().get(0).equals("total"), "Incorrect table name");
 
 		String[] colNames = parser.getColumnNames();
-		assertTrue("Incorrect Column Count", colNames.length == 5);
+		assertTrue(colNames.length == 5, "Incorrect Column Count");
 
-		assertEquals("Incorrect Column Name Col 0", colNames[0].toLowerCase(), "location");
-		assertEquals("Incorrect Column Name Col 1", colNames[1].toLowerCase(), "parameter");
-		assertEquals("Incorrect Column Name Col 2", colNames[2].toLowerCase(), "ts");
-		assertEquals("Incorrect Column Name Col 3", colNames[3].toLowerCase(), "waarde");
-		assertEquals("Incorrect Column Name Col 4", colNames[4].toLowerCase(), "unit");
+		assertEquals(colNames[0].toLowerCase(), "location", "Incorrect Column Name Col 0");
+		assertEquals(colNames[1].toLowerCase(), "parameter", "Incorrect Column Name Col 1");
+		assertEquals(colNames[2].toLowerCase(), "ts", "Incorrect Column Name Col 2");
+		assertEquals(colNames[3].toLowerCase(), "waarde", "Incorrect Column Name Col 3");
+		assertEquals(colNames[4].toLowerCase(), "unit", "Incorrect Column Name Col 4");
 
 		parser.parse("SELECT location, parameter, ts, name.suffix as value FROM total");
-		assertTrue("Incorrect table name", parser.getTableNames().get(0).equals("total"));
+		assertTrue(parser.getTableNames().get(0).equals("total"), "Incorrect table name");
 
-		assertEquals("Incorrect Column Count", 4, parser.getColumns().size());
+		assertEquals(4, parser.getColumns().size(), "Incorrect Column Count");
 
 		List<Object []> cols = parser.getColumns();
-		assertEquals("Incorrect Column Count", 4, cols.size());
+		assertEquals(4, cols.size(), "Incorrect Column Count");
 
 		Object[] colSpec = cols.get(3);
-		assertEquals("Incorrect Column Name Col 3", "VALUE", colSpec[0].toString());
-		assertEquals("Incorrect Column Name Col 3", "[NAME.SUFFIX]", colSpec[1].toString());
+		assertEquals("VALUE", colSpec[0].toString(), "Incorrect Column Name Col 3");
+		assertEquals("[NAME.SUFFIX]", colSpec[1].toString(), "Incorrect Column Name Col 3");
 
 		try
 		{
@@ -81,15 +81,15 @@ public class TestSqlParser
 
 		parser.parse("SELECT location+parameter FROM total");
 		colNames = parser.getColumnNames();
-		assertEquals("Incorrect Column Name Col 1", "+ [LOCATION] [PARAMETER]", colNames[0]);
+		assertEquals("+ [LOCATION] [PARAMETER]", colNames[0], "Incorrect Column Name Col 1");
 
 		parser.parse("SELECT location-parameter FROM total");
 		colNames = parser.getColumnNames();
-		assertEquals("Incorrect Column Name Col 1", "- [LOCATION] [PARAMETER]", colNames[0]);
+		assertEquals("- [LOCATION] [PARAMETER]", colNames[0], "Incorrect Column Name Col 1");
 
 		parser.parse("SELECT location*parameter FROM total");
 		colNames = parser.getColumnNames();
-		assertEquals("Incorrect Column Name Col 1", "* [LOCATION] [PARAMETER]", colNames[0]);
+		assertEquals("* [LOCATION] [PARAMETER]", colNames[0], "Incorrect Column Name Col 1");
 	}
 
 	@Test
@@ -98,15 +98,15 @@ public class TestSqlParser
 		SqlParser parser = new SqlParser();
 
 		parser.parse("SELECT FLD_A,FLD_B, TEST, H FROM test");
-		assertTrue("Incorrect table name", parser.getTableNames().get(0).equals("test"));
+		assertTrue(parser.getTableNames().get(0).equals("test"), "Incorrect table name");
 
 		String[] cols = parser.getColumnNames();
-		assertTrue("Incorrect Column Count", cols.length == 4);
+		assertTrue(cols.length == 4, "Incorrect Column Count");
 
-		assertTrue("Incorrect Column Name Col 0", cols[0].equals("FLD_A"));
-		assertTrue("Incorrect Column Name Col 1", cols[1].equals("FLD_B"));
-		assertTrue("Incorrect Column Name Col 2", cols[2].equals("TEST"));
-		assertTrue("Incorrect Column Name Col 3", cols[3].equals("H"));
+		assertTrue(cols[0].equals("FLD_A"), "Incorrect Column Name Col 0");
+		assertTrue(cols[1].equals("FLD_B"), "Incorrect Column Name Col 1");
+		assertTrue(cols[2].equals("TEST"), "Incorrect Column Name Col 2");
+		assertTrue(cols[3].equals("H"), "Incorrect Column Name Col 3");
 	}
 
 	@Test
@@ -115,15 +115,15 @@ public class TestSqlParser
 		SqlParser parser = new SqlParser();
 
 		parser.parse("SELECT 'abc' as FLD_A, 123 as FLD_B FROM test");
-		assertTrue("Incorrect table name", parser.getTableNames().get(0).equals("test"));
+		assertTrue(parser.getTableNames().get(0).equals("test"), "Incorrect table name");
 
 		String[] cols = parser.getColumnNames();
-		assertTrue("Incorrect Column Count", cols.length == 2);
+		assertTrue(cols.length == 2, "Incorrect Column Count");
 
-		assertTrue("Column Name Col 0 '" + cols[0] + "' is not equal FLD_A",
-			cols[0].equalsIgnoreCase("fld_a"));
-		assertTrue("Column Name Col 1 '" + cols[1] + "' is not equal FLD_B",
-			cols[1].equalsIgnoreCase("FLD_B"));
+		assertTrue(cols[0].equalsIgnoreCase("fld_a"),
+			"Column Name Col 0 '" + cols[0] + "' is not equal FLD_A");
+		assertTrue(cols[1].equalsIgnoreCase("FLD_B"),
+			"Column Name Col 1 '" + cols[1] + "' is not equal FLD_B");
 	}
 
 	@Test
@@ -132,15 +132,15 @@ public class TestSqlParser
 		SqlParser parser = new SqlParser();
 
 		parser.parse("SELECT abc as FLD_A, eee as FLD_B FROM test");
-		assertTrue("Incorrect table name", parser.getTableNames().get(0).equals("test"));
+		assertTrue(parser.getTableNames().get(0).equals("test"), "Incorrect table name");
 
 		String[] cols = parser.getColumnNames();
-		assertTrue("Incorrect Column Count", cols.length == 2);
+		assertTrue(cols.length == 2, "Incorrect Column Count");
 
-		assertTrue("Column Name Col 0 '" + cols[0] + "' is not equal FLD_A",
-			cols[0].equalsIgnoreCase("fld_a"));
-		assertTrue("Column Name Col 1 '" + cols[1] + "' is not equal FLD_B",
-			cols[1].equalsIgnoreCase("FLD_B"));
+		assertTrue(cols[0].equalsIgnoreCase("fld_a"),
+			"Column Name Col 0 '" + cols[0] + "' is not equal FLD_A");
+		assertTrue(cols[1].equalsIgnoreCase("FLD_B"),
+			"Column Name Col 1 '" + cols[1] + "' is not equal FLD_B");
 	}
 
 	/**
@@ -152,10 +152,10 @@ public class TestSqlParser
 		SqlParser parser = new SqlParser();
 
 		parser.parse("SELECT * FROM test");
-		assertTrue("Incorrect table name", parser.getTableNames().get(0).equals("test"));
+		assertTrue(parser.getTableNames().get(0).equals("test"), "Incorrect table name");
 
 		String[] cols = parser.getColumnNames();
-		assertEquals("Incorrect Column Count", 1, cols.length);
+		assertEquals(1, cols.length, "Incorrect Column Count");
 	}
 
 	/**
@@ -166,19 +166,19 @@ public class TestSqlParser
 	{
 		SqlParser parser = new SqlParser();
 		parser.parse("SELECT FLD_A, FLD_B FROM test WHERE FLD_A = 20");
-		assertEquals("Incorrect table name", "test", parser.getTableNames().get(0));
+		assertEquals("test", parser.getTableNames().get(0), "Incorrect table name");
 
 		parser.parse("SELECT FLD_A, FLD_B FROM test WHERE FLD_A = '20'");
-		assertEquals("Incorrect table name", "test", parser.getTableNames().get(0));
+		assertEquals("test", parser.getTableNames().get(0), "Incorrect table name");
 
 		parser.parse("SELECT FLD_A,FLD_B FROM test WHERE FLD_A =20");
-		assertEquals("Incorrect table name", "test", parser.getTableNames().get(0));
+		assertEquals("test", parser.getTableNames().get(0), "Incorrect table name");
 
 		parser.parse("SELECT FLD_A FROM test WHERE FLD_A=20");
-		assertEquals("Incorrect table name", "test", parser.getTableNames().get(0));
+		assertEquals("test", parser.getTableNames().get(0), "Incorrect table name");
 
 		parser.parse("SELECT FLD_A, FLD_B FROM test WHERE FLD_B='Test Me'");
-		assertEquals("Incorrect table name", "test", parser.getTableNames().get(0));
+		assertEquals("test", parser.getTableNames().get(0), "Incorrect table name");
 	}
 
 	/**
@@ -192,28 +192,28 @@ public class TestSqlParser
 
 		parser.parse("SELECT * FROM test WHERE A='20'");
 		whereClause = parser.getWhereClause();
-		assertNotNull("query has a WHERE clause", whereClause);
-		assertEquals("Incorrect WHERE", "= [A] '20'", whereClause.toString());
+		assertNotNull(whereClause, "query has a WHERE clause");
+		assertEquals("= [A] '20'", whereClause.toString(), "Incorrect WHERE");
 
 		parser.parse("SELECT * FROM test WHERE A='20' AND B='AA'");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "AND = [A] '20' = [B] 'AA'",
-			whereClause.toString());
+		assertEquals("AND = [A] '20' = [B] 'AA'",
+			whereClause.toString(), "Incorrect WHERE");
 
 		parser.parse("SELECT * FROM test WHERE A='20' OR B='AA'");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "OR = [A] '20' = [B] 'AA'",
-			whereClause.toString());
+		assertEquals("OR = [A] '20' = [B] 'AA'",
+			whereClause.toString(), "Incorrect WHERE");
 
 		parser.parse("SELECT * FROM test WHERE A='20' OR B='AA' AND c=1");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "OR = [A] '20' AND = [B] 'AA' = [C] 1",
-			whereClause.toString());
+		assertEquals("OR = [A] '20' AND = [B] 'AA' = [C] 1",
+			whereClause.toString(), "Incorrect WHERE");
 
 		parser.parse("SELECT * FROM test WHERE (A='20' OR B='AA') AND c=1");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "AND OR = [A] '20' = [B] 'AA' = [C] 1",
-			whereClause.toString());
+		assertEquals("AND OR = [A] '20' = [B] 'AA' = [C] 1",
+			whereClause.toString(), "Incorrect WHERE");
 	}
 
 	@Test
@@ -254,32 +254,32 @@ public class TestSqlParser
 
 		parser.parse("SELECT * FROM test WHERE B IS NULL");
 		Expression whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "N [B]", whereClause.toString());
+		assertEquals("N [B]", whereClause.toString(), "Incorrect WHERE");
 		parser.parse("SELECT * FROM test WHERE B IS NOT NULL");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "NOT N [B]", whereClause.toString());
+		assertEquals("NOT N [B]", whereClause.toString(), "Incorrect WHERE");
 		parser.parse("SELECT * FROM test WHERE B BETWEEN '20' AND 'AA'");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "B [B] '20' 'AA'", whereClause.toString());
+		assertEquals("B [B] '20' 'AA'", whereClause.toString(), "Incorrect WHERE");
 		parser.parse("SELECT * FROM test WHERE B NOT BETWEEN '20' AND 'AA'");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "NOT B [B] '20' 'AA'", whereClause.toString());
+		assertEquals("NOT B [B] '20' 'AA'", whereClause.toString(), "Incorrect WHERE");
 		parser.parse("SELECT * FROM test WHERE B LIKE '20 AND AA'");
 		whereClause = parser.getWhereClause();
 		parser.parse("SELECT * FROM test WHERE B LIKE '12^_34' ESCAPE '^'");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "L [B] '12^_34' ESCAPE '^'", whereClause.toString());
+		assertEquals("L [B] '12^_34' ESCAPE '^'", whereClause.toString(), "Incorrect WHERE");
 		parser.parse("SELECT * FROM test WHERE B NOT LIKE 'X%'");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "NOT L [B] 'X%'", whereClause.toString());
+		assertEquals("NOT L [B] 'X%'", whereClause.toString(), "Incorrect WHERE");
 		parser.parse("SELECT * FROM test WHERE B IN ('XX', 'YY')");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "IN [B] ('XX', 'YY')", whereClause.toString());
+		assertEquals("IN [B] ('XX', 'YY')", whereClause.toString(), "Incorrect WHERE");
 
 		parser.parse("SELECT * FROM test WHERE B IS NULL OR B BETWEEN '20' AND 'AA' AND B LIKE '20 AND AA'");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "OR N [B] AND B [B] '20' 'AA' L [B] '20 AND AA'",
-			whereClause.toString());
+		assertEquals("OR N [B] AND B [B] '20' 'AA' L [B] '20 AND AA'",
+			whereClause.toString(), "Incorrect WHERE");
 
 		try
 		{
@@ -313,19 +313,19 @@ public class TestSqlParser
 
 		parser.parse("SELECT * FROM test WHERE B = (20)");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "= [B] 20", whereClause.toString());
+		assertEquals("= [B] 20", whereClause.toString(), "Incorrect WHERE");
 		
 		parser.parse("SELECT * FROM test WHERE B = 20 + 30");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "= [B] + 20 30", whereClause.toString());
+		assertEquals("= [B] + 20 30", whereClause.toString(), "Incorrect WHERE");
 		
 		parser.parse("SELECT * FROM test WHERE B + 20 = 30");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "= + [B] 20 30", whereClause.toString());
+		assertEquals("= + [B] 20 30", whereClause.toString(), "Incorrect WHERE");
 
 		parser.parse("SELECT * FROM test WHERE (B + 20) = 30");
 		whereClause = parser.getWhereClause();
-		assertEquals("Incorrect WHERE", "= + [B] 20 30", whereClause.toString());
+		assertEquals("= + [B] 20 30", whereClause.toString(), "Incorrect WHERE");
 	}
 
 	/**
@@ -899,13 +899,13 @@ public class TestSqlParser
 		SqlParser parser = new SqlParser();
 
 		parser.parse("\r\nSELECT NAME\r\nas FLD_A\r\nFROM test\r\nWHERE ID=1\r\n");
-		assertTrue("Incorrect table name", parser.getTableNames().get(0).equals("test"));
+		assertTrue(parser.getTableNames().get(0).equals("test"), "Incorrect table name");
 
 		String[] cols = parser.getColumnNames();
-		assertTrue("Incorrect Column Count", cols.length == 1);
+		assertTrue(cols.length == 1, "Incorrect Column Count");
 
-		assertTrue("Column Name Col 0 '" + cols[0] + "' is not equal FLD_A",
-			cols[0].equalsIgnoreCase("fld_a"));
+		assertTrue(cols[0].equalsIgnoreCase("fld_a"),
+			"Column Name Col 0 '" + cols[0] + "' is not equal FLD_A");
 	}
 
 	@Test
@@ -925,8 +925,8 @@ public class TestSqlParser
 
 		parser.parse("SELECT Id FROM sample where Signature = 'sent from my iPhone'");
 		whereClause = parser.getWhereClause();
-		assertNotNull("query has a WHERE clause", whereClause);
-		assertEquals("Incorrect WHERE", "= [SIGNATURE] 'sent from my iPhone'", whereClause.toString());
+		assertNotNull(whereClause, "query has a WHERE clause");
+		assertEquals("= [SIGNATURE] 'sent from my iPhone'", whereClause.toString(), "Incorrect WHERE");
 	}
 
 	@Test
@@ -937,8 +937,8 @@ public class TestSqlParser
 
 		parser.parse("SELECT Id FROM sample where Title like '%NOT WHERE I BELONG%'");
 		whereClause = parser.getWhereClause();
-		assertNotNull("query has a WHERE clause", whereClause);
-		assertEquals("Incorrect WHERE", "L [TITLE] '%NOT WHERE I BELONG%'", whereClause.toString());
+		assertNotNull(whereClause, "query has a WHERE clause");
+		assertEquals("L [TITLE] '%NOT WHERE I BELONG%'", whereClause.toString(), "Incorrect WHERE");
 	}
 
 	@Test
@@ -963,9 +963,9 @@ public class TestSqlParser
 			"-- Comment After");
 		assertEquals("sample", parser1.getTableNames().get(0));
 		String[] cols = parser1.getColumnNames();
-		assertTrue("Incorrect Column Count", cols.length == 1);
-		assertTrue("Column Name Col 0 '" + cols[0] + "' is not equal Id",
-			cols[0].equalsIgnoreCase("Id"));
+		assertTrue(cols.length == 1, "Incorrect Column Count");
+		assertTrue(cols[0].equalsIgnoreCase("Id"),
+			"Column Name Col 0 '" + cols[0] + "' is not equal Id");
 
 		SqlParser parser2 = new SqlParser();
 		parser2.parse("SELECT\r\n" +
@@ -977,11 +977,11 @@ public class TestSqlParser
 			"CITYID = 77 -- See CITYINDEX.TXT\r\n");
 		assertEquals("climate", parser2.getTableNames().get(0));
 		cols = parser2.getColumnNames();
-		assertTrue("Incorrect Column Count", cols.length == 2);
-		assertTrue("Column Name Col 0 '" + cols[0] + "' is not equal MONTH",
-			cols[0].equalsIgnoreCase("MONTH"));
-		assertTrue("Column Name Col 1 '" + cols[1] + "' is not equal TEMP",
-			cols[1].equalsIgnoreCase("TEMP"));
+		assertTrue(cols.length == 2, "Incorrect Column Count");
+		assertTrue(cols[0].equalsIgnoreCase("MONTH"),
+			"Column Name Col 0 '" + cols[0] + "' is not equal MONTH");
+		assertTrue(cols[1].equalsIgnoreCase("TEMP"),
+			"Column Name Col 1 '" + cols[1] + "' is not equal TEMP");
 	}
 
 	@Test
@@ -996,11 +996,11 @@ public class TestSqlParser
 			"/* another comment */");
 		assertEquals("sample", parser1.getTableNames().get(0));
 		String[] cols = parser1.getColumnNames();
-		assertTrue("Incorrect Column Count", cols.length == 2);
-		assertTrue("Column Name Col 0 '" + cols[0] + "' is not NAME",
-			cols[0].equalsIgnoreCase("NAME"));
-		assertTrue("Column Name Col 1 '" + cols[1] + "' is not S",
-			cols[1].equalsIgnoreCase("S"));
+		assertTrue(cols.length == 2, "Incorrect Column Count");
+		assertTrue(cols[0].equalsIgnoreCase("NAME"),
+			"Column Name Col 0 '" + cols[0] + "' is not NAME");
+		assertTrue(cols[1].equalsIgnoreCase("S"),
+			"Column Name Col 1 '" + cols[1] + "' is not S");
 
 		try
 		{
@@ -1018,16 +1018,16 @@ public class TestSqlParser
 	{
 		MultipleSqlParser parser = new MultipleSqlParser();
 		List<SqlParser> parsers = parser.parse("SELECT A FROM test1 ; SELECT B FROM test2 ; SELECT C FROM test3");
-		assertEquals("SQL statement count", 3, parsers.size());
+		assertEquals(3, parsers.size(), "SQL statement count");
 		
 		assertEquals("[A]", parsers.get(0).getExpression(0).toString());
-		assertEquals("Incorrect table name", parsers.get(0).getTableNames().get(0), "test1");
+		assertEquals(parsers.get(0).getTableNames().get(0), "test1", "Incorrect table name");
 
 		assertEquals("[B]", parsers.get(1).getExpression(0).toString());
-		assertEquals("Incorrect table name", parsers.get(1).getTableNames().get(0), "test2");
+		assertEquals(parsers.get(1).getTableNames().get(0), "test2", "Incorrect table name");
 
 		assertEquals("[C]", parsers.get(2).getExpression(0).toString());
-		assertEquals("Incorrect table name", parsers.get(2).getTableNames().get(0), "test3");
+		assertEquals(parsers.get(2).getTableNames().get(0), "test3", "Incorrect table name");
 	}
 	
 	@Test
@@ -1037,8 +1037,8 @@ public class TestSqlParser
 
 		parser.parse("SELECT ID, (SELECT SUM(Amount) FROM t2 WHERE sample.ID=t2.ID) FROM sample");
 		String subquery = parser.getExpression(1).toString();
-		assertTrue("Incorrect Subquery", subquery.startsWith("(SELECT"));
-		assertTrue("Incorrect Subquery", subquery.endsWith(")"));
+		assertTrue(subquery.startsWith("(SELECT"), "Incorrect Subquery");
+		assertTrue(subquery.endsWith(")"), "Incorrect Subquery");
 	}
 
 	@Test

--- a/src/test/java/org/relique/jdbc/csv/TestStringConverter.java
+++ b/src/test/java/org/relique/jdbc/csv/TestStringConverter.java
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Date;
 import java.sql.Time;
@@ -29,8 +29,7 @@ import java.text.SimpleDateFormat;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This class is used to test the SqlParser class.

--- a/src/test/java/org/relique/jdbc/csv/TestSubQuery.java
+++ b/src/test/java/org/relique/jdbc/csv/TestSubQuery.java
@@ -18,11 +18,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -32,20 +32,20 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestSubQuery
 {
 	private static String filePath;
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -86,16 +86,16 @@ public class TestSubQuery
 			ResultSet rs1 = stmt.executeQuery("SELECT (SELECT BANK_NAME FROM banks WHERE BLZ=FROM_BLZ), AMOUNT FROM transactions"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-			assertTrue("The AMOUNT is wrong", fuzzyEquals(250.0, rs1.getDouble(2)));
+			assertEquals("Postbank (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
+			assertTrue(fuzzyEquals(250.0, rs1.getDouble(2)), "The AMOUNT is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+			assertEquals("Postbank (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+			assertEquals("Postbank (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", rs1.getString(1));
+			assertEquals("Bank f\u00FCr Sozialwirtschaft (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
+			assertEquals("Postbank (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
 		}
 	}
 
@@ -228,19 +228,19 @@ public class TestSubQuery
 			ResultSet rs1 = stmt.executeQuery("SELECT ID, NAME, (SELECT NAME FROM sample2 s2 WHERE s2.ID=s1.ID) FROM sample s1"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The ID is wrong", "Q123", rs1.getString(1));
-			assertEquals("The Name is wrong", "\"S,\"", rs1.getString(2));
+			assertEquals("Q123", rs1.getString(1), "The ID is wrong");
+			assertEquals("\"S,\"", rs1.getString(2), "The Name is wrong");
 			// No match so subquery returns null for this row.
-			assertNull("The Subquery is wrong", rs1.getString(3));
+			assertNull(rs1.getString(3), "The Subquery is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The ID is wrong", "A123", rs1.getString(1));
-			assertEquals("The Name is wrong", "Jonathan Ackerman", rs1.getString(2));
-			assertEquals("The Subquery is wrong", "Aman", rs1.getString(3));
+			assertEquals("A123", rs1.getString(1), "The ID is wrong");
+			assertEquals("Jonathan Ackerman", rs1.getString(2), "The Name is wrong");
+			assertEquals("Aman", rs1.getString(3), "The Subquery is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The ID is wrong", "B234", rs1.getString(1));
-			assertEquals("The Name is wrong", "Grady O'Neil", rs1.getString(2));
+			assertEquals("B234", rs1.getString(1), "The ID is wrong");
+			assertEquals("Grady O'Neil", rs1.getString(2), "The Name is wrong");
 			// No match so subquery returns null for this row.
-			assertNull("The Subquery is wrong", rs1.getString(3));
+			assertNull(rs1.getString(3), "The Subquery is wrong");
 		}
 	}
 
@@ -262,14 +262,14 @@ public class TestSubQuery
 			ResultSet rs1 = stmt.executeQuery("SELECT BANK_NAME, (SELECT COUNT(*) FROM transactions WHERE BLZ=FROM_BLZ) COUNT_ FROM banks"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Bundesbank (Berlin)", rs1.getString(1));
-			assertEquals("The Subquery is wrong", 0, rs1.getInt(2));
+			assertEquals("Bundesbank (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
+			assertEquals(0, rs1.getInt(2), "The Subquery is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-			assertEquals("The Subquery is wrong", 5, rs1.getInt(2));
+			assertEquals("Postbank (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
+			assertEquals(5, rs1.getInt(2), "The Subquery is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "SEB (Berlin)", rs1.getString(1));
-			assertEquals("The Subquery is wrong", 0, rs1.getInt(2));
+			assertEquals("SEB (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
+			assertEquals(0, rs1.getInt(2), "The Subquery is wrong");
 		}
 	}
 
@@ -291,14 +291,14 @@ public class TestSubQuery
 			ResultSet rs1 = stmt.executeQuery("SELECT BANK_NAME, (SELECT COUNT(*) FROM transactions WHERE BLZ=FROM_BLZ) COUNT_ FROM banks ORDER BY COUNT_ DESC"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Postbank (Berlin)", rs1.getString(1));
-			assertEquals("The Subquery is wrong", 5, rs1.getInt(2));
+			assertEquals("Postbank (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
+			assertEquals(5, rs1.getInt(2), "The Subquery is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "Bank f\u00FCr Sozialwirtschaft (Berlin)", rs1.getString(1));
-			assertEquals("The Subquery is wrong", 3, rs1.getInt(2));
+			assertEquals("Bank f\u00FCr Sozialwirtschaft (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
+			assertEquals(3, rs1.getInt(2), "The Subquery is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The BANK_NAME is wrong", "BHF-BANK (Berlin)", rs1.getString(1));
-			assertEquals("The Subquery is wrong", 1, rs1.getInt(2));
+			assertEquals("BHF-BANK (Berlin)", rs1.getString(1), "The BANK_NAME is wrong");
+			assertEquals(1, rs1.getInt(2), "The Subquery is wrong");
 		}
 	}
 
@@ -315,7 +315,7 @@ public class TestSubQuery
 			ResultSet rs1 = stmt.executeQuery("select AccountNo from Purchase where CampaignNo=(select max(CampaignNo) from Purchase)"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The AccountNo is wrong", 22021, rs1.getInt(1));
+			assertEquals(22021, rs1.getInt(1), "The AccountNo is wrong");
 			assertFalse(rs1.next());
 		}
 	}
@@ -331,13 +331,13 @@ public class TestSubQuery
 			ResultSet rs1 = stmt.executeQuery("select NAME from sample5 where ID in (select ID from sample4)"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The NAME is wrong", "Juan Pablo Morales", rs1.getString(1));
+			assertEquals("Juan Pablo Morales", rs1.getString(1), "The NAME is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The NAME is wrong", "Mauricio Hernandez", rs1.getString(1));
+			assertEquals("Mauricio Hernandez", rs1.getString(1), "The NAME is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The NAME is wrong", "Maria Cristina Lucero", rs1.getString(1));
+			assertEquals("Maria Cristina Lucero", rs1.getString(1), "The NAME is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The NAME is wrong", "Felipe Grajales", rs1.getString(1));
+			assertEquals("Felipe Grajales", rs1.getString(1), "The NAME is wrong");
 			assertFalse(rs1.next());
 		}
 	}
@@ -367,7 +367,7 @@ public class TestSubQuery
 			ResultSet rs1 = stmt.executeQuery("select EXTRA_FIELD from sample where exists (select 1 from sample2 where sample2.id=sample.id)"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The EXTRA_FIELD is wrong", "A", rs1.getString(1));
+			assertEquals("A", rs1.getString(1), "The EXTRA_FIELD is wrong");
 			assertFalse(rs1.next());
 		}
 	}
@@ -383,15 +383,15 @@ public class TestSubQuery
 			ResultSet rs1 = stmt.executeQuery("select EXTRA_FIELD from sample where not exists (select 1 from sample2 where sample2.id=sample.id)"))
 		{
 			assertTrue(rs1.next());
-			assertEquals("The EXTRA_FIELD is wrong", "F", rs1.getString(1));
+			assertEquals("F", rs1.getString(1), "The EXTRA_FIELD is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The EXTRA_FIELD is wrong", "B", rs1.getString(1));
+			assertEquals("B", rs1.getString(1), "The EXTRA_FIELD is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The EXTRA_FIELD is wrong", "C", rs1.getString(1));
+			assertEquals("C", rs1.getString(1), "The EXTRA_FIELD is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The EXTRA_FIELD is wrong", "E", rs1.getString(1));
+			assertEquals("E", rs1.getString(1), "The EXTRA_FIELD is wrong");
 			assertTrue(rs1.next());
-			assertEquals("The EXTRA_FIELD is wrong", "G", rs1.getString(1));
+			assertEquals("G", rs1.getString(1), "The EXTRA_FIELD is wrong");
 			assertFalse(rs1.next());
 		}
 	}

--- a/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
+++ b/src/test/java/org/relique/jdbc/csv/TestZipFiles.java
@@ -18,10 +18,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 package org.relique.jdbc.csv;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.sql.Connection;
@@ -31,8 +31,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 
 /**
  * Tests reading of database tables from ZIP files.
@@ -43,13 +44,13 @@ public class TestZipFiles
 	private static String TEST_ZIP_FILENAME_1 = "olympic-medals.zip";
 	private static String TEST_ZIP_FILENAME_2 = "encodings.zip";
 
-	@BeforeClass
+	@BeforeAll
 	public static void setUp()
 	{
 		filePath = ".." + File.separator + "src" + File.separator + "testdata";
 		if (!new File(filePath).isDirectory())
 			filePath = "src" + File.separator + "testdata";
-		assertTrue("Sample files directory not found: " + filePath, new File(filePath).isDirectory());
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
 
 		// load CSV driver
 		try
@@ -86,15 +87,15 @@ public class TestZipFiles
 			ResultSet results = stmt.executeQuery("SELECT * FROM medals2004"))
 		{
 			assertTrue(results.next());
-			assertEquals("The YEAR is wrong", 2004, results.getShort(1));
-			assertEquals("The COUNTRY is wrong", "United States", results.getString(2));
-			assertEquals("The CODE is wrong", "USA", results.getString(3));
-			assertEquals("The GOLD is wrong", 36, results.getShort(4));
+			assertEquals(2004, results.getShort(1), "The YEAR is wrong");
+			assertEquals("United States", results.getString(2), "The COUNTRY is wrong");
+			assertEquals("USA", results.getString(3), "The CODE is wrong");
+			assertEquals(36, results.getShort(4), "The GOLD is wrong");
 			assertTrue(results.next());
-			assertEquals("The YEAR is wrong", 2004, results.getShort(1));
-			assertEquals("The COUNTRY is wrong", "China", results.getString(2));
-			assertEquals("The CODE is wrong", "CHN", results.getString(3));
-			assertEquals("The GOLD is wrong", 32, results.getShort(4));
+			assertEquals(2004, results.getShort(1), "The YEAR is wrong");
+			assertEquals("China", results.getString(2), "The COUNTRY is wrong");
+			assertEquals("CHN", results.getString(3), "The CODE is wrong");
+			assertEquals(32, results.getShort(4), "The GOLD is wrong");
 		}
 	}
 	
@@ -106,9 +107,9 @@ public class TestZipFiles
 			ResultSet results = conn.getMetaData().getTables(null, null, "%", null))
 		{
 			assertTrue(results.next());
-			assertEquals("The TABLE_NAME is wrong", "medals2004", results.getString("TABLE_NAME"));
+			assertEquals("medals2004", results.getString("TABLE_NAME"), "The TABLE_NAME is wrong");
 			assertTrue(results.next());
-			assertEquals("The TABLE_NAME is wrong", "medals2008", results.getString("TABLE_NAME"));
+			assertEquals("medals2008", results.getString("TABLE_NAME"), "The TABLE_NAME is wrong");
 			assertFalse(results.next());
 		}
 	}
@@ -161,11 +162,11 @@ public class TestZipFiles
 			ResultSet results = stmt.executeQuery("SELECT * FROM iso8859-1"))
 		{
 			assertTrue(results.next());
-			assertEquals("ISO8859-1 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertEquals("K\u00D8BENHAVN", results.getString(1), "ISO8859-1 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("ISO8859-1 encoding is wrong", "100\u00B0", results.getString(1));
+			assertEquals("100\u00B0", results.getString(1), "ISO8859-1 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("ISO8859-1 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			assertEquals("\u00A9 Copyright", results.getString(1), "ISO8859-1 encoding is wrong");
 		}
 	}
 
@@ -183,11 +184,11 @@ public class TestZipFiles
 			ResultSet results = stmt.executeQuery("SELECT * FROM utf-8"))
 		{
 			assertTrue(results.next());
-			assertEquals("UTF-8 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertEquals("K\u00D8BENHAVN", results.getString(1), "UTF-8 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("UTF-8 encoding is wrong", "100\u00B0", results.getString(1));
+			assertEquals("100\u00B0", results.getString(1), "UTF-8 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("UTF-8 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			assertEquals("\u00A9 Copyright", results.getString(1), "UTF-8 encoding is wrong");
 		}
 	}
 
@@ -205,11 +206,11 @@ public class TestZipFiles
 			ResultSet results = stmt.executeQuery("SELECT * FROM utf-16"))
 		{
 			assertTrue(results.next());
-			assertEquals("UTF-16 encoding is wrong", "K\u00D8BENHAVN", results.getString(1));
+			assertEquals("K\u00D8BENHAVN", results.getString(1), "UTF-16 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("UTF-16 encoding is wrong", "100\u00B0", results.getString(1));
+			assertEquals("100\u00B0", results.getString(1), "UTF-16 encoding is wrong");
 			assertTrue(results.next());
-			assertEquals("UTF-16 encoding is wrong", "\u00A9 Copyright", results.getString(1));
+			assertEquals("\u00A9 Copyright", results.getString(1), "UTF-16 encoding is wrong");
 		}
 	}
 }


### PR DESCRIPTION
Update unit tests from JUnit 4 to 5, replacing imports, and changing order of arguments in `assertEquals()` calls.

Updated JUnit dependencies in `pom.xml` from JUnit 4 to 5.

Fixes #77.