### PR TITLE
Implement java.sql.Array.getResultSet()

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -91,10 +91,10 @@ all records up to the furthest accessed record are held into memory. For other
 queries, CsvJdbc holds only one record at a time in memory.
 
 Notes on functions returning an array:
-* `ResultSet.getArray(...)` will return an `org.relique.jdbc.csv.SqlArray`
-* SqlArray has working getArray(...) methods, but getResultSet(...) methods are not implemented
-* SqlArray tries to infer the type of the values for its `getBaseTypeName()` and `getBaseType()` 
-methods; an `IllegalStateException` will be thrown if it detects values of different types
+* `ResultSet.getArray(...)` returns an object of type `org.relique.jdbc.csv.SqlArray`, that implements interface `java.sql.Array`
+* Both `java.sql.Array.getArray(...)` and `getResultSet(...)` methods are implemented
+* `SqlArray` tries to infer the type of the values for its `getBaseTypeName()` and `getBaseType()`
+methods; an `IllegalStateException` is thrown if values of different types are detected
 
 ## Dependencies
 

--- a/src/main/java/org/relique/jdbc/csv/SQLArrayAggFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLArrayAggFunction.java
@@ -65,7 +65,8 @@ public class SQLArrayAggFunction extends AggregateFunction
 			}
 		}
 		StringConverter converter = (StringConverter)env.get(StringConverter.COLUMN_NAME);
-		return new SqlArray(values, converter);
+		CsvStatement statement = (CsvStatement)env.get(CsvStatement.STATEMENT_COLUMN_NAME);
+		return new SqlArray(values, converter, statement.getConnection());
 
 	}
 

--- a/src/main/java/org/relique/jdbc/csv/SQLToArrayFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLToArrayFunction.java
@@ -54,7 +54,8 @@ public class SQLToArrayFunction extends SQLCoalesceFunction
 			}
 		}
 		StringConverter converter = (StringConverter)env.get(StringConverter.COLUMN_NAME);
-		return new SqlArray(values, converter);
+		CsvStatement statement = (CsvStatement)env.get(CsvStatement.STATEMENT_COLUMN_NAME);
+		return new SqlArray(values, converter, statement.getConnection());
 	}
 
 	@Override


### PR DESCRIPTION
Implement methods that return array column as a JDBC ResultSet.

Added unit tests for these methods in class `TestArrayFunctions`.

Fixes #78.