### PR TITLE
ResultSetMetaData.getColumnType returns ARRAY

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/CsvResultSetMetaData.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResultSetMetaData.java
@@ -178,6 +178,7 @@ public class CsvResultSetMetaData implements ResultSetMetaData
 			put("Timestamp", Integer.valueOf(Types.TIMESTAMP));
 			put("Blob", Integer.valueOf(Types.BLOB));
 			put("Clob", Integer.valueOf(Types.CLOB));
+			put("Array", Integer.valueOf(Types.ARRAY));
 			put("expression", Integer.valueOf(Types.BLOB));
 		}
 	};

--- a/src/main/java/org/relique/jdbc/csv/StringConverter.java
+++ b/src/main/java/org/relique/jdbc/csv/StringConverter.java
@@ -942,7 +942,7 @@ public class StringConverter
 			intZero, intZero, intZero });
 
 		retval.add(new Object[]
-		{ "Array", Integer.valueOf(Types.ARRAY), null, null, null,
+		{ "Array", Integer.valueOf(Types.ARRAY), shortMax, null, null,
 			null, nullable, Boolean.TRUE, searchable, Boolean.FALSE,
 			Boolean.FALSE, Boolean.FALSE, null, shortZero, shortMax,
 			intZero, intZero, intZero });

--- a/src/main/java/org/relique/jdbc/csv/StringConverter.java
+++ b/src/main/java/org/relique/jdbc/csv/StringConverter.java
@@ -19,6 +19,7 @@ package org.relique.jdbc.csv;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.sql.Array;
 import java.sql.DatabaseMetaData;
 import java.sql.Date;
 import java.sql.Time;
@@ -846,6 +847,8 @@ public class StringConverter
 			retval = "Timestamp";
 		else if (literal instanceof InputStream)
 			retval = "AsciiStream";
+		else if (literal instanceof Array)
+			retval = "Array";
 		return retval;
 	}
 
@@ -934,6 +937,12 @@ public class StringConverter
 
 		retval.add(new Object[]
 		{ "Asciistream", Integer.valueOf(Types.CLOB), shortMax, null, null,
+			null, nullable, Boolean.TRUE, searchable, Boolean.FALSE,
+			Boolean.FALSE, Boolean.FALSE, null, shortZero, shortMax,
+			intZero, intZero, intZero });
+
+		retval.add(new Object[]
+		{ "Array", Integer.valueOf(Types.ARRAY), null, null, null,
 			null, nullable, Boolean.TRUE, searchable, Boolean.FALSE,
 			Boolean.FALSE, Boolean.FALSE, null, shortZero, shortMax,
 			intZero, intZero, intZero });

--- a/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
@@ -54,6 +54,20 @@ public class TestArrayFunctions
 	}
 
 	@Test
+	public void testToArrayColumnType() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT name, TO_ARRAY(role_1, role_2) AS roles FROM arrays_sample"))
+		{
+			assertTrue(results.next());
+			ResultSetMetaData meta = results.getMetaData();
+			int type = meta.getColumnType(2);
+			assertEquals(Types.ARRAY, type);
+		}
+	}
+
+	@Test
 	public void testToArrayWithStringData() throws SQLException
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);


### PR DESCRIPTION
Added type Array to internal data structures, so that getColumnType() returns java.sql.Types.ARRAY for array columns.

Added unit test testToArrayColumnType to check this.

Fixes #82.