### PR TITLE
update GitHub actions to current version 3

### DIFF
--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 11
       - name: Build with Maven
         run: mvn -B clean package

--- a/.github/workflows/maven-package.yml
+++ b/.github/workflows/maven-package.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
       - name: Build with Maven


### PR DESCRIPTION
This avoids a _The following actions uses node12 which is deprecated_ warning during GitHub builds.