### PR TITLE
Fix array in WHERE and ORDER BY clauses in SQL statements

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/SqlArray.java
+++ b/src/main/java/org/relique/jdbc/csv/SqlArray.java
@@ -24,11 +24,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.relique.io.ListDataReader;
 
@@ -45,13 +43,16 @@ public class SqlArray implements Array, Comparable<SqlArray>
 
 	public SqlArray(List<Object> values, StringConverter converter, Connection connection)
 	{
-		String[] inferredTypes = converter.inferColumnTypes(values.toArray());
-		baseTypeName = getBaseTypeNameImpl(values, Arrays.asList(inferredTypes));
+		ArrayList<String> inferredTypes = new ArrayList<String>();
+		for (int i = 0; i < values.size(); i++)
+		{
+			inferredTypes.add(StringConverter.getTypeNameForLiteral(values.get(i)));
+		}
+		baseTypeName = getBaseTypeNameImpl(values, inferredTypes);
 		baseType = getBaseTypeImpl(baseTypeName);
 
-		this.values = values.stream()
-				.map(o -> converter.convert(baseTypeName, o.toString()))
-				.collect(Collectors.toList());
+		this.values = new ArrayList<Object>();
+		this.values.addAll(values);
 		this.converter = converter;
 		this.createdByConnection = connection;
 	}

--- a/src/main/java/org/relique/jdbc/csv/SqlArray.java
+++ b/src/main/java/org/relique/jdbc/csv/SqlArray.java
@@ -33,12 +33,13 @@ import java.util.stream.Collectors;
 import org.relique.io.ListDataReader;
 
 
-public class SqlArray implements Array 
+public class SqlArray implements Array, Comparable<SqlArray>
 {
 	private final List<Object> values;
 	private final String baseTypeName;
 	private final int baseType;
 	private boolean freed;
+	StringConverter converter;
 	Connection createdByConnection;
 	CsvStatement internalStatement;
 
@@ -51,6 +52,7 @@ public class SqlArray implements Array
 		this.values = values.stream()
 				.map(o -> converter.convert(baseTypeName, o.toString()))
 				.collect(Collectors.toList());
+		this.converter = converter;
 		this.createdByConnection = connection;
 	}
 
@@ -231,5 +233,57 @@ public class SqlArray implements Array
 			internalStatement = null;
 		}
 		freed = true;
+	}
+
+	@Override
+	public int compareTo(SqlArray other)
+	{
+		// Compare elements in arrays
+		int minSize = Math.min(values.size(), other.values.size());
+		for (int i = 0; i < minSize; i++)
+		{
+			Comparable left = (Comparable)values.get(i);
+			Comparable right = (Comparable)other.values.get(i);
+			Map<String, Object> env = new HashMap<>();
+			env.put(StringConverter.COLUMN_NAME, converter);
+			try
+			{
+				Integer compared = RelopExpression.compare(left, right, env);
+				if (compared == null)
+				{
+					throw new ClassCastException(CsvResources.getString("arrayElementTypes") + ": " +
+						(i + 1) + ": " + left.toString() + ": " + right.toString());
+				}
+				if (compared.intValue() != 0)
+				{
+					return compared.intValue();
+				}
+			}
+			catch (SQLException e)
+			{
+				throw new ClassCastException(e.getMessage() + ": " +
+					(i + 1) + ": " + left.toString() + ": " + right.toString());
+			}
+		}
+		// All elements are equal, choose largest array instead.
+		int sign = values.size() - other.values.size();
+		return sign;
+	}
+
+	@Override
+	public String toString()
+	{
+		StringBuffer sb = new StringBuffer();
+		sb.append("TO_ARRAY(");
+		for (int i = 0; i < values.size(); i++)
+		{
+			if (i > 0)
+			{
+				sb.append(", ");
+			}
+			sb.append(values.get(i));
+		}
+		sb.append(")");
+		return sb.toString();
 	}
 }

--- a/src/main/java/org/relique/jdbc/csv/StringConverter.java
+++ b/src/main/java/org/relique/jdbc/csv/StringConverter.java
@@ -19,6 +19,7 @@ package org.relique.jdbc.csv;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.sql.Array;
 import java.sql.DatabaseMetaData;
 import java.sql.Date;
 import java.sql.Time;
@@ -846,6 +847,8 @@ public class StringConverter
 			retval = "Timestamp";
 		else if (literal instanceof InputStream)
 			retval = "AsciiStream";
+		else if (literal instanceof Array)
+			retval = "Array";
 		return retval;
 	}
 

--- a/src/main/resources/org/relique/jdbc/csv/messages.properties
+++ b/src/main/resources/org/relique/jdbc/csv/messages.properties
@@ -17,6 +17,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #
 arraySubListOutOfBounds=Array subList out of bounds
+arrayElementTypes=Array element types do not match
 cannotConvertToBigDecimal=Cannot convert value to java.math.BigDecimal
 cannotInferColumns=Cannot infer column types until first row is fetched
 caseNotLogical=CASE condition must result in true or false

--- a/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
@@ -298,4 +298,18 @@ public class TestArrayFunctions
 			}
 		}
 	}
+
+	@Test
+	public void testToArrayInWhereClause() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT name, TO_ARRAY(role_1, role_2) AS roles FROM arrays_sample " +
+			 "WHERE roles = TO_ARRAY('', 'admin')"))
+		{
+			assertTrue(results.next());
+			assertEquals("bob", results.getString(1), "Incorrect row");
+			assertFalse(results.next());
+		}
+	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
@@ -85,7 +85,10 @@ public class TestArrayFunctions
 	@Test
 	public void testToArrayWithIntegerData() throws SQLException
 	{
-		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+		Properties props = new Properties();
+		props.put("columnTypes", "String,String,String,Int,Int");
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
 			 Statement stmt = conn.createStatement();
 			 ResultSet results = stmt.executeQuery("SELECT name,TO_ARRAY(role_id_1, role_id_2) AS roles FROM arrays_sample"))
 		{
@@ -107,6 +110,31 @@ public class TestArrayFunctions
 			assertEquals(2, data.length);
 			assertNull(data[0]);
 			assertEquals(1, data[1]);
+		}
+	}
+
+	@Test
+	public void testToArrayWithDateData() throws SQLException
+	{
+		Properties props = new Properties();
+		props.put("columnTypes", "Int,Int,Int,Date,Time");
+		props.put("dateFormat", "M/D/YYYY");
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT TO_ARRAY(PurchaseDate, PurchaseDate + 28) AS date_range FROM Purchase"))
+		{
+			assertTrue(results.next());
+			Array array = results.getArray(1);
+			assertEquals("Date", array.getBaseTypeName(), "Not an array of dates");
+			assertEquals(Types.DATE, array.getBaseType(), "Not an array of dates");
+			ResultSet arrayResults = array.getResultSet();
+			assertTrue(arrayResults.next());
+			assertEquals(Date.valueOf("2013-01-09"), arrayResults.getDate(2));
+			assertTrue(arrayResults.next());
+			assertEquals(Date.valueOf("2013-02-06"), arrayResults.getDate(2));
+			array.free();
+			assertTrue(results.next());
 		}
 	}
 

--- a/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
@@ -315,6 +315,29 @@ public class TestArrayFunctions
 	}
 
 	@Test
+	public void testToArrayNumericWithWhere() throws SQLException
+	{
+		Properties props = new Properties();
+		props.put("columnTypes", "Integer,Integer,Integer,Long,Float,Double,BigDecimal");
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT TO_ARRAY(C1, C2, C3) AS c FROM numeric " +
+			 "WHERE c = TO_ARRAY(-22, 15, 2147483647)"))
+		{
+			assertTrue(results.next());
+			Array array = results.getArray(1);
+			Object[] data = (Object[]) array.getArray();
+			assertEquals(3, data.length);
+			assertEquals(Integer.valueOf(-22), data[0]);
+			assertEquals(Integer.valueOf(15), data[1]);
+			assertEquals(Integer.valueOf(2147483647), data[2]);
+			array.free();
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
 	public void testToArrayWithWhereWrongColumnType() throws SQLException
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);

--- a/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.sql.*;
+import java.util.Properties;
 
 public class TestArrayFunctions
 {
@@ -300,7 +301,7 @@ public class TestArrayFunctions
 	}
 
 	@Test
-	public void testToArrayInWhereClause() throws SQLException
+	public void testToArrayWithWhere() throws SQLException
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
 			 Statement stmt = conn.createStatement();
@@ -309,6 +310,56 @@ public class TestArrayFunctions
 		{
 			assertTrue(results.next());
 			assertEquals("bob", results.getString(1), "Incorrect row");
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
+	public void testToArrayWithWhereWrongColumnType() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT name, TO_ARRAY(role_1, role_2) AS roles FROM arrays_sample " +
+			 "WHERE roles = 66"))
+		{
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
+	public void testToArrayWithOrderBy() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT name, TO_ARRAY(role_1, role_2) AS roles FROM arrays_sample " +
+			 "ORDER BY roles"))
+		{
+			assertTrue(results.next());
+			assertEquals("bob", results.getString(1), "Incorrect row");
+			assertTrue(results.next());
+			assertEquals("eve", results.getString(1), "Incorrect row");
+
+			Array array = results.getArray(2);
+			ResultSet arrayResults = array.getResultSet();
+			assertTrue(arrayResults.next());
+			assertEquals("", arrayResults.getString(2));
+			assertTrue(arrayResults.next());
+			assertEquals("teacher", arrayResults.getString(2));
+			assertFalse(arrayResults.next());
+
+			assertTrue(results.next());
+			assertEquals("alice", results.getString(1), "Incorrect row");
+			assertTrue(results.next());
+			assertEquals("eve", results.getString(1), "Incorrect row");
+
+			array = results.getArray(2);
+			arrayResults = array.getResultSet();
+			assertTrue(arrayResults.next());
+			assertEquals("teacher", arrayResults.getString(2));
+			assertTrue(arrayResults.next());
+			assertEquals("teacher", arrayResults.getString(2));
+			assertFalse(arrayResults.next());
+
 			assertFalse(results.next());
 		}
 	}


### PR DESCRIPTION
Implement `Comparable` interface for class `SqlArray`, so that array types work correctly in the the WHERE and ORDER BY clauses in SQL statements.

Added unit tests to class `TestArrayFunctions` to test this.

Also improved the logic for deciding the type of elements in an array. Now, the data type of the each element in the array is checked. This is more reliable than evaluating the expression of each element to a string, and then parsing the string to decide the data type. This enables arrays containing dates and times to be used. Added test `testToArrayWithDateData` to test this.

@PeterFokkinga
This also means, I changed your unit test `testToArrayWithIntegerData`, adding `props.put("columnTypes", "String,String,String,Int,Int");`, so the column types are clear, and the type of elements in the SQL array is also clear.

Fixes #84.