### PR TITLE
Throw SQLException for array with elements that are not all the same type

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/SqlArray.java
+++ b/src/main/java/org/relique/jdbc/csv/SqlArray.java
@@ -73,6 +73,7 @@ public class SqlArray implements Array, Comparable<SqlArray>
 	{
 		int index = 0;
 		String firstType = null;
+		int firstIndex = 0;
 		for (String type : inferredTypes)
 		{
 			if (type == null)
@@ -83,12 +84,14 @@ public class SqlArray implements Array, Comparable<SqlArray>
 			{
 				// Save first non-NULL type
 				firstType = type;
+				firstIndex = index;
 			}
 			else if (!type.equals(firstType))
 			{
 				// Every other type must match the first type
 				throw new SQLException(CsvResources.getString("arrayElementTypes") + ": " +
-					"1: " + firstType + " " + (index + 1) + ": " + type);
+					(firstIndex + 1) + ": " + firstType + " " +
+					(index + 1) + ": " + type);
 			}
 			index++;
 		}

--- a/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
+++ b/src/test/java/org/relique/jdbc/csv/TestArrayFunctions.java
@@ -392,6 +392,31 @@ public class TestArrayFunctions
 	}
 
 	@Test
+	public void testToArrayWithTypeMismatch() throws SQLException
+	{
+		Properties props = new Properties();
+		props.put("columnTypes", "Int,Int,Int,Date,Time");
+		props.put("dateFormat", "M/D/YYYY");
+
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath, props);
+			 Statement stmt = conn.createStatement();
+			 ResultSet rs = stmt.executeQuery("SELECT TO_ARRAY(AccountNo, PurchaseDate) FROM Purchase"))
+		{
+			try
+			{
+				assertTrue(rs.next());
+				rs.getArray(1);
+				fail("Array type mismatch should throw SQLException");
+			}
+			catch (SQLException e)
+			{
+				assertTrue(e.toString().startsWith("java.sql.SQLException: " +
+					CsvResources.getString("arrayElementTypes")));
+			}
+		}
+	}
+
+	@Test
 	public void testToArrayWithOrderBy() throws SQLException
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);


### PR DESCRIPTION
Throw an `SQLException`, not an `IllegalStateException` (which is a runtime/unchecked exception), if elements in an array are not all the same type.

For example, for the following SQL statement,:

    SELECT TO_ARRAY(AccountNo, PurchaseDate) FROM Purchase

the following SQLException will be thrown:

    java.sql.SQLException: Array element types do not match: 1: Int 2: Date

Added unit test `testToArrayWithTypeMismatch` to test this.

Fixes #87