### PR TITLE
Added LINE_NUMBER() SQL function

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -57,6 +57,7 @@ TO_ARRAY([DISTINCT] N1, N2, ...) | Returns java.sql.Array containing (optionally
 DAYOFMONTH(D)        |Extracts day of month from date or timestamp D (first day of month is 1)
 HOUROFDAY(T)         |Extracts hour of day from time or timestamp T
 LENGTH(S)            |Returns length of string
+LINE_NUMBER()        |Returns line number of row in CSV file
 LOWER(S)             |Converts string to lower case
 LTRIM(S [, T])       |Removes leading characters from S that occur in T
 MINUTE(T)            |Extracts minute of hour from time or timestamp T

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -57,7 +57,7 @@ TO_ARRAY([DISTINCT] N1, N2, ...) | Returns java.sql.Array containing (optionally
 DAYOFMONTH(D)        |Extracts day of month from date or timestamp D (first day of month is 1)
 HOUROFDAY(T)         |Extracts hour of day from time or timestamp T
 LENGTH(S)            |Returns length of string
-LINE_NUMBER()        |Returns line number of row in CSV file (0 if row not corresponding to a line)
+LINE_NUMBER()        |Returns line number of row in CSV file (NULL if row not corresponding to a line)
 LOWER(S)             |Converts string to lower case
 LTRIM(S [, T])       |Removes leading characters from S that occur in T
 MINUTE(T)            |Extracts minute of hour from time or timestamp T

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -57,7 +57,7 @@ TO_ARRAY([DISTINCT] N1, N2, ...) | Returns java.sql.Array containing (optionally
 DAYOFMONTH(D)        |Extracts day of month from date or timestamp D (first day of month is 1)
 HOUROFDAY(T)         |Extracts hour of day from time or timestamp T
 LENGTH(S)            |Returns length of string
-LINE_NUMBER()        |Returns line number of row in CSV file
+LINE_NUMBER()        |Returns line number of row in CSV file (0 if row not corresponding to a line)
 LOWER(S)             |Converts string to lower case
 LTRIM(S [, T])       |Removes leading characters from S that occur in T
 MINUTE(T)            |Extracts minute of hour from time or timestamp T

--- a/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
@@ -122,6 +122,8 @@ public class CsvResultSet implements ResultSet
 
 	private int limit;
 
+	private int offset;
+
 	private int maxDataLines;
 
 	private boolean isClosed = false;
@@ -236,6 +238,7 @@ public class CsvResultSet implements ResultSet
 		fetchSize = statement.getFetchSize();
 		fetchDirection = statement.getFetchDirection();
 		this.limit = sqlLimit;
+		this.offset = sqlOffset;
 		this.resultSetType = resultSetType;
 		this.reader = reader;
 		this.tableName = tableName;
@@ -933,6 +936,15 @@ public class CsvResultSet implements ResultSet
 			{
 				recordEnvironment = reader.getEnvironment();
 				recordEnvironment.put(CsvStatement.STATEMENT_COLUMN_NAME, statement);
+
+				/*
+				 * Always include line number in CSV file, so it can be evaluated later.
+				 */
+				String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
+				int lineNumber = this.currentRow + 1;
+				if (this.offset > 0)
+					lineNumber += this.offset;
+				recordEnvironment.put(key, Integer.valueOf(lineNumber));
 			}
 			else
 			{

--- a/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
@@ -1086,6 +1086,12 @@ public class CsvResultSet implements ResultSet
 
 	private void addLineNumberEnvironment(Map<String, Object> recordEnvironment) throws SQLException
 	{
+		/*
+		 * No line numbers if rows are grouped.
+		 */
+		if (this.groupByColumns != null)
+			return;
+
 		String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
 		int lineNumber = this.currentRow + this.nonMatchingRows + 1;
 		if (this.offset > 0)

--- a/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
@@ -943,11 +943,7 @@ public class CsvResultSet implements ResultSet
 				/*
 				 * Always include line number in CSV file, so it can be evaluated later.
 				 */
-				String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
-				int lineNumber = this.currentRow + this.nonMatchingRows + 1;
-				if (this.offset > 0)
-					lineNumber += this.offset;
-				recordEnvironment.put(key, Integer.valueOf(lineNumber));
+				addLineNumberEnvironment(recordEnvironment);
 			}
 			else
 			{
@@ -985,11 +981,7 @@ public class CsvResultSet implements ResultSet
 						/*
 						 * Always include line number in CSV file, so it can be evaluated later.
 						 */
-						String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
-						int lineNumber = this.currentRow + this.nonMatchingRows + 1;
-						if (this.offset > 0)
-							lineNumber += this.offset;
-						recordEnvironment.put(key, Integer.valueOf(lineNumber));
+						addLineNumberEnvironment(recordEnvironment);
 					}
 					else
 					{
@@ -1008,11 +1000,7 @@ public class CsvResultSet implements ResultSet
 					/*
 					 * Always include line number in CSV file, so it can be evaluated later.
 					 */
-					String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
-					int lineNumber = this.currentRow + this.nonMatchingRows + 1;
-					if (this.offset > 0)
-						lineNumber += this.offset;
-					env.put(key, Integer.valueOf(lineNumber));
+					addLineNumberEnvironment(env);
 
 					bufferedRecordEnvironments.add(env);
 					currentRow++;
@@ -1094,6 +1082,15 @@ public class CsvResultSet implements ResultSet
 			objectEnvironment.put(key, statement);
 
 		return objectEnvironment;
+	}
+
+	private void addLineNumberEnvironment(Map<String, Object> recordEnvironment) throws SQLException
+	{
+		String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
+		int lineNumber = this.currentRow + this.nonMatchingRows + 1;
+		if (this.offset > 0)
+			lineNumber += this.offset;
+		recordEnvironment.put(key, Integer.valueOf(lineNumber));
 	}
 
 	private boolean addDistinctEnvironment(Map<String, Object> objectEnvironment) throws SQLException

--- a/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResultSet.java
@@ -109,6 +109,9 @@ public class CsvResultSet implements ResultSet
 
 	private int currentRow;
 
+	/** Number of rows that have not matched the where clause and have been skipped */
+	private int nonMatchingRows;
+
 	private boolean hitTail = false;
 
 	/** Result of last call to next() */
@@ -941,7 +944,7 @@ public class CsvResultSet implements ResultSet
 				 * Always include line number in CSV file, so it can be evaluated later.
 				 */
 				String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
-				int lineNumber = this.currentRow + 1;
+				int lineNumber = this.currentRow + this.nonMatchingRows + 1;
 				if (this.offset > 0)
 					lineNumber += this.offset;
 				recordEnvironment.put(key, Integer.valueOf(lineNumber));
@@ -972,11 +975,21 @@ public class CsvResultSet implements ResultSet
 							}
 						}
 					}
+					this.nonMatchingRows++;
 					thereWasAnAnswer = reader.next();
 					if(thereWasAnAnswer)
 					{
 						recordEnvironment = reader.getEnvironment();
 						recordEnvironment.put(CsvStatement.STATEMENT_COLUMN_NAME, statement);
+
+						/*
+						 * Always include line number in CSV file, so it can be evaluated later.
+						 */
+						String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
+						int lineNumber = this.currentRow + this.nonMatchingRows + 1;
+						if (this.offset > 0)
+							lineNumber += this.offset;
+						recordEnvironment.put(key, Integer.valueOf(lineNumber));
 					}
 					else
 					{
@@ -991,6 +1004,16 @@ public class CsvResultSet implements ResultSet
 				{
 					Map<String, Object> env = reader.getEnvironment();
 					env.put(CsvStatement.STATEMENT_COLUMN_NAME, statement);
+
+					/*
+					 * Always include line number in CSV file, so it can be evaluated later.
+					 */
+					String key = SQLLineNumberFunction.LINE_NUMBER_COLUMN_NAME;
+					int lineNumber = this.currentRow + this.nonMatchingRows + 1;
+					if (this.offset > 0)
+						lineNumber += this.offset;
+					env.put(key, Integer.valueOf(lineNumber));
+
 					bufferedRecordEnvironments.add(env);
 					currentRow++;
 				}

--- a/src/main/java/org/relique/jdbc/csv/SQLLineNumberFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLLineNumberFunction.java
@@ -39,7 +39,6 @@ class SQLLineNumberFunction extends Expression
 	@Override
 	public Object eval(Map<String, Object> env) throws SQLException
 	{
-		//return new ColumnName(CsvStatement.LINE_NUMBER_COLUMN_NAME).eval(env);
 		return expression.eval(env);
 	}
 	@Override

--- a/src/main/java/org/relique/jdbc/csv/SQLLineNumberFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLLineNumberFunction.java
@@ -1,0 +1,60 @@
+/*
+ *  CsvJdbc - a JDBC driver for CSV files
+ *  Copyright (C) 2023 Simon Chenery
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.relique.jdbc.csv;
+
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class SQLLineNumberFunction extends Expression
+{
+	/*
+	 * Key for column name in database rows for accessing line number in CSV file.
+	 */
+	public static final String LINE_NUMBER_COLUMN_NAME = "@LINE_NUMBER";
+
+	private Expression expression = new ColumnName(LINE_NUMBER_COLUMN_NAME);
+
+	public SQLLineNumberFunction()
+	{
+	}
+	@Override
+	public Object eval(Map<String, Object> env) throws SQLException
+	{
+		//return new ColumnName(CsvStatement.LINE_NUMBER_COLUMN_NAME).eval(env);
+		return expression.eval(env);
+	}
+	@Override
+	public String toString()
+	{
+		return "LINE_NUMBER()";
+	}
+	@Override
+	public List<String> usedColumns(Set<String> availableColumns)
+	{
+		return new LinkedList<>();
+	}
+	@Override
+	public List<AggregateFunction> aggregateFunctions()
+	{
+		return new LinkedList<>();
+	}
+}

--- a/src/main/javacc/org/relique/jdbc/csv/where.jj
+++ b/src/main/javacc/org/relique/jdbc/csv/where.jj
@@ -332,6 +332,10 @@ TOKEN:
 }
 TOKEN:
 {
+	<LINE_NUMBER:"LINE_NUMBER">
+}
+TOKEN:
+{
 	<COUNT:"COUNT">
 }
 TOKEN:
@@ -1020,6 +1024,10 @@ Expression simpleExpression():
 	{
 		return new SQLToArrayFunction(isDistinct, args);
 	}
+	| <LINE_NUMBER> <OPENPARENTHESIS> <CLOSEPARENTHESIS>
+	{
+		return new SQLLineNumberFunction();
+	}
 	| <COUNT> <OPENPARENTHESIS>{isDistinct = false;}
 		(<DISTINCT>{isDistinct = true;})?
 		arg = countOperation() <CLOSEPARENTHESIS>
@@ -1146,7 +1154,7 @@ Expression columnName():
 	Token t;
 }
 {
-	(t=<NAME>|t=<DAYOFMONTH>|t=<MONTH>|t=<YEAR>|t=<HOUROFDAY>|t=<MINUTE>|t=<SECOND>|t=<LOWER>|t=<ROUND>|t=<UPPER>|t=<TRIM>|t=<LTRIM>|t=<RTRIM>|t=<SUBSTRING>|t=<REPLACE>|t=<LENGTH>|t=<NULLIF>|t=<ABS>|t=<COALESCE>|t=<AVG>|t=<COUNT>|t=<MAX>|t=<MIN>|t=<SUM>t=<STRING_AGG>|t=<ARRAY_AGG>|t=<TO_ARRAY>)
+	(t=<NAME>|t=<DAYOFMONTH>|t=<MONTH>|t=<YEAR>|t=<HOUROFDAY>|t=<MINUTE>|t=<SECOND>|t=<LOWER>|t=<ROUND>|t=<UPPER>|t=<TRIM>|t=<LTRIM>|t=<RTRIM>|t=<SUBSTRING>|t=<REPLACE>|t=<LENGTH>|t=<NULLIF>|t=<ABS>|t=<COALESCE>|t=<AVG>|t=<COUNT>|t=<MAX>|t=<MIN>|t=<SUM>t=<STRING_AGG>|t=<ARRAY_AGG>|t=<TO_ARRAY>|t=<LINE_NUMBER>)
 	{
 		return new ColumnName(StringConverter.removeQuotes(t.image));
 	}
@@ -1212,7 +1220,7 @@ Expression columnAlias():
 	Token t;
 }
 {
-	(t=<NAME>|t=<DAYOFMONTH>|t=<MONTH>|t=<YEAR>|t=<HOUROFDAY>|t=<MINUTE>|t=<SECOND>|t=<LOWER>|t=<ROUND>|t=<UPPER>|t=<TRIM>|t=<LTRIM>|t=<RTRIM>|t=<SUBSTRING>|t=<REPLACE>|t=<LENGTH>|t=<NULLIF>|t=<ABS>|t=<COALESCE>|t=<AVG>|t=<COUNT>|t=<MAX>|t=<MIN>|t=<SUM>|t=<STRING_AGG>|t=<ARRAY_AGG>|t=<TO_ARRAY>)
+	(t=<NAME>|t=<DAYOFMONTH>|t=<MONTH>|t=<YEAR>|t=<HOUROFDAY>|t=<MINUTE>|t=<SECOND>|t=<LOWER>|t=<ROUND>|t=<UPPER>|t=<TRIM>|t=<LTRIM>|t=<RTRIM>|t=<SUBSTRING>|t=<REPLACE>|t=<LENGTH>|t=<NULLIF>|t=<ABS>|t=<COALESCE>|t=<AVG>|t=<COUNT>|t=<MAX>|t=<MIN>|t=<SUM>|t=<STRING_AGG>|t=<ARRAY_AGG>|t=<TO_ARRAY>|t=<LINE_NUMBER>)
 	{
 		return new ColumnName(StringConverter.removeQuotes(t.image));
 	}

--- a/src/test/java/org/relique/jdbc/csv/RunSuite.java
+++ b/src/test/java/org/relique/jdbc/csv/RunSuite.java
@@ -38,6 +38,7 @@ import org.junit.platform.suite.api.Suite;
 	TestOrderBy.class,
 	TestGroupBy.class,
 	TestLimitOffset.class,
+	TestLineNumber.class,
 	TestFixedWidthFiles.class,
 	TestDoubleQuoting.class,
 	TestSubQuery.class,

--- a/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
@@ -188,6 +188,7 @@ public class TestLineNumber
 		{
 			assertTrue(results.next());
 			assertEquals(0, results.getInt(2));
+			assertTrue(results.wasNull());
 
 			assertFalse(results.next());
 		}

--- a/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
@@ -195,6 +195,32 @@ public class TestLineNumber
 	}
 
 	@Test
+	public void testLineNumbersGroupBy() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT NAME, COUNT(NAME), LINE_NUMBER() FROM scores GROUP BY NAME"))
+		{
+			assertTrue(results.next());
+			assertEquals(0, results.getInt(3));
+			assertTrue(results.wasNull());
+
+			assertTrue(results.next());
+			assertEquals(0, results.getInt(3));
+			assertTrue(results.wasNull());
+
+			assertTrue(results.next());
+			assertEquals(0, results.getInt(3));
+			assertTrue(results.wasNull());
+
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
 	public void testLineNumbersScrollable() throws SQLException
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);

--- a/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
@@ -169,4 +169,33 @@ public class TestLineNumber
 			assertFalse(results.next());
 		}
 	}
+
+	@Test
+	public void testLineNumbersScrollable() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+
+			Statement stmt = conn.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+				ResultSet.CONCUR_READ_ONLY);
+
+			ResultSet results = stmt
+				.executeQuery("SELECT ID, LINE_NUMBER() FROM sample"))
+		{
+			assertTrue(results.last());
+			assertEquals("X234", results.getString(1));
+			assertEquals(6, results.getInt(2));
+
+			assertTrue(results.previous());
+			assertEquals("D789", results.getString(1));
+			assertEquals(5, results.getInt(2));
+
+			assertTrue(results.first());
+			assertEquals("Q123", results.getString(1));
+			assertEquals(1, results.getInt(2));
+
+			assertTrue(results.next());
+			assertEquals("A123", results.getString(1));
+			assertEquals(2, results.getInt(2));
+		}
+	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
@@ -114,10 +114,6 @@ public class TestLineNumber
 			assertEquals("B234", results.getString(2));
 
 			assertTrue(results.next());
-			assertEquals(3, results.getInt(1));
-			assertEquals("B234", results.getString(2));
-
-			assertTrue(results.next());
 			assertEquals(4, results.getInt(1));
 			assertEquals("C456", results.getString(2));
 

--- a/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
@@ -1,0 +1,176 @@
+/*
+CsvJdbc - a JDBC driver for CSV files
+Copyright (C) 2023  Simon Chenery
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.relique.jdbc.csv;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This class tests SQL LIMIT OFFSET keywords in the CsvJdbc driver.
+ */
+public class TestLineNumber
+{
+	private static String filePath;
+
+	@BeforeAll
+	public static void setUp()
+	{
+		filePath = ".." + File.separator + "src" + File.separator + "testdata";
+		if (!new File(filePath).isDirectory())
+			filePath = "src" + File.separator + "testdata";
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
+
+		// load CSV driver
+		try
+		{
+			Class.forName("org.relique.jdbc.csv.CsvDriver");
+		}
+		catch (ClassNotFoundException e)
+		{
+			fail("Driver is not in the CLASSPATH -> " + e);
+		}
+	}
+
+	@Test
+	public void testLineNumbersSimple() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT LINE_NUMBER(), NAME FROM sample"))
+		{
+			for (int i = 1; i <= 6; i++)
+			{
+				assertTrue(results.next());
+				assertEquals(i, results.getInt(1));
+			}
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
+	public void testLineNumbersWhere() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT LINE_NUMBER(), NAME FROM sample WHERE ID = 'C456'"))
+		{
+			assertTrue(results.next());
+			assertEquals(4, results.getInt(1));
+
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
+	public void testLineNumbersOrderBy() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT LINE_NUMBER(), ID FROM sample ORDER BY ID"))
+		{
+			assertTrue(results.next());
+			assertEquals(2, results.getInt(1));
+			assertEquals("A123", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals(3, results.getInt(1));
+			assertEquals("B234", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals(3, results.getInt(1));
+			assertEquals("B234", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals(4, results.getInt(1));
+			assertEquals("C456", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals(5, results.getInt(1));
+			assertEquals("D789", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals(1, results.getInt(1));
+			assertEquals("Q123", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals(6, results.getInt(1));
+			assertEquals("X234", results.getString(2));
+
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
+	public void testLineNumbersOffset() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT LINE_NUMBER(), ID FROM sample LIMIT 9 OFFSET 4"))
+		{
+			assertTrue(results.next());
+			assertEquals(5, results.getInt(1));
+
+			assertTrue(results.next());
+			assertEquals(6, results.getInt(1));
+
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
+	public void testLineNumbersAggregateFunction() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT MAX(ID), LINE_NUMBER() FROM sample"))
+		{
+			assertTrue(results.next());
+			assertEquals(0, results.getInt(2));
+
+			assertFalse(results.next());
+		}
+	}
+}

--- a/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
+++ b/src/test/java/org/relique/jdbc/csv/TestLineNumber.java
@@ -134,6 +134,29 @@ public class TestLineNumber
 	}
 
 	@Test
+	public void testLineNumbersWhereOrderBy() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+
+			Statement stmt = conn.createStatement();
+
+			ResultSet results = stmt
+				.executeQuery("SELECT LINE_NUMBER(), EXTRA_FIELD FROM sample " +
+					"WHERE ID = 'C456' OR ID = 'Q123' ORDER BY ID"))
+		{
+			assertTrue(results.next());
+			assertEquals(4, results.getInt(1));
+			assertEquals("C", results.getString(2));
+
+			assertTrue(results.next());
+			assertEquals(1, results.getInt(1));
+			assertEquals("F", results.getString(2));
+
+			assertFalse(results.next());
+		}
+	}
+
+	@Test
 	public void testLineNumbersOffset() throws SQLException
 	{
 		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);


### PR DESCRIPTION
Added SQL function to return the line number of each result record in the CSV file, or NULL if the result record does not correspond to a single line in the CSV file.

Added new unit test class `TestLineNumber` to check this functionality.

Fixes #91