### PR TITLE
Update CsvJdbc to Java 11

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -37,7 +37,7 @@ add the following lines to the `pom.xml` file.
         <dependency>
           <groupId>net.sourceforge.csvjdbc</groupId>
           <artifactId>csvjdbc</artifactId>
-          <version>1.0.35</version>
+          <version>1.0.41</version>
         </dependency>
       </dependencies>
 

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -100,7 +100,7 @@ methods; an `IllegalStateException` is thrown if values of different types are d
 
 ## Dependencies
 
-CsvJdbc requires Java version 8, or later. For reading DBF files,
+CsvJdbc requires Java version 11, or later. For reading DBF files,
 [DANS DBF Library](http://dans-dbf-lib.sourceforge.net/)
 must be downloaded and included in the CLASSPATH.
 

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -321,9 +321,7 @@ public class MyHTTPReader implements TableReader
   public List getTableNames(Connection connection)
   {
     // Return list of available table names
-    Vector v = new Vector();
-    v.add("sample");
-    return v;
+    return List.of("sample");
   }
 }
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -8,7 +8,7 @@ Use the following steps to create a CsvJdbc release.
 java -version
 ```
 
-must be 8.
+must be 11.
 
 * Checkout from GitHub
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.13.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/org/relique/io/XORCipher.java
+++ b/src/main/java/org/relique/io/XORCipher.java
@@ -18,6 +18,7 @@ package org.relique.io;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 
 /**
  * Example encryption filter that XOR's the all data with a secret seed value.
@@ -69,14 +70,8 @@ public class XORCipher implements CryptoFilter
 	{
 		StringBuilder sb = new StringBuilder("XORCipher(");
 		sb.append(scrambleKey.length);
-		sb.append("):'");
-		for (int i = 0; i < scrambleKey.length; i++)
-		{
-			if (i > 0)
-				sb.append(' ');
-			sb.append(i);
-		}
-		sb.append("'");
+		sb.append("):");
+		sb.append(Arrays.toString(scrambleKey));
 		return sb.toString();
 	}
 

--- a/src/main/java/org/relique/jdbc/csv/CsvConnection.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvConnection.java
@@ -1499,7 +1499,7 @@ public class CsvConnection implements Connection
 			 */
 			List<String> list = tableReader.getTableNames(this);
 			if (list != null)
-				tableNames = list;
+				tableNames.addAll(list);
 		}
 
 		/*

--- a/src/test/java/org/relique/jdbc/csv/TableReaderTester.java
+++ b/src/test/java/org/relique/jdbc/csv/TableReaderTester.java
@@ -24,7 +24,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
-import java.util.Vector;
 
 import org.relique.io.TableReader;
 
@@ -47,9 +46,6 @@ public class TableReaderTester implements TableReader
 	@Override
 	public List<String> getTableNames(Connection connection) throws SQLException
 	{
-		Vector<String> v = new Vector<>();
-		v.add("AIRLINE");
-		v.add("AIRPORT");
-		return v;
+		return List.of("AIRLINE", "AIRPORT");
 	}		
 }


### PR DESCRIPTION
Update build and documentation to Java 11.

It is not practical to convert CsvJdbc to a Java Module, because the JAR files that CsvJdbc depends on (dans-dbf-lib, classgraph) are not modules.

Fixes #93