### PR TITLE
Do not add file tail to column values spread across multiple lines

### DIFF
--- a/src/main/java/org/relique/io/FileSetInputStream.java
+++ b/src/main/java/org/relique/io/FileSetInputStream.java
@@ -51,11 +51,12 @@ public class FileSetInputStream extends InputStream
 	private Pattern fileNameRE;
 	private String separator;
 	private Character quotechar;
+	private String quoteStyle;
 	private String dataTail;
 	private boolean prepend;
 	private int lookahead = '\n';
 	private int lookahead2 = -1;
-	private boolean inQuotedValue = false;
+	private int quoteCountForRecord = 0;
 	private boolean doingTail;
 	private int currentLineLength;
 	private CryptoFilter filter;
@@ -75,6 +76,7 @@ public class FileSetInputStream extends InputStream
 	 * @param separator
 	 *            the separator to use when faking output (typically the ",").
 	 * @param quotechar the character used to quote column values containing the separator, or null for no quoting.
+	 * @param quoteStyle either "SQL" or "C" for rule for escaping quote characters in column values.
 	 * @param prepend
 	 *            whether the extra fields should precede the ones from the file
 	 *            content.
@@ -84,7 +86,7 @@ public class FileSetInputStream extends InputStream
 	 * @throws IOException if a file cannot be opened or read.
 	 */
 	public FileSetInputStream(String dirName, String fileNamePattern,
-			String[] fieldsInName, String separator, Character quotechar, boolean prepend,
+			String[] fieldsInName, String separator, Character quotechar, String quoteStyle, boolean prepend,
 			boolean headerless, CryptoFilter filter, int skipLeadingDataLines,
 			String charset)
 			throws IOException
@@ -100,6 +102,7 @@ public class FileSetInputStream extends InputStream
 		this.prepend = prepend;
 		this.separator = separator;
 		this.quotechar = quotechar;
+		this.quoteStyle = quoteStyle;
 		tail = "";
 		if (prepend)
 		{
@@ -224,7 +227,7 @@ public class FileSetInputStream extends InputStream
 			}
 			doingTail = false;
 			currentLineLength = 0;
-			inQuotedValue = false;
+			quoteCountForRecord = 0;
 		}
 
 		// shift the lookahead into the current char and get the new lookahead.
@@ -260,19 +263,29 @@ public class FileSetInputStream extends InputStream
 		}
 		while (lookahead == '\r');
 
-		if (quotechar != null && ch == quotechar.charValue())
+		if (quotechar != null)
 		{
-			// Keep track of whether we are in a quoted column value, so we can
-			// avoid adding the file tail to a column value spread across multiple
-			// lines.
-			inQuotedValue = !inQuotedValue;
+			// Keep a count of the number of quotes in current record, so we can
+			// detect whether the record is split across multiple lines (an odd
+			// number of quotes when the end of the line is reached), and avoid
+			// adding the file tail in this situation.
+			if (ch == quotechar.charValue())
+			{
+				quoteCountForRecord++;
+			}
+			else if (ch == '\\' && lookahead == quotechar.charValue() && "C".equals(quoteStyle))
+			{
+				// Also count both '\' and '"' as quote characters, so that quote
+				// count remains even and escaped quote does not count as a quote.
+				quoteCountForRecord++;
+			}
 		}
 
 		// if we met a line border we have to output the lead/tail
 		if (prepend)
 		{
 			// prepending a non empty line...
-			if (ch == '\n' && !(lookahead == '\n' || lookahead == -1) && !inQuotedValue)
+			if (ch == '\n' && !(lookahead == '\n' || lookahead == -1) && quoteCountForRecord % 2 == 0)
 			{
 				doingTail = true;
 				ch = readFromTail();
@@ -289,7 +302,7 @@ public class FileSetInputStream extends InputStream
 		else
 		{
 			// appending to the end of just any line
-			if (currentLineLength > 0 && (ch == '\n' || ch == -1) && !inQuotedValue)
+			if (currentLineLength > 0 && (ch == '\n' || ch == -1) && quoteCountForRecord % 2 == 0)
 			{
 				doingTail = true;
 				if (ch == '\n' && lookahead == 0 &&
@@ -341,6 +354,7 @@ public class FileSetInputStream extends InputStream
 				}
 				while (ch2 != '\n' && ch2 != -1);
 			}
+			quoteCountForRecord = 0;
 			doingTail = prepend;
 			if (doingTail)
 				pos = 1;

--- a/src/main/java/org/relique/io/FileSetInputStream.java
+++ b/src/main/java/org/relique/io/FileSetInputStream.java
@@ -50,10 +50,12 @@ public class FileSetInputStream extends InputStream
 	private int pos;
 	private Pattern fileNameRE;
 	private String separator;
+	private Character quotechar;
 	private String dataTail;
 	private boolean prepend;
 	private int lookahead = '\n';
 	private int lookahead2 = -1;
+	private boolean inQuotedValue = false;
 	private boolean doingTail;
 	private int currentLineLength;
 	private CryptoFilter filter;
@@ -72,6 +74,7 @@ public class FileSetInputStream extends InputStream
 	 *            the names of the fields contained in the file name.
 	 * @param separator
 	 *            the separator to use when faking output (typically the ",").
+	 * @param quotechar the character used to quote column values containing the separator, or null for no quoting.
 	 * @param prepend
 	 *            whether the extra fields should precede the ones from the file
 	 *            content.
@@ -81,7 +84,7 @@ public class FileSetInputStream extends InputStream
 	 * @throws IOException if a file cannot be opened or read.
 	 */
 	public FileSetInputStream(String dirName, String fileNamePattern,
-			String[] fieldsInName, String separator, boolean prepend,
+			String[] fieldsInName, String separator, Character quotechar, boolean prepend,
 			boolean headerless, CryptoFilter filter, int skipLeadingDataLines,
 			String charset)
 			throws IOException
@@ -96,6 +99,7 @@ public class FileSetInputStream extends InputStream
 		// Initialising tail for header...
 		this.prepend = prepend;
 		this.separator = separator;
+		this.quotechar = quotechar;
 		tail = "";
 		if (prepend)
 		{
@@ -220,6 +224,7 @@ public class FileSetInputStream extends InputStream
 			}
 			doingTail = false;
 			currentLineLength = 0;
+			inQuotedValue = false;
 		}
 
 		// shift the lookahead into the current char and get the new lookahead.
@@ -255,11 +260,19 @@ public class FileSetInputStream extends InputStream
 		}
 		while (lookahead == '\r');
 
+		if (quotechar != null && ch == quotechar.charValue())
+		{
+			// Keep track of whether we are in a quoted column value, so we can
+			// avoid adding the file tail to a column value spread across multiple
+			// lines.
+			inQuotedValue = !inQuotedValue;
+		}
+
 		// if we met a line border we have to output the lead/tail
 		if (prepend)
 		{
 			// prepending a non empty line...
-			if (ch == '\n' && !(lookahead == '\n' || lookahead == -1))
+			if (ch == '\n' && !(lookahead == '\n' || lookahead == -1) && !inQuotedValue)
 			{
 				doingTail = true;
 				ch = readFromTail();
@@ -276,7 +289,7 @@ public class FileSetInputStream extends InputStream
 		else
 		{
 			// appending to the end of just any line
-			if (currentLineLength > 0 && (ch == '\n' || ch == -1))
+			if (currentLineLength > 0 && (ch == '\n' || ch == -1) && !inQuotedValue)
 			{
 				doingTail = true;
 				if (ch == '\n' && lookahead == 0 &&

--- a/src/main/java/org/relique/jdbc/csv/CsvStatement.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvStatement.java
@@ -396,6 +396,7 @@ public class CsvStatement implements Statement
 								nameParts,
 								connection.getSeparator(),
 								connection.getQuotechar(),
+								connection.getQuoteStyle(),
 								connection.isFileTailPrepend(),
 								connection.isSuppressHeaders(),
 								filter,

--- a/src/main/java/org/relique/jdbc/csv/CsvStatement.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvStatement.java
@@ -395,6 +395,7 @@ public class CsvStatement implements Statement
 								fileNamePattern,
 								nameParts,
 								connection.getSeparator(),
+								connection.getQuotechar(),
 								connection.isFileTailPrepend(),
 								connection.isSuppressHeaders(),
 								filter,

--- a/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
@@ -276,6 +276,8 @@ public class TestFileSetInputStream
 			assertEquals("3", line);
 			line = in.readLine();
 			assertEquals("value spread across three lines\",three,011020182", line);
+			line = in.readLine();
+			assertEquals("\"4 value containing \"\"quotes\"\"\",four,011020182", line);
 		}
 	}
 
@@ -302,6 +304,8 @@ public class TestFileSetInputStream
 			assertEquals("3", line);
 			line = in.readLine();
 			assertEquals("value spread across three lines\",three", line);
+			line = in.readLine();
+			assertEquals("011020182,\"4 value containing \"\"quotes\"\"\",four", line);
 		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
@@ -278,4 +278,30 @@ public class TestFileSetInputStream
 			assertEquals("value spread across three lines\",three,011020182", line);
 		}
 	}
+
+	@Test
+	public void testFileSetInputStreamMultilinePrepend() throws IOException
+	{
+		try (BufferedReader in = new BufferedReader(new InputStreamReader(
+					new FileSetInputStream(filePath,
+						"Hutchenson_(\\d+).txt", new String[] {
+						"Date"}, ",", Character.valueOf('"'), true, false, null, 0, null))))
+		{
+			// Check that fileTail is correctly prepended to records spread across multiple lines
+			String line = in.readLine();
+			assertEquals("Date,Col1,Col2", line);
+			line = in.readLine();
+			assertEquals("011020182,\"1", line);
+			line = in.readLine();
+			assertEquals("value spread across multiple lines\",one", line);
+			line = in.readLine();
+			assertEquals("011020182,\"2 value on single a line\",\"two\"", line);
+			line = in.readLine();
+			assertEquals("011020182,\"3", line);
+			line = in.readLine();
+			assertEquals("3", line);
+			line = in.readLine();
+			assertEquals("value spread across three lines\",three", line);
+		}
+	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
@@ -68,7 +68,7 @@ public class TestFileSetInputStream
 			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", false, false, null, 0, null))))
+								"location", "file_date" }, ",", Character.valueOf('"'), false, false, null, 0, null))))
 		{
 			Set<String> refSet = new HashSet<>();
 			Set<String> testSet = new HashSet<>();
@@ -97,7 +97,7 @@ public class TestFileSetInputStream
 			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", true, false, null, 0, null))))
+								"location", "file_date" }, ",", Character.valueOf('"'), true, false, null, 0, null))))
 		{
 			Set<String> refSet = new HashSet<>();
 			Set<String> testSet = new HashSet<>();
@@ -126,7 +126,7 @@ public class TestFileSetInputStream
 			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"headerless-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", true, true, null, 0, null))))
+								"location", "file_date" }, ",", Character.valueOf('"'), true, true, null, 0, null))))
 		{
 			Set<String> refSet = new HashSet<>();
 			Set<String> testSet = new HashSet<>();
@@ -153,7 +153,7 @@ public class TestFileSetInputStream
 			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"empty-([0-9]+).txt", new String[] {
-							"EMPTY_ID"}, ",", false, false, null, 0, null))))
+							"EMPTY_ID"}, ",", Character.valueOf('"'), false, false, null, 0, null))))
 		{
 			Set<String> refSet = new HashSet<>();
 			Set<String> testSet = new HashSet<>();
@@ -180,7 +180,7 @@ public class TestFileSetInputStream
 		try (BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"petr-([0-9]{3})-([0-9]{3}).csv", new String[] {
-								"part1", "part2" }, separator, true, true, null, 0, null))))
+								"part1", "part2" }, separator, Character.valueOf('"'), true, true, null, 0, null))))
 		{
 			String lineTest = inputTest.readLine();
 			while (lineTest != null)
@@ -200,7 +200,7 @@ public class TestFileSetInputStream
 	{
 		try (FileSetInputStream in = new FileSetInputStream(filePath,
 					"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-					"location", "file_date"}, ",", false, false, null, 0, null))
+					"location", "file_date"}, ",", Character.valueOf('"'), false, false, null, 0, null))
 		{
 			in.read();
 			in.read();
@@ -224,7 +224,7 @@ public class TestFileSetInputStream
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(
 					new FileSetInputStream(filePath,
 						"utf16le_(\\d+).txt", new String[] {
-						"date"}, "|", false, false, null, 0, charset), charset)))
+						"date"}, "|", Character.valueOf('"'), false, false, null, 0, charset), charset)))
 		{
 			String line = in.readLine();
 			assertEquals("Col1|Col2|Some third|4th|date", line);
@@ -242,7 +242,7 @@ public class TestFileSetInputStream
 		{
 		    try (FileSetInputStream in = new FileSetInputStream("????",
 			"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-			"location", "file_date"}, ",", false, false, null, 0, null))
+			"location", "file_date"}, ",", Character.valueOf('"'), false, false, null, 0, null))
 		    {
 			fail("expected exception java.io.IOException");
 		    }
@@ -250,6 +250,32 @@ public class TestFileSetInputStream
 		catch (IOException e)
 		{
 			assertTrue(("" + e).contains("IOException"));
+		}
+	}
+
+	@Test
+	public void testFileSetInputStreamMultiline() throws IOException
+	{
+		try (BufferedReader in = new BufferedReader(new InputStreamReader(
+					new FileSetInputStream(filePath,
+						"Hutchenson_(\\d+).txt", new String[] {
+						"Date"}, ",", Character.valueOf('"'), false, false, null, 0, null))))
+		{
+			// Check that fileTail is correctly added to records spread across multiple lines
+			String line = in.readLine();
+			assertEquals("Col1,Col2,Date", line);
+			line = in.readLine();
+			assertEquals("\"1", line);
+			line = in.readLine();
+			assertEquals("value spread across multiple lines\",one,011020182", line);
+			line = in.readLine();
+			assertEquals("\"2 value on single a line\",\"two\",011020182", line);
+			line = in.readLine();
+			assertEquals("\"3", line);
+			line = in.readLine();
+			assertEquals("3", line);
+			line = in.readLine();
+			assertEquals("value spread across three lines\",three,011020182", line);
 		}
 	}
 }

--- a/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
+++ b/src/test/java/org/relique/jdbc/csv/TestFileSetInputStream.java
@@ -68,7 +68,7 @@ public class TestFileSetInputStream
 			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", Character.valueOf('"'), false, false, null, 0, null))))
+								"location", "file_date" }, ",", Character.valueOf('"'), "SQL", false, false, null, 0, null))))
 		{
 			Set<String> refSet = new HashSet<>();
 			Set<String> testSet = new HashSet<>();
@@ -97,7 +97,7 @@ public class TestFileSetInputStream
 			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", Character.valueOf('"'), true, false, null, 0, null))))
+								"location", "file_date" }, ",", Character.valueOf('"'), "SQL", true, false, null, 0, null))))
 		{
 			Set<String> refSet = new HashSet<>();
 			Set<String> testSet = new HashSet<>();
@@ -126,7 +126,7 @@ public class TestFileSetInputStream
 			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"headerless-([0-9]{3})-([0-9]{8}).txt", new String[] {
-								"location", "file_date" }, ",", Character.valueOf('"'), true, true, null, 0, null))))
+								"location", "file_date" }, ",", Character.valueOf('"'), "SQL", true, true, null, 0, null))))
 		{
 			Set<String> refSet = new HashSet<>();
 			Set<String> testSet = new HashSet<>();
@@ -153,7 +153,7 @@ public class TestFileSetInputStream
 			BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"empty-([0-9]+).txt", new String[] {
-							"EMPTY_ID"}, ",", Character.valueOf('"'), false, false, null, 0, null))))
+							"EMPTY_ID"}, ",", Character.valueOf('"'), "SQL", false, false, null, 0, null))))
 		{
 			Set<String> refSet = new HashSet<>();
 			Set<String> testSet = new HashSet<>();
@@ -180,7 +180,7 @@ public class TestFileSetInputStream
 		try (BufferedReader inputTest = new BufferedReader(new InputStreamReader(
 				new FileSetInputStream(filePath,
 						"petr-([0-9]{3})-([0-9]{3}).csv", new String[] {
-								"part1", "part2" }, separator, Character.valueOf('"'), true, true, null, 0, null))))
+								"part1", "part2" }, separator, Character.valueOf('"'), "SQL", true, true, null, 0, null))))
 		{
 			String lineTest = inputTest.readLine();
 			while (lineTest != null)
@@ -200,7 +200,7 @@ public class TestFileSetInputStream
 	{
 		try (FileSetInputStream in = new FileSetInputStream(filePath,
 					"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-					"location", "file_date"}, ",", Character.valueOf('"'), false, false, null, 0, null))
+					"location", "file_date"}, ",", Character.valueOf('"'), "SQL", false, false, null, 0, null))
 		{
 			in.read();
 			in.read();
@@ -224,7 +224,7 @@ public class TestFileSetInputStream
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(
 					new FileSetInputStream(filePath,
 						"utf16le_(\\d+).txt", new String[] {
-						"date"}, "|", Character.valueOf('"'), false, false, null, 0, charset), charset)))
+						"date"}, "|", Character.valueOf('"'), "SQL", false, false, null, 0, charset), charset)))
 		{
 			String line = in.readLine();
 			assertEquals("Col1|Col2|Some third|4th|date", line);
@@ -242,7 +242,7 @@ public class TestFileSetInputStream
 		{
 		    try (FileSetInputStream in = new FileSetInputStream("????",
 			"test-([0-9]{3})-([0-9]{8}).txt", new String[] {
-			"location", "file_date"}, ",", Character.valueOf('"'), false, false, null, 0, null))
+			"location", "file_date"}, ",", Character.valueOf('"'), "SQL", false, false, null, 0, null))
 		    {
 			fail("expected exception java.io.IOException");
 		    }
@@ -259,7 +259,7 @@ public class TestFileSetInputStream
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(
 					new FileSetInputStream(filePath,
 						"Hutchenson_(\\d+).txt", new String[] {
-						"Date"}, ",", Character.valueOf('"'), false, false, null, 0, null))))
+						"Date"}, ",", Character.valueOf('"'), "SQL", false, false, null, 0, null))))
 		{
 			// Check that fileTail is correctly added to records spread across multiple lines
 			String line = in.readLine();
@@ -285,7 +285,7 @@ public class TestFileSetInputStream
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(
 					new FileSetInputStream(filePath,
 						"Hutchenson_(\\d+).txt", new String[] {
-						"Date"}, ",", Character.valueOf('"'), true, false, null, 0, null))))
+						"Date"}, ",", Character.valueOf('"'), "SQL", true, false, null, 0, null))))
 		{
 			// Check that fileTail is correctly prepended to records spread across multiple lines
 			String line = in.readLine();

--- a/src/testdata/Hutchenson_011020182.txt
+++ b/src/testdata/Hutchenson_011020182.txt
@@ -1,0 +1,7 @@
+Col1,Col2
+"1
+value spread across multiple lines",one
+"2 value on single a line","two"
+"3
+3
+value spread across three lines",three

--- a/src/testdata/Hutchenson_011020182.txt
+++ b/src/testdata/Hutchenson_011020182.txt
@@ -5,3 +5,4 @@ value spread across multiple lines",one
 "3
 3
 value spread across three lines",three
+"4 value containing ""quotes""",four


### PR DESCRIPTION
When using the Driver Property `indexedFiles=True` to read several CSV files together, keep track of the quoting of column values, to avoid adding the file tail to lines that are inside column values spread across multiple lines.

Added test file `Hutchenson_011020182.txt` and unit tests `testFileSetInputStreamMultiline` and `testFileSetInputStreamMultilinePrepend` to test this functionality.

Fixes #120