### PR TITLE
Document C-style and single line comments in SQL statements

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -51,7 +51,7 @@ or other special characters.
 
 Both C-style comments `/* a comment */` and single line comments following
 two dashes and a space until the end of the line `-- a comment` are
-ignored in SQL statements.
+skipped in SQL statements.
 
 Function             |Description
 -----------          |-------------------

--- a/docs/doc.md
+++ b/docs/doc.md
@@ -49,6 +49,10 @@ Supported comparisons in the optional WHERE clause are
 Use double quotes around table names or column names containing spaces
 or other special characters.
 
+Both C-style comments `/* a comment */` and single line comments following
+two dashes and a space until the end of the line `-- a comment` are
+ignored in SQL statements.
+
 Function             |Description
 -----------          |-------------------
 ABS(N)               |Returns absolute value of N


### PR DESCRIPTION
Add a sentence to Markdown documentation file `docs/doc.md`, explaining that C-style comments `/* a comment */` and single line comments following two dashes and a space until the end of the line `-- a comment` are ignored in SQL statements.

Fixes #133