### PR TITLE
Refactor Placeholder into two classes, removing global nextIndex counter

### DIFF
--- a/src/main/java/org/relique/jdbc/csv/MultipleSqlParser.java
+++ b/src/main/java/org/relique/jdbc/csv/MultipleSqlParser.java
@@ -32,7 +32,8 @@ public class MultipleSqlParser
 		sql = sql + "\n";
 
 		ExpressionParser cs2 = new ExpressionParser(new StringReader(sql));
-		List<ParsedStatement> statements = cs2.parseMultipleStatements();
+		PlaceholderFactory placeholderFactory = new PlaceholderFactory();
+		List<ParsedStatement> statements = cs2.parseMultipleStatements(placeholderFactory);
 		LinkedList<SqlParser> retval = new LinkedList<>();
 		for (ParsedStatement parsedStatement : statements)
 		{

--- a/src/main/java/org/relique/jdbc/csv/PlaceholderFactory.java
+++ b/src/main/java/org/relique/jdbc/csv/PlaceholderFactory.java
@@ -1,6 +1,6 @@
 /*
  *  CsvJdbc - a JDBC driver for CSV files
- *  Copyright (C) 2008  Mario Frasca
+ *  Copyright (C) 2024  Simon Chenery
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -18,41 +18,22 @@
  */
 package org.relique.jdbc.csv;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 /**
- * A place holder for a parameter in a prepared statement.
- * Each parameter is identified by its position in the prepared statement,
+ * Generates sequential placeholder positions in a prepared statement,
  * counting from 1.
  */
-class Placeholder extends Expression
+public class PlaceholderFactory
 {
-	/** position of this place holder, counting from 1. */
-	private int position;
+	private int count = 0;
 
-	/**
-	 * create a new placeholder, with the next available position number.
-	 */
-	public Placeholder(int position)
+	public Placeholder createPlaceholder()
 	{
-		this.position = position;
+		count++;
+		return new Placeholder(count);
 	}
 
-	@Override
-	public Object eval(Map<String, Object> env)
+	public int getPlaceholderCount()
 	{
-		return env.get("?" + position);
-	}
-	@Override
-	public String toString()
-	{
-		return "?";
-	}
-	@Override
-	public List<String> usedColumns(Set<String> availableColumns)
-	{
-		return List.of();
+		return count;
 	}
 }

--- a/src/main/java/org/relique/jdbc/csv/SqlParser.java
+++ b/src/main/java/org/relique/jdbc/csv/SqlParser.java
@@ -53,6 +53,8 @@ public class SqlParser
 
 	private boolean isDistinct;
 
+	private PlaceholderFactory placeHolderFactory;
+
 	public void setPlaceholdersValues(Object[] values)
 	{
 
@@ -76,7 +78,7 @@ public class SqlParser
 
 	public int getPlaceholdersCount()
 	{
-		return Placeholder.nextIndex - 1;
+		return this.placeHolderFactory.getPlaceholderCount();
 	}
 
 	/**
@@ -122,7 +124,8 @@ public class SqlParser
 
 		// parse the SQL statement
 		ExpressionParser cs2 = new ExpressionParser(new StringReader(sql));
-		ParsedStatement parsedStatement = cs2.parseSingleStatement();
+		this.placeHolderFactory = new PlaceholderFactory();
+		ParsedStatement parsedStatement = cs2.parseSingleStatement(this.placeHolderFactory);
 		setParsedStatement(parsedStatement);
 	}
 

--- a/src/main/javacc/org/relique/jdbc/csv/where.jj
+++ b/src/main/javacc/org/relique/jdbc/csv/where.jj
@@ -40,6 +40,7 @@ public class ExpressionParser
 	private ParsedExpression content;
 	private Date currentDate;
 	private Time currentTime;
+	private PlaceholderFactory placeholderFactory;
 
 	public void parseLogicalExpression()throws ParseException
 	{
@@ -57,17 +58,17 @@ public class ExpressionParser
 	{
 		content = queryEnvEntry();
 	}
-	public ParsedStatement parseSingleStatement()throws ParseException
+	public ParsedStatement parseSingleStatement(PlaceholderFactory factory)throws ParseException
 	{
-		/* Reset prepared statement place-holder counter */
-		Placeholder.nextIndex = 1;
+		/* Keep prepared statement place-holder counter */
+		this.placeholderFactory = factory;
 		ParsedStatement parsedStatement = singleStatement();
 		return parsedStatement;
 	}
-	public List<ParsedStatement> parseMultipleStatements()throws ParseException
+	public List<ParsedStatement> parseMultipleStatements(PlaceholderFactory factory)throws ParseException
 	{
-		/* Reset prepared statement place-holder counter */
-		Placeholder.nextIndex = 1;
+		/* Keep prepared statement place-holder counter */
+		this.placeholderFactory = factory;
 		List<ParsedStatement> statements = multipleStatements();
 		return statements;
 	}
@@ -1127,7 +1128,7 @@ Expression simpleExpression():
 	}
 	| <PLACEHOLDER>
 	{
-		return new Placeholder();
+		return this.placeholderFactory.createPlaceholder();
 	}
 }
 Expression searchedCaseExpression():


### PR DESCRIPTION
Refactor class `Placeholder` into `PlaceholderFactory` and `Placeholder`, removing the global counter `Placeholder.nextIndex`.

This avoids a race condition when two threads are parsing two SQL Prepared Statements at the same time (and also counting the number of place holders in the SQL statement at the same time).

This fixes CsvJdbc Prepared Statements with Hikari JDBC Connection Pooling.

Fixes #159 