### PR TITLE
Added VERSION SQL function

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -80,6 +80,7 @@ TO_NUMBER(S, P)      |Converts string S to a number in current locale, using loc
 TRIM(S, [, T])       |Removes leading and trailing characters from S that occur in T
 UPPER(S)             |Converts string to upper case
 YEAR(D)              |Extracts year from date or timestamp D
+VERSION()            |Returns a string containing the CsvJdbc version number.
 
 Additional functions are defined from java methods using the
 `function.NAME` driver property.

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
   </properties>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/relique/jdbc/csv/CsvDatabaseMetaData.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvDatabaseMetaData.java
@@ -228,13 +228,13 @@ public class CsvDatabaseMetaData implements DatabaseMetaData
 	@Override
 	public int getDriverMajorVersion()
 	{
-		return 1;
+		return CsvResources.getMajorVersion();
 	}
 
 	@Override
 	public int getDriverMinorVersion()
 	{
-		return 0;
+		return CsvResources.getMinorVersion();
 	}
 
 	@Override

--- a/src/main/java/org/relique/jdbc/csv/CsvDatabaseMetaData.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvDatabaseMetaData.java
@@ -246,7 +246,7 @@ public class CsvDatabaseMetaData implements DatabaseMetaData
 	@Override
 	public String getDriverVersion() throws SQLException
 	{
-		return "1";
+		return CsvResources.getString("versionString");
 	}
 
 	@Override

--- a/src/main/java/org/relique/jdbc/csv/CsvDriver.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvDriver.java
@@ -127,13 +127,13 @@ public class CsvDriver implements Driver
 	@Override
 	public int getMajorVersion()
 	{
-		return 1;
+		return CsvResources.getMajorVersion();
 	}
 
 	@Override
 	public int getMinorVersion()
 	{
-		return 0;
+		return CsvResources.getMinorVersion();
 	}
 
 	@Override

--- a/src/main/java/org/relique/jdbc/csv/CsvResources.java
+++ b/src/main/java/org/relique/jdbc/csv/CsvResources.java
@@ -38,4 +38,33 @@ public class CsvResources
 			return "[" + key + "]";
 		}
 	}
+
+	public static int getMajorVersion()
+	{
+		return parseVersion(getVersionString(), 0,1);
+	}
+
+	public static int getMinorVersion()
+	{
+		return parseVersion(getVersionString(), 1,0);
+	}
+
+	public static String getVersionString()
+	{
+		return messages.containsKey("versionString") ? CsvResources.getString("versionString"): "1.0";
+	}
+
+	public  static int parseVersion(String versionString, int index, int defaultValue)
+	{
+		try {
+			if (versionString != null) {
+				return Integer.parseInt(versionString.split("\\.")[index]);
+			}
+		} catch (NumberFormatException e)
+		{
+			// We just return the default
+		}
+		return defaultValue;
+	}
+
 }

--- a/src/main/java/org/relique/jdbc/csv/SQLVersionFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLVersionFunction.java
@@ -1,0 +1,57 @@
+/*
+ *  CsvJdbc - a JDBC driver for CSV files
+ *  Copyright (C) 2024 Simon Chenery
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+package org.relique.jdbc.csv;
+
+import java.sql.SQLException;
+import java.util.*;
+
+class SQLVersionFunction extends Expression
+{
+
+	private final String version;
+
+	public SQLVersionFunction()
+	{
+		this.version = CsvResources.getString("versionString");
+	}
+
+	@Override
+	public Object eval(Map<String, Object> env) throws SQLException
+	{
+		return this.version;
+	}
+
+	@Override
+	public String toString()
+	{
+		return "VERSION";
+	}
+
+	@Override
+	public List<String> usedColumns(Set<String> availableColumns)
+	{
+		return List.of();
+	}
+
+	@Override
+	public List<AggregateFunction> aggregateFunctions()
+	{
+		return List.of();
+	}
+}

--- a/src/main/java/org/relique/jdbc/csv/SQLVersionFunction.java
+++ b/src/main/java/org/relique/jdbc/csv/SQLVersionFunction.java
@@ -28,7 +28,7 @@ class SQLVersionFunction extends Expression
 
 	public SQLVersionFunction()
 	{
-		this.version = CsvResources.getString("versionString");
+		this.version = CsvResources.getVersionString();
 	}
 
 	@Override

--- a/src/main/javacc/org/relique/jdbc/csv/where.jj
+++ b/src/main/javacc/org/relique/jdbc/csv/where.jj
@@ -289,6 +289,10 @@ TOKEN:
 }
 TOKEN:
 {
+	<VERSION:"VERSION">
+}
+TOKEN:
+{
 	<ROUND:"ROUND">
 }
 TOKEN:
@@ -987,6 +991,10 @@ Expression simpleExpression():
 	{
 		return new SQLRandomFunction();
 	}
+	| <VERSION> <OPENPARENTHESIS> <CLOSEPARENTHESIS>
+	{
+		return new SQLVersionFunction();
+	}
 	| <ROUND> <OPENPARENTHESIS> arg = binaryOperation() (<COMMA>
 		arg2 = binaryOperation())? <CLOSEPARENTHESIS>
 	{
@@ -1172,7 +1180,7 @@ Expression columnName():
 	Token t;
 }
 {
-	(t=<NAME>|t=<DAYOFMONTH>|t=<MONTH>|t=<YEAR>|t=<HOUROFDAY>|t=<MINUTE>|t=<SECOND>|t=<LOWER>|t=<RANDOM>|t=<ROUND>|t=<UPPER>|t=<TRIM>|t=<LTRIM>|t=<RTRIM>|t=<SUBSTRING>|t=<REPLACE>|t=<LENGTH>|t=<NULLIF>|t=<ABS>|t=<COALESCE>|t=<AVG>|t=<COUNT>|t=<MAX>|t=<MIN>|t=<SUM>t=<STRING_AGG>|t=<ARRAY_AGG>|t=<TO_ARRAY>|t=<TO_NUMBER>|t=<LINE_NUMBER>)
+	(t=<NAME>|t=<DAYOFMONTH>|t=<MONTH>|t=<YEAR>|t=<HOUROFDAY>|t=<MINUTE>|t=<SECOND>|t=<LOWER>|t=<RANDOM>|t=<VERSION>|t=<ROUND>|t=<UPPER>|t=<TRIM>|t=<LTRIM>|t=<RTRIM>|t=<SUBSTRING>|t=<REPLACE>|t=<LENGTH>|t=<NULLIF>|t=<ABS>|t=<COALESCE>|t=<AVG>|t=<COUNT>|t=<MAX>|t=<MIN>|t=<SUM>t=<STRING_AGG>|t=<ARRAY_AGG>|t=<TO_ARRAY>|t=<TO_NUMBER>|t=<LINE_NUMBER>)
 	{
 		return new ColumnName(StringConverter.removeQuotes(t.image));
 	}
@@ -1238,7 +1246,7 @@ Expression columnAlias():
 	Token t;
 }
 {
-	(t=<NAME>|t=<DAYOFMONTH>|t=<MONTH>|t=<YEAR>|t=<HOUROFDAY>|t=<MINUTE>|t=<SECOND>|t=<LOWER>|t=<RANDOM>|t=<ROUND>|t=<UPPER>|t=<TRIM>|t=<LTRIM>|t=<RTRIM>|t=<SUBSTRING>|t=<REPLACE>|t=<LENGTH>|t=<NULLIF>|t=<ABS>|t=<COALESCE>|t=<AVG>|t=<COUNT>|t=<MAX>|t=<MIN>|t=<SUM>|t=<STRING_AGG>|t=<ARRAY_AGG>|t=<TO_ARRAY>|t=<TO_NUMBER>|t=<LINE_NUMBER>)
+	(t=<NAME>|t=<DAYOFMONTH>|t=<MONTH>|t=<YEAR>|t=<HOUROFDAY>|t=<MINUTE>|t=<SECOND>|t=<LOWER>|t=<RANDOM>|t=<VERSION>|t=<ROUND>|t=<UPPER>|t=<TRIM>|t=<LTRIM>|t=<RTRIM>|t=<SUBSTRING>|t=<REPLACE>|t=<LENGTH>|t=<NULLIF>|t=<ABS>|t=<COALESCE>|t=<AVG>|t=<COUNT>|t=<MAX>|t=<MIN>|t=<SUM>|t=<STRING_AGG>|t=<ARRAY_AGG>|t=<TO_ARRAY>|t=<TO_NUMBER>|t=<LINE_NUMBER>)
 	{
 		return new ColumnName(StringConverter.removeQuotes(t.image));
 	}

--- a/src/main/resources/org/relique/jdbc/csv/messages.properties
+++ b/src/main/resources/org/relique/jdbc/csv/messages.properties
@@ -86,6 +86,7 @@ unknownCommandLine=Unknown command line option
 unsupportedDirection=Direction not supported
 unsupportedHoldability=Holdability not supported
 usage=Usage: java -jar csvjdbc.jar [-p properties.txt] jdbc-url file.sql ...\n\nConnects to CsvJdbc database with URL jdbc-url and optional database\nconnection properties and executes SQL statements in file.sql and other\nfiles given as command line arguments.\n\nIf no files are given, then standard input is read.
+versionString=@project.version@
 whereNotLogical=WHERE clause must result in true or false
 wrongColumnCount=Wrong number of columns in line
 wrongResultSetType=Method not allowed for result set type TYPE_FORWARD_ONLY

--- a/src/test/java/org/relique/jdbc/csv/TestVersionFunction.java
+++ b/src/test/java/org/relique/jdbc/csv/TestVersionFunction.java
@@ -66,7 +66,14 @@ public class TestVersionFunction
 			assertEquals(version, conn.getMetaData().getDriverVersion());
 
 			Pattern semverPattern = Pattern.compile("^(\\d+\\.\\d+|\\d+\\.\\d+\\.\\d+)(?:-SNAPSHOT)?$");
-			assertTrue(semverPattern.asMatchPredicate().test(version), "Version is not valid semver version: "+version);
+			assertTrue(semverPattern.asMatchPredicate().test(version),
+					"Version is not valid semver version: "+version);
+
+			int major = conn.getMetaData().getDriverMajorVersion();
+			int minor = conn.getMetaData().getDriverMinorVersion();
+
+			assertTrue(version.startsWith(major+"."+minor),
+					"Driver version '"+major+"."+minor+"' does not match "+version);
 		}
 	}
 

--- a/src/test/java/org/relique/jdbc/csv/TestVersionFunction.java
+++ b/src/test/java/org/relique/jdbc/csv/TestVersionFunction.java
@@ -1,0 +1,73 @@
+/*
+CsvJdbc - a JDBC driver for CSV files
+Copyright (C) 2024 Simon Chenery
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+package org.relique.jdbc.csv;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestVersionFunction
+{
+	public static String filePath;
+
+	@BeforeAll
+	public static void setUp()
+	{
+		filePath = ".." + File.separator + "src" + File.separator + "testdata";
+		if (!new File(filePath).isDirectory())
+			filePath = "src" + File.separator + "testdata";
+		assertTrue(new File(filePath).isDirectory(), "Sample files directory not found: " + filePath);
+
+		// load CSV driver
+		try
+		{
+			Class.forName("org.relique.jdbc.csv.CsvDriver");
+		}
+		catch (ClassNotFoundException e)
+		{
+			fail("Driver is not in the CLASSPATH -> " + e);
+		}
+	}
+
+	@Test
+	public void testVersionFunction() throws SQLException
+	{
+		try (Connection conn = DriverManager.getConnection("jdbc:relique:csv:" + filePath);
+			 Statement stmt = conn.createStatement();
+			 ResultSet results = stmt.executeQuery("SELECT VERSION()"))
+		{
+			assertTrue(results.next());
+			String version = results.getString(1);
+			assertEquals(version, conn.getMetaData().getDriverVersion());
+
+			Pattern semverPattern = Pattern.compile("^(\\d+\\.\\d+|\\d+\\.\\d+\\.\\d+)(?:-SNAPSHOT)?$");
+			assertTrue(semverPattern.asMatchPredicate().test(version), "Version is not valid semver version: "+version);
+		}
+	}
+
+}


### PR DESCRIPTION
Coming from MySQL I was missing database metadata functions. This is one of the simplest ones and might be handy. 
I'm not really familiar with JavaCC, but followed the implementation of similar RANDOM SQL function to add VERSION to vocabulary. The version information itself is added from pom.xml during build to the messages using resource filtering. 