### PR TITLE
Minor improvements to VERSION SQL function

### DIFF
--- a/docs/doc.md
+++ b/docs/doc.md
@@ -80,7 +80,7 @@ TO_NUMBER(S, P)      |Converts string S to a number in current locale, using loc
 TRIM(S, [, T])       |Removes leading and trailing characters from S that occur in T
 UPPER(S)             |Converts string to upper case
 YEAR(D)              |Extracts year from date or timestamp D
-VERSION()            |Returns a string containing the CsvJdbc version number.
+VERSION()            |Returns a string containing the CsvJdbc version number
 
 Additional functions are defined from java methods using the
 `function.NAME` driver property.

--- a/src/test/java/org/relique/jdbc/csv/RunSuite.java
+++ b/src/test/java/org/relique/jdbc/csv/RunSuite.java
@@ -37,6 +37,7 @@ import org.junit.platform.suite.api.Suite;
 	TestArrayFunctions.class,
 	TestRandomFunction.class,
 	TestToNumberFunction.class,
+	TestVersionFunction.class,
 	TestOrderBy.class,
 	TestGroupBy.class,
 	TestLimitOffset.class,


### PR DESCRIPTION
Removed unwanted '.' from description of VERSION() function.

Added new `TestVersionFunction` to `RunSuite` list of test classes.